### PR TITLE
Fix platform-specific path resolution for data and saves directories

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -10,10 +12,12 @@ export interface SimulationConfig {
   maxTicksPerFrame: number;
 }
 
+const defaultDataPath = fileURLToPath(new URL('../../data', import.meta.url));
+
 export const config: SimulationConfig = {
   tickLengthMinutes: Number(process.env.TICK_LENGTH_MINUTES ?? 5),
   seed: process.env.SIM_SEED ?? 'wb-sim-seed',
-  dataPath: process.env.DATA_PATH ?? new URL('../../data', import.meta.url).pathname,
+  dataPath: process.env.DATA_PATH ? path.resolve(process.env.DATA_PATH) : defaultDataPath,
   socketPort: Number(process.env.SOCKET_PORT ?? 4050),
   maxTicksPerFrame: Number(process.env.MAX_TICKS_PER_FRAME ?? 10)
 };

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { config } from './config.js';
 import { loadBlueprintRegistry } from './data/loader.js';
 import { createInitialWorldState } from './data/worldFactory.js';
@@ -6,6 +7,8 @@ import { SocketGateway } from './server/socketGateway.js';
 import { SaveLoadService } from './services/saveLoadService.js';
 import { logger } from './lib/logger.js';
 
+const savesDirectory = fileURLToPath(new URL('../../saves', import.meta.url));
+
 async function bootstrap(): Promise<void> {
   try {
     logger.info('Loading blueprints');
@@ -13,7 +16,7 @@ async function bootstrap(): Promise<void> {
     const state = createInitialWorldState(registry);
     const simulation = new SimulationEngine(state);
     const gateway = new SocketGateway(simulation);
-    const saveService = new SaveLoadService(new URL('../../saves', import.meta.url).pathname);
+    const saveService = new SaveLoadService(savesDirectory);
 
     await gateway.start(config.socketPort);
     simulation.play();


### PR DESCRIPTION
## Summary
- ensure the default data path uses fileURLToPath and resolve DATA_PATH overrides for cross-platform safety
- reuse the same fileURLToPath approach for the saves directory so bootstrap works on Windows

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce8b5cf6b483258370a5169baa1329