### PR TITLE
feat(backend): add blueprint data loader and repository

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,14 @@ importers:
         specifier: ^1.4.0
         version: 1.6.1(@types/node@20.19.17)
 
-  src/backend: {}
+  src/backend:
+    dependencies:
+      chokidar:
+        specifier: ^3.5.3
+        version: 3.6.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
 
   src/frontend:
     dependencies:
@@ -1446,6 +1453,14 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: false
+
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: true
@@ -1556,6 +1571,11 @@ packages:
     hasBin: true
     dev: true
 
+  /binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+    dev: false
+
   /brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
     dependencies:
@@ -1574,7 +1594,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
-    dev: true
 
   /browserslist@4.26.2:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
@@ -1659,6 +1678,21 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: true
+
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
 
   /cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -2447,7 +2481,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2497,7 +2530,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind@1.1.2:
@@ -2583,7 +2615,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2798,6 +2829,13 @@ packages:
       has-bigints: 1.1.0
     dev: true
 
+  /is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.3.0
+    dev: false
+
   /is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -2844,7 +2882,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
@@ -2880,7 +2917,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -2903,7 +2939,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -3284,6 +3319,11 @@ packages:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
     dev: true
 
+  /normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3474,7 +3514,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -3610,6 +3649,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
     dev: false
 
   /recharts-scale@0.4.5:
@@ -4107,7 +4153,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
@@ -4656,6 +4701,10 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    dev: false
 
   /zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}

--- a/src/backend/data/blueprintRepository.ts
+++ b/src/backend/data/blueprintRepository.ts
@@ -1,0 +1,140 @@
+import { watch } from 'chokidar';
+import path from 'path';
+import {
+  BlueprintData,
+  DataLoadResult,
+  DataLoadSummary,
+  DataLoaderError,
+  loadBlueprintData,
+} from './dataLoader.js';
+
+export type HotReloadHandler = (payload: DataLoadResult) => void;
+export type HotReloadErrorHandler = (error: unknown) => void;
+
+export interface BlueprintRepositoryOptions {
+  onHotReloadError?: HotReloadErrorHandler;
+}
+
+export class BlueprintRepository {
+  private data: BlueprintData;
+  private summary: DataLoadSummary;
+
+  private constructor(
+    private readonly dataDirectory: string,
+    result: DataLoadResult,
+  ) {
+    this.data = result.data;
+    this.summary = result.summary;
+  }
+
+  static async loadFrom(dataDirectory: string): Promise<BlueprintRepository> {
+    const absoluteDir = path.resolve(dataDirectory);
+    const result = await loadBlueprintData(absoluteDir);
+    return new BlueprintRepository(absoluteDir, result);
+  }
+
+  getStrain(id: string) {
+    return this.data.strains.get(id);
+  }
+
+  getDevice(id: string) {
+    return this.data.devices.get(id);
+  }
+
+  getCultivationMethod(id: string) {
+    return this.data.cultivationMethods.get(id);
+  }
+
+  listStrains() {
+    return Array.from(this.data.strains.values());
+  }
+
+  listDevices() {
+    return Array.from(this.data.devices.values());
+  }
+
+  listCultivationMethods() {
+    return Array.from(this.data.cultivationMethods.values());
+  }
+
+  getDevicePrice(id: string) {
+    return this.data.prices.devices.get(id);
+  }
+
+  getStrainPrice(id: string) {
+    return this.data.prices.strains.get(id);
+  }
+
+  getUtilityPrices() {
+    return this.data.prices.utility;
+  }
+
+  getSummary(): DataLoadSummary {
+    return {
+      loadedFiles: this.summary.loadedFiles,
+      versions: { ...this.summary.versions },
+      issues: [...this.summary.issues],
+    };
+  }
+
+  async reload(): Promise<DataLoadResult> {
+    const result = await loadBlueprintData(this.dataDirectory);
+    this.data = result.data;
+    this.summary = result.summary;
+    return result;
+  }
+
+  onHotReload(
+    handler: HotReloadHandler,
+    options: BlueprintRepositoryOptions = {},
+  ): () => Promise<void> {
+    const watcher = watch(this.dataDirectory, {
+      ignoreInitial: true,
+    });
+
+    let reloading = false;
+    let queued = false;
+
+    const triggerReload = async () => {
+      if (reloading) {
+        queued = true;
+        return;
+      }
+      reloading = true;
+      try {
+        const result = await this.reload();
+        handler(result);
+      } catch (error) {
+        if (error instanceof DataLoaderError) {
+          options.onHotReloadError?.({
+            name: error.name,
+            message: error.message,
+            issues: error.issues,
+          });
+        } else {
+          options.onHotReloadError?.(error);
+        }
+      }
+      reloading = false;
+      if (queued) {
+        queued = false;
+        void triggerReload();
+      }
+    };
+
+    const onWatcherError = (error: Error) => {
+      options.onHotReloadError?.(error);
+    };
+
+    watcher.on('add', triggerReload);
+    watcher.on('change', triggerReload);
+    watcher.on('unlink', triggerReload);
+    watcher.on('error', onWatcherError);
+
+    return async () => {
+      await watcher.close();
+    };
+  }
+}
+
+export default BlueprintRepository;

--- a/src/backend/data/dataLoader.ts
+++ b/src/backend/data/dataLoader.ts
@@ -1,0 +1,348 @@
+import { promises as fs, Dirent } from 'fs';
+import path from 'path';
+import { ZodError, ZodType, ZodTypeDef } from 'zod';
+import {
+  StrainBlueprint,
+  strainSchema,
+  DeviceBlueprint,
+  deviceSchema,
+  CultivationMethodBlueprint,
+  cultivationMethodSchema,
+  DevicePriceEntry,
+  devicePricesSchema,
+  StrainPriceEntry,
+  strainPricesSchema,
+  UtilityPrices,
+  utilityPricesSchema,
+} from './schemas/index.js';
+
+export type IssueLevel = 'error' | 'warning';
+
+export interface DataIssue {
+  level: IssueLevel;
+  message: string;
+  file?: string;
+  details?: unknown;
+}
+
+export interface DataLoadSummary {
+  loadedFiles: number;
+  versions: Record<string, string>;
+  issues: DataIssue[];
+}
+
+export interface BlueprintData {
+  strains: Map<string, StrainBlueprint>;
+  devices: Map<string, DeviceBlueprint>;
+  cultivationMethods: Map<string, CultivationMethodBlueprint>;
+  prices: {
+    devices: Map<string, DevicePriceEntry>;
+    strains: Map<string, StrainPriceEntry>;
+    utility: UtilityPrices;
+  };
+}
+
+export interface DataLoadResult {
+  data: BlueprintData;
+  summary: DataLoadSummary;
+}
+
+export class DataLoaderError extends Error {
+  constructor(public readonly issues: DataIssue[]) {
+    super('Data loader encountered blocking issues.');
+    this.name = 'DataLoaderError';
+  }
+}
+
+interface CollectionEntry<T> {
+  data: T;
+  file: string;
+}
+
+const JSON_EXTENSION = '.json';
+
+type BlueprintSchema<T> = ZodType<T, ZodTypeDef, unknown>;
+
+const formatRelative = (baseDir: string, filePath: string) =>
+  path.relative(baseDir, filePath).split(path.sep).join('/');
+
+const readJsonFile = async (filePath: string): Promise<unknown> => {
+  const raw = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(raw);
+};
+
+const collectZodIssues = (error: ZodError): string[] =>
+  error.issues.map((issue) => {
+    const location = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    return `${location}: ${issue.message}`;
+  });
+
+async function loadDirectoryCollection<T>(
+  directory: string,
+  schema: BlueprintSchema<T>,
+  baseDir: string,
+  summary: DataLoadSummary,
+  issues: DataIssue[],
+): Promise<CollectionEntry<T>[]> {
+  const entries: CollectionEntry<T>[] = [];
+  let dirEntries: Dirent[] = [];
+  try {
+    dirEntries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    issues.push({
+      level: 'error',
+      message: `Failed to read directory: ${(error as Error).message}`,
+      file: formatRelative(baseDir, directory),
+    });
+    return entries;
+  }
+
+  for (const entry of dirEntries) {
+    if (!entry.isFile() || !entry.name.endsWith(JSON_EXTENSION)) {
+      continue;
+    }
+    const absoluteFile = path.join(directory, entry.name);
+    const relativeFile = formatRelative(baseDir, absoluteFile);
+    let payload: unknown;
+    try {
+      payload = await readJsonFile(absoluteFile);
+    } catch (error) {
+      issues.push({
+        level: 'error',
+        message: `Failed to parse JSON: ${(error as Error).message}`,
+        file: relativeFile,
+      });
+      continue;
+    }
+
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      const errorMessages = collectZodIssues(parsed.error);
+      issues.push({
+        level: 'error',
+        message: `Schema validation failed`,
+        file: relativeFile,
+        details: errorMessages,
+      });
+      continue;
+    }
+
+    const rawRecord = payload as Record<string, unknown>;
+    if (typeof rawRecord.version === 'string') {
+      summary.versions[relativeFile] = rawRecord.version;
+    }
+
+    summary.loadedFiles += 1;
+    entries.push({ data: parsed.data, file: relativeFile });
+  }
+
+  return entries;
+}
+
+const toMapWithDuplicateCheck = <T extends { id: string }>(
+  entries: CollectionEntry<T>[],
+  issues: DataIssue[],
+): Map<string, T> => {
+  const map = new Map<string, T>();
+  const seenFiles = new Map<string, string>();
+  for (const entry of entries) {
+    const previousFile = seenFiles.get(entry.data.id);
+    if (previousFile) {
+      issues.push({
+        level: 'error',
+        message: `Duplicate identifier '${entry.data.id}' detected`,
+        file: entry.file,
+        details: { previousFile },
+      });
+      continue;
+    }
+    seenFiles.set(entry.data.id, entry.file);
+    map.set(entry.data.id, entry.data);
+  }
+  return map;
+};
+
+const buildPriceMap = <T>(
+  payload: Record<string, T>,
+  file: string,
+  issues: DataIssue[],
+): Map<string, T> => {
+  const map = new Map<string, T>();
+  for (const [id, price] of Object.entries(payload)) {
+    if (map.has(id)) {
+      issues.push({
+        level: 'error',
+        message: `Duplicate price entry for '${id}'`,
+        file,
+      });
+      continue;
+    }
+    map.set(id, price);
+  }
+  return map;
+};
+
+const runCrossChecks = (data: BlueprintData, summary: DataLoadSummary) => {
+  const issues = summary.issues;
+
+  const strainPriceFile = 'prices/strainPrices.json';
+  const devicePriceFile = 'prices/devicePrices.json';
+
+  for (const id of data.prices.strains.keys()) {
+    if (!data.strains.has(id)) {
+      issues.push({
+        level: 'error',
+        message: `Strain price references unknown strain '${id}'`,
+        file: strainPriceFile,
+      });
+    }
+  }
+
+  for (const id of data.prices.devices.keys()) {
+    if (!data.devices.has(id)) {
+      issues.push({
+        level: 'error',
+        message: `Device price references unknown device '${id}'`,
+        file: devicePriceFile,
+      });
+    }
+  }
+
+  for (const [id] of data.strains) {
+    if (!data.prices.strains.has(id)) {
+      issues.push({
+        level: 'warning',
+        message: `Strain '${id}' has no price entry`,
+        file: strainPriceFile,
+      });
+    }
+  }
+
+  for (const [id] of data.devices) {
+    if (!data.prices.devices.has(id)) {
+      issues.push({
+        level: 'warning',
+        message: `Device '${id}' has no price entry`,
+        file: devicePriceFile,
+      });
+    }
+  }
+};
+
+export const loadBlueprintData = async (dataDirectory: string): Promise<DataLoadResult> => {
+  const absoluteDataDir = path.resolve(dataDirectory);
+  const summary: DataLoadSummary = {
+    loadedFiles: 0,
+    versions: {},
+    issues: [],
+  };
+  const issues = summary.issues;
+
+  const blueprintsDir = path.join(absoluteDataDir, 'blueprints');
+  const strainDir = path.join(blueprintsDir, 'strains');
+  const deviceDir = path.join(blueprintsDir, 'devices');
+  const cultivationDir = path.join(blueprintsDir, 'cultivationMethods');
+  const pricesDir = path.join(absoluteDataDir, 'prices');
+
+  const strainEntries = await loadDirectoryCollection(
+    strainDir,
+    strainSchema,
+    absoluteDataDir,
+    summary,
+    issues,
+  );
+  const deviceEntries = await loadDirectoryCollection(
+    deviceDir,
+    deviceSchema,
+    absoluteDataDir,
+    summary,
+    issues,
+  );
+  const cultivationEntries = await loadDirectoryCollection(
+    cultivationDir,
+    cultivationMethodSchema,
+    absoluteDataDir,
+    summary,
+    issues,
+  );
+
+  const strains = toMapWithDuplicateCheck(strainEntries, issues);
+  const devices = toMapWithDuplicateCheck(deviceEntries, issues);
+  const cultivationMethods = toMapWithDuplicateCheck(cultivationEntries, issues);
+
+  const loadPriceFile = async <T>(
+    fileName: string,
+    schema: BlueprintSchema<T>,
+  ): Promise<T | undefined> => {
+    const absoluteFile = path.join(pricesDir, fileName);
+    const relativeFile = formatRelative(absoluteDataDir, absoluteFile);
+    let payload: unknown;
+    try {
+      payload = await readJsonFile(absoluteFile);
+    } catch (error) {
+      issues.push({
+        level: 'error',
+        message: `Failed to parse JSON: ${(error as Error).message}`,
+        file: relativeFile,
+      });
+      return undefined;
+    }
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      issues.push({
+        level: 'error',
+        message: `Schema validation failed`,
+        file: relativeFile,
+        details: collectZodIssues(parsed.error),
+      });
+      return undefined;
+    }
+    const rawRecord = payload as Record<string, unknown>;
+    if (typeof rawRecord.version === 'string') {
+      summary.versions[relativeFile] = rawRecord.version;
+    }
+    summary.loadedFiles += 1;
+    return parsed.data;
+  };
+
+  const devicePricePayload = await loadPriceFile('devicePrices.json', devicePricesSchema);
+  const strainPricePayload = await loadPriceFile('strainPrices.json', strainPricesSchema);
+  const utilityPricePayload = await loadPriceFile('utilityPrices.json', utilityPricesSchema);
+
+  const devicePrices: Map<string, DevicePriceEntry> = devicePricePayload
+    ? buildPriceMap(devicePricePayload.devicePrices, 'prices/devicePrices.json', issues)
+    : new Map();
+  const strainPrices: Map<string, StrainPriceEntry> = strainPricePayload
+    ? buildPriceMap(strainPricePayload.strainPrices, 'prices/strainPrices.json', issues)
+    : new Map();
+  const utilityPrices: UtilityPrices =
+    utilityPricePayload ??
+    ({
+      pricePerKwh: 0,
+      pricePerLiterWater: 0,
+      pricePerGramNutrients: 0,
+    } as UtilityPrices);
+
+  const data: BlueprintData = {
+    strains,
+    devices,
+    cultivationMethods,
+    prices: {
+      devices: devicePrices,
+      strains: strainPrices,
+      utility: utilityPrices,
+    },
+  };
+
+  runCrossChecks(data, summary);
+
+  const blockingIssues = summary.issues.filter((item) => item.level === 'error');
+  if (blockingIssues.length > 0) {
+    throw new DataLoaderError(blockingIssues);
+  }
+
+  return {
+    data,
+    summary,
+  };
+};

--- a/src/backend/data/index.ts
+++ b/src/backend/data/index.ts
@@ -1,0 +1,3 @@
+export * from './dataLoader.js';
+export * from './blueprintRepository.js';
+export * from './schemas/index.js';

--- a/src/backend/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/data/schemas/cultivationMethodSchema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+const rangeTuple = z.tuple([z.number(), z.number()]);
+
+export const cultivationMethodSchema = z
+  .object({
+    id: z.string().uuid(),
+    kind: z.string().default('CultivationMethod'),
+    name: z.string().min(1),
+    setupCost: z.number(),
+    laborIntensity: z.number(),
+    areaPerPlant: z.number(),
+    minimumSpacing: z.number(),
+    maxCycles: z.number().int().min(0).optional(),
+    substrate: z
+      .object({
+        type: z.string(),
+        costPerSquareMeter: z.number().optional(),
+        maxCycles: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    containerSpec: z
+      .object({
+        type: z.string(),
+        volumeInLiters: z.number().optional(),
+        footprintArea: z.number().optional(),
+        reusableCycles: z.number().optional(),
+        costPerUnit: z.number().optional(),
+        packingDensity: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    strainTraitCompatibility: z.record(z.string(), z.number()).optional(),
+    idealConditions: z
+      .object({
+        idealTemperature: rangeTuple.optional(),
+        idealHumidity: rangeTuple.optional(),
+      })
+      .passthrough()
+      .optional(),
+    meta: z
+      .object({
+        description: z.string().optional(),
+        advantages: z.array(z.string()).optional(),
+        disadvantages: z.array(z.string()).optional(),
+        notes: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type CultivationMethodBlueprint = z.infer<typeof cultivationMethodSchema>;

--- a/src/backend/data/schemas/deviceSchema.ts
+++ b/src/backend/data/schemas/deviceSchema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const rangeTuple = z.tuple([z.number(), z.number()]);
+
+export const deviceSchema = z
+  .object({
+    id: z.string().uuid(),
+    kind: z.string().min(1),
+    name: z.string().min(1),
+    quality: z.number(),
+    complexity: z.number(),
+    lifespanInHours: z.number(),
+    settings: z
+      .object({
+        power: z.number().optional(),
+        ppfd: z.number().optional(),
+        coverageArea: z.number().optional(),
+        spectralRange: rangeTuple.optional(),
+        heatFraction: z.number().optional(),
+        airflow: z.number().optional(),
+        coolingCapacity: z.number().optional(),
+        moistureRemoval: z.number().optional(),
+        targetCo2: z.number().optional(),
+      })
+      .passthrough(),
+    meta: z
+      .object({
+        description: z.string().optional(),
+        advantages: z.array(z.string()).optional(),
+        disadvantages: z.array(z.string()).optional(),
+        notes: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type DeviceBlueprint = z.infer<typeof deviceSchema>;

--- a/src/backend/data/schemas/index.ts
+++ b/src/backend/data/schemas/index.ts
@@ -1,0 +1,4 @@
+export * from './strainsSchema.js';
+export * from './deviceSchema.js';
+export * from './cultivationMethodSchema.js';
+export * from './priceSchemas.js';

--- a/src/backend/data/schemas/priceSchemas.ts
+++ b/src/backend/data/schemas/priceSchemas.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+export const devicePriceSchema = z.object({
+  capitalExpenditure: z.number(),
+  baseMaintenanceCostPerTick: z.number(),
+  costIncreasePer1000Ticks: z.number(),
+});
+
+export const devicePricesSchema = z
+  .object({
+    version: z.string().optional(),
+    devicePrices: z.record(z.string().uuid(), devicePriceSchema),
+  })
+  .passthrough();
+
+export type DevicePriceEntry = z.infer<typeof devicePriceSchema>;
+export type DevicePriceMap = z.infer<typeof devicePricesSchema>['devicePrices'];
+
+export const strainPriceSchema = z.object({
+  seedPrice: z.number(),
+  harvestPricePerGram: z.number(),
+});
+
+export const strainPricesSchema = z
+  .object({
+    version: z.string().optional(),
+    strainPrices: z.record(z.string().uuid(), strainPriceSchema),
+  })
+  .passthrough();
+
+export type StrainPriceEntry = z.infer<typeof strainPriceSchema>;
+export type StrainPriceMap = z.infer<typeof strainPricesSchema>['strainPrices'];
+
+export const utilityPricesSchema = z
+  .object({
+    version: z.string().optional(),
+    pricePerKwh: z.number(),
+    pricePerLiterWater: z.number(),
+    pricePerGramNutrients: z.number(),
+  })
+  .passthrough();
+
+export type UtilityPrices = z.infer<typeof utilityPricesSchema>;

--- a/src/backend/data/schemas/strainsSchema.ts
+++ b/src/backend/data/schemas/strainsSchema.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+const rangeTuple = z.tuple([z.number(), z.number()]);
+
+const nutrientTripleSchema = z.object({
+  nitrogen: z.number(),
+  phosphorus: z.number(),
+  potassium: z.number(),
+});
+
+export const strainSchema = z
+  .object({
+    id: z.string().uuid(),
+    slug: z.string().min(1),
+    name: z.string().min(1),
+    lineage: z
+      .object({
+        parents: z.array(z.string()),
+      })
+      .passthrough(),
+    genotype: z
+      .object({
+        sativa: z.number(),
+        indica: z.number(),
+        ruderalis: z.number(),
+      })
+      .passthrough(),
+    generalResilience: z.number(),
+    germinationRate: z.number(),
+    chemotype: z
+      .object({
+        thcContent: z.number(),
+        cbdContent: z.number(),
+      })
+      .passthrough(),
+    morphology: z
+      .object({
+        growthRate: z.number(),
+        yieldFactor: z.number(),
+        leafAreaIndex: z.number(),
+      })
+      .passthrough(),
+    growthModel: z
+      .object({
+        maxBiomassDry_g: z.number(),
+        baseLUE_gPerMol: z.number(),
+        maintenanceFracPerDay: z.number(),
+      })
+      .passthrough(),
+    noise: z
+      .object({
+        enabled: z.boolean(),
+        pct: z.number(),
+      })
+      .passthrough()
+      .optional(),
+    environmentalPreferences: z
+      .object({
+        lightSpectrum: z.record(rangeTuple).optional(),
+        lightIntensity: z.record(rangeTuple).optional(),
+        lightCycle: z.record(rangeTuple).optional(),
+        idealTemperature: z.record(rangeTuple).optional(),
+        idealHumidity: z.record(rangeTuple).optional(),
+        phRange: rangeTuple.optional(),
+      })
+      .passthrough(),
+    nutrientDemand: z
+      .object({
+        dailyNutrientDemand: z.record(z.string(), nutrientTripleSchema),
+        npkTolerance: z.number(),
+        npkStressIncrement: z.number(),
+      })
+      .passthrough(),
+    waterDemand: z
+      .object({
+        dailyWaterUsagePerSquareMeter: z.record(z.string(), z.number()),
+        minimumFractionRequired: z.number(),
+      })
+      .passthrough(),
+    diseaseResistance: z
+      .object({
+        dailyInfectionIncrement: z.number(),
+        infectionThreshold: z.number(),
+        recoveryRate: z.number(),
+      })
+      .passthrough(),
+    photoperiod: z
+      .object({
+        vegetationDays: z.number(),
+        floweringDays: z.number(),
+        transitionTriggerHours: z.number(),
+      })
+      .passthrough(),
+    stageChangeThresholds: z.record(z.string(), z.object({}).passthrough()),
+    harvestWindowInDays: rangeTuple,
+    harvestProperties: z
+      .object({
+        ripeningTimeInHours: z.number(),
+        maxStorageTimeInHours: z.number(),
+        qualityDecayPerHour: z.number(),
+      })
+      .passthrough(),
+    meta: z
+      .object({
+        description: z.string().optional(),
+        advantages: z.array(z.string()).optional(),
+        disadvantages: z.array(z.string()).optional(),
+        notes: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type StrainBlueprint = z.infer<typeof strainSchema>;

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -8,7 +8,11 @@
   "scripts": {
     "dev": "ts-node --esm src/index.ts",
     "build": "tsc --project tsconfig.json",
-    "lint": "eslint --ext .ts src",
+    "lint": "eslint --ext .ts src data",
     "test": "vitest --run --passWithNoTests"
+  },
+  "dependencies": {
+    "chokidar": "^3.5.3",
+    "zod": "^3.23.8"
   }
 }

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -1,7 +1,58 @@
-export const bootstrap = () => {
-  console.log('Backend simulation bootstrap placeholder');
+import { access } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { BlueprintRepository } from '../data/index.js';
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+const resolveDataDirectory = async (): Promise<string> => {
+  const candidates = [
+    process.env.WEEBBREED_DATA_DIR,
+    path.resolve(moduleDirectory, '../../../..', 'data'),
+    path.resolve(process.cwd(), 'data'),
+    path.resolve(process.cwd(), '..', 'data'),
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch (error) {
+      // continue searching
+    }
+  }
+
+  throw new Error('Unable to locate data directory. Set WEEBBREED_DATA_DIR to override.');
+};
+
+export const bootstrap = async () => {
+  const dataDirectory = await resolveDataDirectory();
+  const repository = await BlueprintRepository.loadFrom(dataDirectory);
+  const summary = repository.getSummary();
+
+  console.log(
+    `Loaded blueprint data from ${dataDirectory} (${summary.loadedFiles} files, versions: ${Object.keys(summary.versions).length})`,
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    repository.onHotReload(
+      (result) => {
+        console.log(`Blueprint data hot-reloaded (${result.summary.loadedFiles} files validated).`);
+      },
+      {
+        onHotReloadError: (error) => {
+          console.error('Blueprint data reload failed', error);
+        },
+      },
+    );
+  }
+
+  return repository;
 };
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  bootstrap();
+  bootstrap().catch((error) => {
+    console.error('Backend simulation bootstrap failed', error);
+    process.exitCode = 1;
+  });
 }

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
+    "module": "NodeNext",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "data/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add zod-based schemas for strains, devices, cultivation methods, and pricing blueprints
- implement a blueprint data loader with cross-file validation and a hot-reloadable repository API
- wire the backend bootstrap to the repository and update build tooling configuration

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend build

------
https://chatgpt.com/codex/tasks/task_e_68ceb6c64c148325bd8ddf65d4f41d14