### PR TITLE
feat: add state models and initialization utilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,16 +894,11 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  /anymatch@3.1.3:
+  anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-    dev: false
 
-  /arg@4.1.3:
-
+  arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
@@ -959,12 +954,11 @@ packages:
     resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
     hasBin: true
 
-  /binary-extensions@2.3.0:
+  binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-    dev: false
 
-  /brace-expansion@1.1.12:
+  brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
@@ -973,8 +967,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.1.1
 
   browserslist@4.26.2:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
@@ -1020,22 +1012,11 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
-  /chokidar@3.6.0:
+  chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
 
-  /cli-cursor@5.0.0:
+  cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
@@ -1611,6 +1592,10 @@ packages:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -1882,6 +1867,10 @@ packages:
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2060,6 +2049,10 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
@@ -2601,6 +2594,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -3331,6 +3327,11 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
   arg@4.1.3: {}
 
   argparse@2.0.1: {}
@@ -3401,6 +3402,8 @@ snapshots:
 
   baseline-browser-mapping@2.8.6: {}
 
+  binary-extensions@2.3.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3461,6 +3464,18 @@ snapshots:
   chalk@5.6.2: {}
 
   check-error@2.1.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   cli-cursor@5.0.0:
     dependencies:
@@ -3981,11 +3996,7 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
+  fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
@@ -4164,16 +4175,11 @@ snapshots:
     dependencies:
       has-bigints: 1.1.0
 
-  /is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
+  is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
-    dev: false
 
-  /is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
+  is-boolean-object@1.2.2:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
@@ -4199,9 +4205,7 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+  is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
     dependencies:
@@ -4233,14 +4237,7 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
-  /is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-    dev: true
+  is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
 
@@ -4451,14 +4448,9 @@ snapshots:
 
   node-releases@2.0.21: {}
 
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
+  normalize-path@3.0.0: {}
 
-  /npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
 
@@ -4558,9 +4550,7 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
@@ -4629,15 +4619,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  /readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-    dev: false
 
-  /recharts-scale@0.4.5:
-    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+  recharts-scale@0.4.5:
     dependencies:
       decimal.js-light: 2.5.1
 
@@ -5279,24 +5265,9 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  /zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-    dev: false
+  zod@3.25.76: {}
 
-  /zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
-    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      immer: '>=9.0.6'
-      react: '>=16.8'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
+  zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
     dependencies:
       use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -3,6 +3,11 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { BlueprintRepository } from '../data/index.js';
 
+export * from './state/models.js';
+export * from './lib/rng.js';
+export * from './state/serialization.js';
+export * from './stateFactory.js';
+
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 const resolveDataDirectory = async (): Promise<string> => {

--- a/src/backend/src/lib/rng.ts
+++ b/src/backend/src/lib/rng.ts
@@ -1,0 +1,166 @@
+const UINT32_MAX = 0xffffffff;
+const DEFAULT_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+const mulberry32 = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), (state | 1) >>> 0);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / (UINT32_MAX + 1);
+  };
+};
+
+const hashString = (input: string): number => {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+export interface SerializedRngState {
+  seed: string;
+  streams: Record<string, number>;
+}
+
+export class RngStream {
+  private generator: () => number;
+  private offset = 0;
+
+  constructor(
+    private readonly name: string,
+    streamSeed: number,
+    offset = 0,
+  ) {
+    this.generator = mulberry32(streamSeed);
+    if (offset > 0) {
+      this.advance(offset);
+    }
+  }
+
+  private advance(steps: number) {
+    for (let index = 0; index < steps; index += 1) {
+      // discard value to fast-forward the stream
+      this.generator();
+    }
+    this.offset += steps;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  getOffset(): number {
+    return this.offset;
+  }
+
+  next(): number {
+    const value = this.generator();
+    this.offset += 1;
+    return value;
+  }
+
+  nextFloat(): number {
+    return this.next();
+  }
+
+  nextRange(min: number, max: number): number {
+    if (max <= min) {
+      throw new Error(`Invalid range for RNG stream '${this.name}': [${min}, ${max}]`);
+    }
+    return min + (max - min) * this.next();
+  }
+
+  nextInt(maxExclusive: number): number {
+    if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+      throw new Error(`Invalid integer bound for RNG stream '${this.name}': ${maxExclusive}`);
+    }
+    return Math.floor(this.next() * maxExclusive);
+  }
+
+  nextBoolean(trueWeight = 0.5): boolean {
+    if (trueWeight <= 0) {
+      return false;
+    }
+    if (trueWeight >= 1) {
+      return true;
+    }
+    return this.next() < trueWeight;
+  }
+
+  nextString(length: number, alphabet = DEFAULT_ALPHABET): string {
+    if (length <= 0) {
+      return '';
+    }
+    if (alphabet.length === 0) {
+      throw new Error('Alphabet for RNG string generation must not be empty.');
+    }
+    let result = '';
+    for (let index = 0; index < length; index += 1) {
+      const charIndex = this.nextInt(alphabet.length);
+      result += alphabet.charAt(charIndex);
+    }
+    return result;
+  }
+
+  pick<T>(items: readonly T[]): T {
+    if (items.length === 0) {
+      throw new Error(`Cannot pick from empty array using RNG stream '${this.name}'.`);
+    }
+    const index = this.nextInt(items.length);
+    return items[index];
+  }
+}
+
+export class RngService {
+  private readonly streams = new Map<string, RngStream>();
+  private readonly knownOffsets = new Map<string, number>();
+
+  constructor(
+    private readonly seed: string,
+    snapshot?: SerializedRngState,
+  ) {
+    if (snapshot) {
+      if (snapshot.seed !== seed) {
+        throw new Error('Seed mismatch while restoring RNG state.');
+      }
+      Object.entries(snapshot.streams ?? {}).forEach(([name, offset]) => {
+        this.knownOffsets.set(name, offset);
+      });
+    }
+  }
+
+  getSeed(): string {
+    return this.seed;
+  }
+
+  getStream(name: string): RngStream {
+    let stream = this.streams.get(name);
+    if (!stream) {
+      const streamSeed = hashString(`${this.seed}:${name}`);
+      const offset = this.knownOffsets.get(name) ?? 0;
+      stream = new RngStream(name, streamSeed, offset);
+      this.streams.set(name, stream);
+    }
+    return stream;
+  }
+
+  serialize(): SerializedRngState {
+    const mergedOffsets = new Map<string, number>(this.knownOffsets);
+    for (const [name, stream] of this.streams.entries()) {
+      mergedOffsets.set(name, stream.getOffset());
+    }
+    const streams: Record<string, number> = {};
+    for (const [name, offset] of mergedOffsets.entries()) {
+      streams[name] = offset;
+    }
+    return {
+      seed: this.seed,
+      streams,
+    };
+  }
+}
+
+export default RngService;

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -1,0 +1,407 @@
+/**
+ * Core TypeScript interfaces for the simulation game state.
+ * These structures intentionally mirror the blueprint driven domain model
+ * and provide a strongly typed foundation for serialization, factories and
+ * simulation logic.
+ */
+
+export type DifficultyLevel = 'easy' | 'normal' | 'hard';
+
+export interface EconomicsSettings {
+  initialCapital: number;
+  itemPriceMultiplier: number;
+  harvestPriceMultiplier: number;
+  rentPerSqmStructurePerTick: number;
+  rentPerSqmRoomPerTick: number;
+}
+
+export interface GameMetadata {
+  gameId: string;
+  createdAt: string;
+  seed: string;
+  difficulty: DifficultyLevel;
+  simulationVersion: string;
+  tickLengthMinutes: number;
+  economics: EconomicsSettings;
+}
+
+export interface SimulationClockState {
+  tick: number;
+  isPaused: boolean;
+  startedAt: string;
+  lastUpdatedAt: string;
+  targetTickRate: number;
+}
+
+export interface SimulationNote {
+  id: string;
+  tick: number;
+  message: string;
+  level: 'info' | 'warning' | 'error';
+}
+
+export interface GameState {
+  metadata: GameMetadata;
+  clock: SimulationClockState;
+  structures: StructureState[];
+  inventory: GlobalInventoryState;
+  finances: FinanceState;
+  personnel: PersonnelRoster;
+  tasks: TaskSystemState;
+  notes?: SimulationNote[];
+}
+
+export interface FootprintBlueprint {
+  length: number;
+  width: number;
+  height: number;
+}
+
+export interface StructureBlueprint {
+  id: string;
+  name: string;
+  footprint: FootprintBlueprint;
+  rentalCostPerSqmPerMonth: number;
+  upfrontFee: number;
+}
+
+export interface FootprintDimensions extends FootprintBlueprint {
+  area: number;
+  volume: number;
+}
+
+export type StructureStatus = 'active' | 'underConstruction' | 'decommissioned';
+
+export interface StructureState {
+  id: string;
+  blueprintId: string;
+  name: string;
+  status: StructureStatus;
+  footprint: FootprintDimensions;
+  rooms: RoomState[];
+  rentPerTick: number;
+  upfrontCostPaid: number;
+  notes?: string;
+}
+
+export interface RoomState {
+  id: string;
+  structureId: string;
+  name: string;
+  purposeId: string;
+  area: number;
+  height: number;
+  volume: number;
+  zones: ZoneState[];
+  cleanliness: number;
+  maintenanceLevel: number;
+}
+
+export interface ZoneEnvironmentState {
+  temperature: number;
+  relativeHumidity: number;
+  co2: number;
+  ppfd: number;
+  vpd: number;
+}
+
+export interface ZoneResourceState {
+  waterLiters: number;
+  nutrientSolutionLiters: number;
+  nutrientStrength: number;
+  substrateHealth: number;
+  reservoirLevel: number;
+}
+
+export interface ZoneMetricState {
+  averageTemperature: number;
+  averageHumidity: number;
+  averageCo2: number;
+  averagePpfd: number;
+  stressLevel: number;
+  lastUpdatedTick: number;
+}
+
+export interface ZoneState {
+  id: string;
+  roomId: string;
+  name: string;
+  cultivationMethodId: string;
+  strainId?: string;
+  environment: ZoneEnvironmentState;
+  resources: ZoneResourceState;
+  plants: PlantState[];
+  devices: DeviceInstanceState[];
+  metrics: ZoneMetricState;
+  activeTaskIds: string[];
+}
+
+export type PlantStage =
+  | 'seedling'
+  | 'vegetative'
+  | 'flowering'
+  | 'ripening'
+  | 'harvestReady'
+  | 'drying'
+  | 'cured'
+  | 'dead';
+
+export interface PlantState {
+  id: string;
+  strainId: string;
+  zoneId: string;
+  stage: PlantStage;
+  plantedAtTick: number;
+  ageInHours: number;
+  health: number;
+  stress: number;
+  biomassDryGrams: number;
+  heightMeters: number;
+  canopyCover: number;
+  yieldDryGrams: number;
+  quality: number;
+  lastMeasurementTick: number;
+  notes?: string;
+}
+
+export type DeviceStatus = 'operational' | 'maintenance' | 'offline' | 'failed';
+
+export interface DeviceMaintenanceState {
+  lastServiceTick: number;
+  nextDueTick: number;
+  condition: number;
+  degradation: number;
+}
+
+export interface DeviceInstanceState {
+  id: string;
+  blueprintId: string;
+  name: string;
+  zoneId: string;
+  status: DeviceStatus;
+  efficiency: number;
+  runtimeHours: number;
+  maintenance: DeviceMaintenanceState;
+  settings: Record<string, unknown>;
+}
+
+export interface ResourceInventory {
+  waterLiters: number;
+  nutrientsGrams: number;
+  co2Kg: number;
+  substrateKg: number;
+  packagingUnits: number;
+  sparePartsValue: number;
+}
+
+export interface SeedStockEntry {
+  id: string;
+  strainId: string;
+  quantity: number;
+  viability: number;
+  storedAtTick: number;
+}
+
+export interface DeviceStockEntry {
+  id: string;
+  blueprintId: string;
+  quantity: number;
+  condition: number;
+}
+
+export type HarvestStage = 'fresh' | 'drying' | 'cured' | 'waste';
+
+export interface HarvestBatch {
+  id: string;
+  strainId: string;
+  weightGrams: number;
+  quality: number;
+  stage: HarvestStage;
+  harvestedAtTick: number;
+  notes?: string;
+}
+
+export interface GlobalInventoryState {
+  resources: ResourceInventory;
+  seeds: SeedStockEntry[];
+  devices: DeviceStockEntry[];
+  harvest: HarvestBatch[];
+  consumables: Record<string, number>;
+}
+
+export type LedgerEntryType = 'income' | 'expense';
+
+export type LedgerCategory =
+  | 'capital'
+  | 'structure'
+  | 'device'
+  | 'inventory'
+  | 'rent'
+  | 'utilities'
+  | 'payroll'
+  | 'maintenance'
+  | 'sales'
+  | 'loan'
+  | 'other';
+
+export interface LedgerEntry {
+  id: string;
+  tick: number;
+  timestamp: string;
+  amount: number;
+  type: LedgerEntryType;
+  category: LedgerCategory;
+  description: string;
+}
+
+export interface LoanState {
+  id: string;
+  principal: number;
+  interestRate: number;
+  paymentsRemaining: number;
+  nextPaymentTick: number;
+}
+
+export interface FinancialSummary {
+  totalRevenue: number;
+  totalExpenses: number;
+  totalPayroll: number;
+  totalMaintenance: number;
+  netIncome: number;
+  lastTickRevenue: number;
+  lastTickExpenses: number;
+}
+
+export interface FinanceState {
+  cashOnHand: number;
+  reservedCash: number;
+  outstandingLoans: LoanState[];
+  ledger: LedgerEntry[];
+  summary: FinancialSummary;
+}
+
+export type EmployeeRole = 'Gardener' | 'Technician' | 'Janitor' | 'Operator' | 'Manager';
+
+export type SkillName =
+  | 'Gardening'
+  | 'Maintenance'
+  | 'Logistics'
+  | 'Cleanliness'
+  | 'Administration';
+
+export type EmployeeSkills = Partial<Record<SkillName, number>>;
+
+export type EmployeeStatus = 'idle' | 'assigned' | 'offShift' | 'training';
+
+export interface PersonnelTrait {
+  id: string;
+  name: string;
+  description: string;
+  type: 'positive' | 'negative' | 'neutral';
+}
+
+export interface PersonnelNameDirectory {
+  firstNames: string[];
+  lastNames: string[];
+  traits: PersonnelTrait[];
+}
+
+export interface EmployeeState {
+  id: string;
+  name: string;
+  role: EmployeeRole;
+  salaryPerTick: number;
+  status: EmployeeStatus;
+  morale: number;
+  energy: number;
+  skills: EmployeeSkills;
+  experience: EmployeeSkills;
+  traits: string[];
+  assignedStructureId?: string;
+  assignedRoomId?: string;
+  assignedZoneId?: string;
+  currentTaskId?: string;
+}
+
+export interface ApplicantState {
+  id: string;
+  name: string;
+  desiredRole: EmployeeRole;
+  expectedSalary: number;
+  traits: string[];
+  skills: EmployeeSkills;
+}
+
+export interface TrainingProgramState {
+  id: string;
+  name: string;
+  targetRole: EmployeeRole;
+  progress: number;
+  attendees: string[];
+}
+
+export interface PersonnelRoster {
+  employees: EmployeeState[];
+  applicants: ApplicantState[];
+  trainingPrograms: TrainingProgramState[];
+  overallMorale: number;
+}
+
+export type TaskStatus =
+  | 'pending'
+  | 'queued'
+  | 'inProgress'
+  | 'completed'
+  | 'cancelled'
+  | 'blocked';
+
+export type TaskBasis = 'perAction' | 'perPlant' | 'perSquareMeter';
+
+export interface TaskCostModel {
+  basis: TaskBasis;
+  laborMinutes: number;
+}
+
+export interface TaskDefinition {
+  id: string;
+  costModel: TaskCostModel;
+  priority: number;
+  requiredRole: EmployeeRole;
+  requiredSkill: SkillName;
+  minSkillLevel: number;
+  description: string;
+}
+
+export type TaskDefinitionMap = Record<string, TaskDefinition>;
+
+export interface TaskLocation {
+  structureId: string;
+  roomId?: string;
+  zoneId?: string;
+}
+
+export interface TaskAssignment {
+  employeeId: string;
+  startedAtTick: number;
+  progress: number;
+  etaTick?: number;
+}
+
+export interface TaskState {
+  id: string;
+  definitionId: string;
+  status: TaskStatus;
+  priority: number;
+  createdAtTick: number;
+  dueTick?: number;
+  location?: TaskLocation;
+  assignment?: TaskAssignment;
+  metadata: Record<string, unknown>;
+}
+
+export interface TaskSystemState {
+  backlog: TaskState[];
+  active: TaskState[];
+  completed: TaskState[];
+  cancelled: TaskState[];
+}

--- a/src/backend/src/state/serialization.ts
+++ b/src/backend/src/state/serialization.ts
@@ -1,0 +1,72 @@
+import { GameState } from './models.js';
+import { RngService, SerializedRngState } from '../lib/rng.js';
+
+export const SAVEGAME_KIND = 'WeedBreedSave';
+export const DEFAULT_SAVEGAME_VERSION = '0.1.0';
+
+export interface SaveGameEnvelope {
+  kind: typeof SAVEGAME_KIND;
+  version: string;
+  createdAt: string;
+  tickLengthMinutes: number;
+  rngSeed: string;
+  rng: SerializedRngState;
+  state: GameState;
+}
+
+export interface SerializeOptions {
+  version?: string;
+  createdAt?: string;
+}
+
+export const serializeGameState = (
+  state: GameState,
+  rng: RngService,
+  options: SerializeOptions = {},
+): SaveGameEnvelope => {
+  const snapshot = rng.serialize();
+  const version = options.version ?? state.metadata.simulationVersion ?? DEFAULT_SAVEGAME_VERSION;
+  const createdAt = options.createdAt ?? new Date().toISOString();
+
+  return {
+    kind: SAVEGAME_KIND,
+    version,
+    createdAt,
+    tickLengthMinutes: state.metadata.tickLengthMinutes,
+    rngSeed: snapshot.seed,
+    rng: snapshot,
+    state,
+  };
+};
+
+export interface DeserializeResult {
+  state: GameState;
+  rng: RngService;
+}
+
+export const deserializeGameState = (payload: SaveGameEnvelope): DeserializeResult => {
+  if (payload.kind !== SAVEGAME_KIND) {
+    throw new Error(`Unsupported savegame kind: ${payload.kind}`);
+  }
+  if (payload.rng.seed !== payload.rngSeed) {
+    throw new Error('Savegame RNG seed mismatch.');
+  }
+  const rng = new RngService(payload.rngSeed, payload.rng);
+  return {
+    state: payload.state,
+    rng,
+  };
+};
+
+export const cloneSerializedState = (payload: SaveGameEnvelope): SaveGameEnvelope => ({
+  kind: payload.kind,
+  version: payload.version,
+  createdAt: payload.createdAt,
+  tickLengthMinutes: payload.tickLengthMinutes,
+  rngSeed: payload.rngSeed,
+  rng: {
+    seed: payload.rng.seed,
+    streams: { ...payload.rng.streams },
+  },
+  state: payload.state,
+});

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -1,0 +1,876 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { BlueprintRepository } from '../data/blueprintRepository.js';
+import type {
+  CultivationMethodBlueprint,
+  DeviceBlueprint,
+  StrainBlueprint,
+  DevicePriceEntry,
+} from '../data/schemas/index.js';
+import { DEFAULT_SAVEGAME_VERSION } from './state/serialization.js';
+import {
+  DeviceInstanceState,
+  DifficultyLevel,
+  EconomicsSettings,
+  EmployeeRole,
+  EmployeeState,
+  EmployeeSkills,
+  FinanceState,
+  FinancialSummary,
+  FootprintDimensions,
+  GameMetadata,
+  GameState,
+  GlobalInventoryState,
+  HarvestBatch,
+  LedgerEntry,
+  PersonnelNameDirectory,
+  PersonnelRoster,
+  PlantState,
+  ResourceInventory,
+  SeedStockEntry,
+  SkillName,
+  StructureBlueprint,
+  StructureState,
+  TaskDefinition,
+  TaskDefinitionMap,
+  TaskState,
+  TaskSystemState,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+  ZoneResourceState,
+} from './state/models.js';
+import { RngService, RngStream } from './lib/rng.js';
+
+const DEFAULT_TICK_LENGTH_MINUTES = 60;
+const DEFAULT_TARGET_TICK_RATE = 1;
+const DEFAULT_ZONE_RESERVOIR_LEVEL = 0.75;
+const DEFAULT_ZONE_WATER_LITERS = 800;
+const DEFAULT_ZONE_NUTRIENT_LITERS = 400;
+const DEFAULT_SALARY_BY_ROLE: Record<EmployeeRole, number> = {
+  Gardener: 24,
+  Technician: 28,
+  Janitor: 18,
+  Operator: 22,
+  Manager: 35,
+};
+const DEFAULT_EMPLOYEE_COUNTS: Record<EmployeeRole, number> = {
+  Gardener: 3,
+  Technician: 1,
+  Janitor: 1,
+  Operator: 0,
+  Manager: 0,
+};
+
+const DIFFICULTY_ECONOMICS: Record<DifficultyLevel, EconomicsSettings> = {
+  easy: {
+    initialCapital: 2_000_000,
+    itemPriceMultiplier: 0.9,
+    harvestPriceMultiplier: 1.1,
+    rentPerSqmStructurePerTick: 0.1,
+    rentPerSqmRoomPerTick: 0.2,
+  },
+  normal: {
+    initialCapital: 1_500_000,
+    itemPriceMultiplier: 1.0,
+    harvestPriceMultiplier: 1.0,
+    rentPerSqmStructurePerTick: 0.15,
+    rentPerSqmRoomPerTick: 0.3,
+  },
+  hard: {
+    initialCapital: 1_000_000,
+    itemPriceMultiplier: 1.1,
+    harvestPriceMultiplier: 0.9,
+    rentPerSqmStructurePerTick: 0.2,
+    rentPerSqmRoomPerTick: 0.4,
+  },
+};
+
+interface StructureCreationResult {
+  structure: StructureState;
+  growRoom: StructureState['rooms'][number];
+  growZone: StructureState['rooms'][number]['zones'][number];
+  installedDeviceBlueprints: DeviceBlueprint[];
+  plantCount: number;
+}
+
+const generateId = (stream: RngStream, prefix: string, length = 10) =>
+  `${prefix}_${stream.nextString(length)}`;
+
+const computeFootprint = (blueprint: StructureBlueprint): FootprintDimensions => {
+  const area = blueprint.footprint.length * blueprint.footprint.width;
+  const volume = area * blueprint.footprint.height;
+  return {
+    ...blueprint.footprint,
+    area,
+    volume,
+  };
+};
+
+const readJsonFile = async <T>(filePath: string): Promise<T | undefined> => {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const cause = error as NodeJS.ErrnoException;
+    if (cause.code === 'ENOENT') {
+      return undefined;
+    }
+    throw new Error(`Failed to read JSON file at ${filePath}: ${cause.message}`);
+  }
+};
+
+interface RawStructureBlueprint {
+  id: string;
+  name: string;
+  footprint: {
+    length_m: number;
+    width_m: number;
+    height_m: number;
+  };
+  rentalCostPerSqmPerMonth: number;
+  upfrontFee: number;
+}
+
+const normaliseStructureBlueprint = (blueprint: RawStructureBlueprint): StructureBlueprint => ({
+  id: blueprint.id,
+  name: blueprint.name,
+  footprint: {
+    length: blueprint.footprint.length_m,
+    width: blueprint.footprint.width_m,
+    height: blueprint.footprint.height_m,
+  },
+  rentalCostPerSqmPerMonth: blueprint.rentalCostPerSqmPerMonth,
+  upfrontFee: blueprint.upfrontFee,
+});
+
+export interface StateFactoryContext {
+  repository: BlueprintRepository;
+  rng: RngService;
+  dataDirectory?: string;
+  structureBlueprints?: StructureBlueprint[];
+  personnelDirectory?: PersonnelNameDirectory;
+  taskDefinitions?: TaskDefinitionMap;
+}
+
+export interface StateFactoryOptions {
+  difficulty?: DifficultyLevel;
+  tickLengthMinutes?: number;
+  structureId?: string;
+  preferredStrainId?: string;
+  preferredCultivationMethodId?: string;
+  employeeCountByRole?: Partial<Record<EmployeeRole, number>>;
+  zonePlantCount?: number;
+}
+
+export const loadStructureBlueprints = async (
+  dataDirectory: string,
+): Promise<StructureBlueprint[]> => {
+  const directory = path.join(dataDirectory, 'blueprints', 'structures');
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(directory);
+  } catch (error) {
+    const cause = error as NodeJS.ErrnoException;
+    if (cause.code === 'ENOENT') {
+      return [];
+    }
+    throw new Error(`Failed to read structure blueprints directory: ${cause.message}`);
+  }
+
+  const blueprints: StructureBlueprint[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) {
+      continue;
+    }
+    const filePath = path.join(directory, entry);
+    const raw = await readJsonFile<RawStructureBlueprint>(filePath);
+    if (!raw) {
+      continue;
+    }
+    blueprints.push(normaliseStructureBlueprint(raw));
+  }
+  return blueprints;
+};
+
+export const loadPersonnelDirectory = async (
+  dataDirectory: string,
+): Promise<PersonnelNameDirectory> => {
+  const personnelDir = path.join(dataDirectory, 'personnel');
+  const [firstNames, lastNames, traits] = await Promise.all([
+    readJsonFile<string[]>(path.join(personnelDir, 'firstNames.json')),
+    readJsonFile<string[]>(path.join(personnelDir, 'lastNames.json')),
+    readJsonFile<PersonnelNameDirectory['traits']>(path.join(personnelDir, 'traits.json')),
+  ]);
+
+  return {
+    firstNames: firstNames ?? [],
+    lastNames: lastNames ?? [],
+    traits: traits ?? [],
+  };
+};
+
+interface RawTaskDefinition {
+  costModel: {
+    basis: string;
+    laborMinutes: number;
+  };
+  priority: number;
+  requiredRole: string;
+  requiredSkill: string;
+  minSkillLevel: number;
+  description: string;
+}
+
+export const loadTaskDefinitions = async (dataDirectory: string): Promise<TaskDefinitionMap> => {
+  const configFile = path.join(dataDirectory, 'configs', 'task_definitions.json');
+  const raw = await readJsonFile<Record<string, RawTaskDefinition>>(configFile);
+
+  if (!raw) {
+    return {};
+  }
+
+  const definitions: TaskDefinitionMap = {};
+  for (const [id, value] of Object.entries(raw)) {
+    const basis = value.costModel?.basis as TaskDefinition['costModel']['basis'] | undefined;
+    definitions[id] = {
+      id,
+      costModel: {
+        basis: basis ?? 'perAction',
+        laborMinutes: value.costModel?.laborMinutes ?? 0,
+      },
+      priority: value.priority,
+      requiredRole: value.requiredRole as EmployeeRole,
+      requiredSkill: value.requiredSkill as SkillName,
+      minSkillLevel: value.minSkillLevel,
+      description: value.description,
+    } satisfies TaskDefinition;
+  }
+
+  return definitions;
+};
+
+const sortBlueprints = <T extends { id: string; name?: string }>(items: readonly T[]): T[] => {
+  return [...items].sort((a, b) => {
+    const left = a.name ?? a.id;
+    const right = b.name ?? b.id;
+    return left.localeCompare(right);
+  });
+};
+
+const selectBlueprint = <T extends { id: string; name?: string }>(
+  items: readonly T[],
+  stream: RngStream,
+  preferredId?: string,
+): T => {
+  if (items.length === 0) {
+    throw new Error('No blueprints available for selection.');
+  }
+  if (preferredId) {
+    const match = items.find((item) => item.id === preferredId);
+    if (match) {
+      return match;
+    }
+  }
+  if (items.length === 1) {
+    return items[0];
+  }
+  const sorted = sortBlueprints(items);
+  const index = stream.nextInt(sorted.length);
+  return sorted[index];
+};
+
+const chooseDeviceBlueprints = (
+  devices: DeviceBlueprint[],
+  stream: RngStream,
+): DeviceBlueprint[] => {
+  const byKind = new Map<string, DeviceBlueprint[]>();
+  for (const device of devices) {
+    const kindEntries = byKind.get(device.kind) ?? [];
+    kindEntries.push(device);
+    byKind.set(device.kind, kindEntries);
+  }
+
+  const selected: DeviceBlueprint[] = [];
+  const desiredKinds = ['Lamp', 'ClimateUnit', 'Dehumidifier'];
+  for (const kind of desiredKinds) {
+    const options = byKind.get(kind);
+    if (options && options.length > 0) {
+      selected.push(selectBlueprint(options, stream));
+    }
+  }
+
+  if (selected.length === 0 && devices.length > 0) {
+    selected.push(selectBlueprint(devices, stream));
+  }
+
+  return selected;
+};
+
+const cloneSettings = (settings: DeviceBlueprint['settings'] | undefined) => {
+  if (!settings) {
+    return {};
+  }
+  return JSON.parse(JSON.stringify(settings)) as Record<string, unknown>;
+};
+
+const createDeviceInstances = (
+  blueprints: DeviceBlueprint[],
+  zoneId: string,
+  idStream: RngStream,
+): DeviceInstanceState[] => {
+  return blueprints.map((device) => ({
+    id: generateId(idStream, 'device'),
+    blueprintId: device.id,
+    name: device.name,
+    zoneId,
+    status: 'operational',
+    efficiency: device.quality ?? 1,
+    runtimeHours: 0,
+    maintenance: {
+      lastServiceTick: 0,
+      nextDueTick: 24 * 30,
+      condition: Math.min(1, Math.max(0, device.quality ?? 1)),
+      degradation: 0,
+    },
+    settings: cloneSettings(device.settings),
+  }));
+};
+
+const createZoneEnvironment = (): ZoneEnvironmentState => ({
+  temperature: 24,
+  relativeHumidity: 0.62,
+  co2: 900,
+  ppfd: 550,
+  vpd: 1.2,
+});
+
+const createZoneResources = (): ZoneResourceState => ({
+  waterLiters: DEFAULT_ZONE_WATER_LITERS,
+  nutrientSolutionLiters: DEFAULT_ZONE_NUTRIENT_LITERS,
+  nutrientStrength: 1,
+  substrateHealth: 1,
+  reservoirLevel: DEFAULT_ZONE_RESERVOIR_LEVEL,
+});
+
+const createZoneMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
+  averageTemperature: environment.temperature,
+  averageHumidity: environment.relativeHumidity,
+  averageCo2: environment.co2,
+  averagePpfd: environment.ppfd,
+  stressLevel: 0,
+  lastUpdatedTick: 0,
+});
+
+const drawUnique = <T>(items: readonly T[], count: number, stream: RngStream): T[] => {
+  if (items.length === 0 || count <= 0) {
+    return [];
+  }
+  const pool = [...items];
+  const picks = Math.min(count, pool.length);
+  const result: T[] = [];
+  for (let index = 0; index < picks; index += 1) {
+    const chosenIndex = stream.nextInt(pool.length);
+    result.push(pool.splice(chosenIndex, 1)[0]);
+  }
+  return result;
+};
+
+const createEmployeeSkills = (role: EmployeeRole): EmployeeSkills => {
+  switch (role) {
+    case 'Gardener':
+      return { Gardening: 4, Cleanliness: 2 };
+    case 'Technician':
+      return { Maintenance: 4, Logistics: 2 };
+    case 'Janitor':
+      return { Cleanliness: 4, Logistics: 1 };
+    case 'Operator':
+      return { Logistics: 3, Administration: 2 };
+    case 'Manager':
+      return { Administration: 4, Logistics: 2 };
+    default:
+      return {};
+  }
+};
+
+const createExperienceStub = (skills: EmployeeSkills): EmployeeSkills => {
+  return Object.fromEntries(Object.keys(skills).map((skill) => [skill, 0])) as EmployeeSkills;
+};
+
+const createPlants = (
+  count: number,
+  zoneId: string,
+  strain: StrainBlueprint,
+  idStream: RngStream,
+  plantStream: RngStream,
+): PlantState[] => {
+  const plants: PlantState[] = [];
+  for (let index = 0; index < count; index += 1) {
+    plants.push({
+      id: generateId(idStream, 'plant'),
+      strainId: strain.id,
+      zoneId,
+      stage: 'seedling',
+      plantedAtTick: 0,
+      ageInHours: 0,
+      health: 0.95,
+      stress: 0.05,
+      biomassDryGrams: 0,
+      heightMeters: 0.1 + plantStream.nextRange(0, 0.05),
+      canopyCover: 0.12,
+      yieldDryGrams: 0,
+      quality: 0.8,
+      lastMeasurementTick: 0,
+    });
+  }
+  return plants;
+};
+
+const buildStructureState = (
+  blueprint: StructureBlueprint,
+  structureId: string,
+  strain: StrainBlueprint,
+  method: CultivationMethodBlueprint,
+  deviceBlueprints: DeviceBlueprint[],
+  idStream: RngStream,
+  rng: RngService,
+  plantCountOverride?: number,
+): StructureCreationResult => {
+  const footprint = computeFootprint(blueprint);
+  const totalArea = footprint.area;
+  const growRoomArea = totalArea * 0.65;
+  const supportRoomArea = Math.max(0, totalArea - growRoomArea);
+  const plantStream = rng.getStream('plants');
+  const zoneId = generateId(idStream, 'zone');
+  const deviceInstances = createDeviceInstances(deviceBlueprints, zoneId, idStream);
+  const capacity = Math.max(1, Math.floor(growRoomArea / Math.max(0.1, method.areaPerPlant)));
+  const plantCount = Math.min(capacity, plantCountOverride ?? Math.min(12, capacity));
+  const plants = createPlants(plantCount, zoneId, strain, idStream, plantStream);
+  const environment = createZoneEnvironment();
+  const zone: StructureCreationResult['growZone'] = {
+    id: zoneId,
+    roomId: '',
+    name: 'Zone A',
+    cultivationMethodId: method.id,
+    strainId: strain.id,
+    environment,
+    resources: createZoneResources(),
+    plants,
+    devices: deviceInstances,
+    metrics: createZoneMetrics(environment),
+    activeTaskIds: [],
+  };
+
+  const growRoomId = generateId(idStream, 'room');
+  zone.roomId = growRoomId;
+
+  const growRoom = {
+    id: growRoomId,
+    structureId,
+    name: 'Grow Room Alpha',
+    purposeId: 'growroom',
+    area: growRoomArea,
+    height: footprint.height,
+    volume: growRoomArea * footprint.height,
+    zones: [zone],
+    cleanliness: 0.85,
+    maintenanceLevel: 0.9,
+  } satisfies StructureState['rooms'][number];
+
+  const supportRoom = {
+    id: generateId(idStream, 'room'),
+    structureId,
+    name: 'Support Room',
+    purposeId: 'breakroom',
+    area: supportRoomArea,
+    height: footprint.height,
+    volume: supportRoomArea * footprint.height,
+    zones: [],
+    cleanliness: 0.9,
+    maintenanceLevel: 0.95,
+  } satisfies StructureState['rooms'][number];
+
+  const structure: StructureState = {
+    id: structureId,
+    blueprintId: blueprint.id,
+    name: blueprint.name,
+    status: 'active',
+    footprint,
+    rooms: [growRoom, supportRoom],
+    rentPerTick: (blueprint.rentalCostPerSqmPerMonth * footprint.area) / (30 * 24),
+    upfrontCostPaid: blueprint.upfrontFee,
+  };
+
+  return {
+    structure,
+    growRoom,
+    growZone: zone,
+    installedDeviceBlueprints: deviceBlueprints,
+    plantCount,
+  };
+};
+
+const createInventory = (
+  strain: StrainBlueprint,
+  plantCount: number,
+  idStream: RngStream,
+): GlobalInventoryState => {
+  const seedQuantity = Math.max(plantCount * 3, 30);
+  const seeds: SeedStockEntry = {
+    id: generateId(idStream, 'seed'),
+    strainId: strain.id,
+    quantity: seedQuantity,
+    viability: strain.germinationRate,
+    storedAtTick: 0,
+  };
+
+  const resources: ResourceInventory = {
+    waterLiters: 12_000,
+    nutrientsGrams: 8_000,
+    co2Kg: 40,
+    substrateKg: 2_000,
+    packagingUnits: 400,
+    sparePartsValue: 1_500,
+  };
+
+  return {
+    resources,
+    seeds: [seeds],
+    devices: [],
+    harvest: [] as HarvestBatch[],
+    consumables: {
+      trimBins: 6,
+      gloves: 200,
+      filters: 12,
+      labels: 500,
+    },
+  };
+};
+
+const createPersonnel = (
+  structureId: string,
+  counts: Record<EmployeeRole, number>,
+  directory: PersonnelNameDirectory | undefined,
+  rng: RngService,
+  idStream: RngStream,
+): PersonnelRoster => {
+  const firstNames = directory?.firstNames ?? [];
+  const lastNames = directory?.lastNames ?? [];
+  const traits = directory?.traits ?? [];
+  const nameStream = rng.getStream('personnel-names');
+  const traitStream = rng.getStream('personnel-traits');
+  const moraleStream = rng.getStream('personnel-morale');
+  const employees: EmployeeState[] = [];
+
+  for (const role of Object.keys(counts) as EmployeeRole[]) {
+    const count = counts[role] ?? 0;
+    for (let index = 0; index < count; index += 1) {
+      const firstName = firstNames.length > 0 ? nameStream.pick(firstNames) : `Crew${index + 1}`;
+      const lastName = lastNames.length > 0 ? nameStream.pick(lastNames) : role;
+      const fullName = `${firstName} ${lastName}`;
+      const skills = createEmployeeSkills(role);
+      const employeeTraits = drawUnique(
+        traits,
+        traits.length > 0 ? 1 + Number(traitStream.nextBoolean(0.35)) : 0,
+        traitStream,
+      ).map((trait) => trait.id);
+      employees.push({
+        id: generateId(idStream, 'emp'),
+        name: fullName,
+        role,
+        salaryPerTick: DEFAULT_SALARY_BY_ROLE[role] ?? 20,
+        status: 'idle',
+        morale: 0.82 + moraleStream.nextRange(0, 0.08),
+        energy: 1,
+        skills,
+        experience: createExperienceStub(skills),
+        traits: employeeTraits,
+        assignedStructureId: structureId,
+      });
+    }
+  }
+
+  const morale =
+    employees.length > 0
+      ? employees.reduce((sum, employee) => sum + employee.morale, 0) / employees.length
+      : 1;
+
+  return {
+    employees,
+    applicants: [],
+    trainingPrograms: [],
+    overallMorale: morale,
+  };
+};
+
+const sumDeviceCapitalCosts = (
+  devices: DeviceBlueprint[],
+  priceLookup: (id: string) => DevicePriceEntry | undefined,
+): number => {
+  return devices.reduce((sum, device) => {
+    const price = priceLookup(device.id);
+    return sum + (price?.capitalExpenditure ?? 0);
+  }, 0);
+};
+
+const createFinanceState = (
+  createdAt: string,
+  economics: EconomicsSettings,
+  blueprint: StructureBlueprint,
+  installedDevices: DeviceBlueprint[],
+  repository: BlueprintRepository,
+  idStream: RngStream,
+): FinanceState => {
+  const ledgerEntries: LedgerEntry[] = [];
+  const addEntry = (
+    entry: Omit<LedgerEntry, 'id' | 'tick' | 'timestamp'> & { tick?: number; timestamp?: string },
+  ) => {
+    ledgerEntries.push({
+      id: generateId(idStream, 'ledger'),
+      tick: entry.tick ?? 0,
+      timestamp: entry.timestamp ?? createdAt,
+      amount: entry.amount,
+      type: entry.type,
+      category: entry.category,
+      description: entry.description,
+    });
+  };
+
+  addEntry({
+    amount: economics.initialCapital,
+    type: 'income',
+    category: 'capital',
+    description: 'Initial capital injection',
+  });
+
+  if (blueprint.upfrontFee > 0) {
+    addEntry({
+      amount: -blueprint.upfrontFee,
+      type: 'expense',
+      category: 'structure',
+      description: `Lease upfront payment for ${blueprint.name}`,
+    });
+  }
+
+  const deviceCosts = sumDeviceCapitalCosts(installedDevices, (id) =>
+    repository.getDevicePrice(id),
+  );
+  if (deviceCosts > 0) {
+    addEntry({
+      amount: -deviceCosts,
+      type: 'expense',
+      category: 'device',
+      description: 'Initial device purchases',
+    });
+  }
+
+  const cashOnHand = economics.initialCapital - blueprint.upfrontFee - deviceCosts;
+  const totalExpenses = blueprint.upfrontFee + deviceCosts;
+
+  const summary: FinancialSummary = {
+    totalRevenue: economics.initialCapital,
+    totalExpenses,
+    totalPayroll: 0,
+    totalMaintenance: 0,
+    netIncome: economics.initialCapital - totalExpenses,
+    lastTickRevenue: economics.initialCapital,
+    lastTickExpenses: totalExpenses,
+  };
+
+  return {
+    cashOnHand,
+    reservedCash: 0,
+    outstandingLoans: [],
+    ledger: ledgerEntries,
+    summary,
+  };
+};
+
+const createTasks = (
+  structure: StructureState,
+  room: StructureState['rooms'][number],
+  zone: StructureState['rooms'][number]['zones'][number],
+  plantCount: number,
+  definitions: TaskDefinitionMap | undefined,
+  idStream: RngStream,
+): TaskSystemState => {
+  const backlog: TaskState[] = [];
+  const createTask = (
+    definitionId: string,
+    fallbackPriority: number,
+    metadata: Record<string, unknown>,
+  ) => {
+    const definition = definitions?.[definitionId];
+    backlog.push({
+      id: generateId(idStream, 'task'),
+      definitionId,
+      status: 'pending',
+      priority: definition?.priority ?? fallbackPriority,
+      createdAtTick: 0,
+      dueTick: definition ? Math.round(definition.priority * 4) : undefined,
+      location: {
+        structureId: structure.id,
+        roomId: room.id,
+        zoneId: zone.id,
+      },
+      metadata: {
+        zoneName: zone.name,
+        structureName: structure.name,
+        ...(definition ? { description: definition.description } : {}),
+        ...metadata,
+      },
+    });
+  };
+
+  createTask('execute_planting_plan', 5, { plantCount });
+  createTask('refill_supplies_water', 4, {});
+  createTask('maintain_device', 3, { deviceCount: zone.devices.length });
+
+  return {
+    backlog,
+    active: [],
+    completed: [],
+    cancelled: [],
+  };
+};
+
+export const createInitialState = async (
+  context: StateFactoryContext,
+  options: StateFactoryOptions = {},
+): Promise<GameState> => {
+  const difficulty = options.difficulty ?? 'normal';
+  const economics = DIFFICULTY_ECONOMICS[difficulty];
+  const tickLengthMinutes = options.tickLengthMinutes ?? DEFAULT_TICK_LENGTH_MINUTES;
+  const createdAt = new Date().toISOString();
+  const idStream = context.rng.getStream('ids');
+
+  const structureBlueprints =
+    context.structureBlueprints ??
+    (context.dataDirectory ? await loadStructureBlueprints(context.dataDirectory) : []);
+  if (structureBlueprints.length === 0) {
+    throw new Error('No structure blueprints available to create initial state.');
+  }
+
+  const structureSelectionStream = context.rng.getStream('structures');
+  const structureBlueprint = selectBlueprint(
+    structureBlueprints,
+    structureSelectionStream,
+    options.structureId,
+  );
+
+  const strains = context.repository.listStrains();
+  if (strains.length === 0) {
+    throw new Error('Blueprint repository has no strain blueprints.');
+  }
+  const strain = selectBlueprint(
+    strains,
+    context.rng.getStream('strains'),
+    options.preferredStrainId,
+  );
+
+  const cultivationMethods = context.repository.listCultivationMethods();
+  if (cultivationMethods.length === 0) {
+    throw new Error('Blueprint repository has no cultivation method blueprints.');
+  }
+  const method = selectBlueprint(
+    cultivationMethods,
+    context.rng.getStream('methods'),
+    options.preferredCultivationMethodId,
+  );
+
+  const devices = context.repository.listDevices();
+  if (devices.length === 0) {
+    throw new Error('Blueprint repository has no device blueprints.');
+  }
+  const deviceBlueprints = chooseDeviceBlueprints(devices, context.rng.getStream('devices'));
+
+  const structureId = generateId(idStream, 'structure');
+  const structureResult = buildStructureState(
+    structureBlueprint,
+    structureId,
+    strain,
+    method,
+    deviceBlueprints,
+    idStream,
+    context.rng,
+    options.zonePlantCount,
+  );
+
+  const personnelDirectory =
+    context.personnelDirectory ??
+    (context.dataDirectory ? await loadPersonnelDirectory(context.dataDirectory) : undefined);
+
+  const employeeCounts: Record<EmployeeRole, number> = {
+    ...DEFAULT_EMPLOYEE_COUNTS,
+    ...options.employeeCountByRole,
+  } as Record<EmployeeRole, number>;
+
+  const personnel = createPersonnel(
+    structureId,
+    employeeCounts,
+    personnelDirectory,
+    context.rng,
+    idStream,
+  );
+
+  const inventory = createInventory(strain, structureResult.plantCount, idStream);
+
+  const finance = createFinanceState(
+    createdAt,
+    economics,
+    structureBlueprint,
+    structureResult.installedDeviceBlueprints,
+    context.repository,
+    idStream,
+  );
+
+  const taskDefinitions =
+    context.taskDefinitions ??
+    (context.dataDirectory ? await loadTaskDefinitions(context.dataDirectory) : undefined);
+
+  const tasks = createTasks(
+    structureResult.structure,
+    structureResult.growRoom,
+    structureResult.growZone,
+    structureResult.plantCount,
+    taskDefinitions,
+    idStream,
+  );
+
+  const metadata: GameMetadata = {
+    gameId: generateId(idStream, 'game'),
+    createdAt,
+    seed: context.rng.getSeed(),
+    difficulty,
+    simulationVersion: DEFAULT_SAVEGAME_VERSION,
+    tickLengthMinutes,
+    economics,
+  };
+
+  const clock = {
+    tick: 0,
+    isPaused: true,
+    startedAt: createdAt,
+    lastUpdatedAt: createdAt,
+    targetTickRate: DEFAULT_TARGET_TICK_RATE,
+  };
+
+  const notes = [
+    {
+      id: generateId(idStream, 'note'),
+      tick: 0,
+      message: 'Simulation initialized.',
+      level: 'info' as const,
+    },
+  ];
+
+  return {
+    metadata,
+    clock,
+    structures: [structureResult.structure],
+    inventory,
+    finances: finance,
+    personnel,
+    tasks,
+    notes,
+  };
+};


### PR DESCRIPTION
## Summary
- add comprehensive TypeScript interfaces for the simulation state hierarchy, inventory, finance, personnel, and task systems
- implement a deterministic RNG service with named substreams and serialisable offsets alongside save/load helpers
- provide a state factory that assembles an initial game state from blueprint data, including loaders for structures, personnel, and task definitions, and re-export the new modules from the backend entry point

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cebb4c8e448325b9bd34f26e9af3a2