### PR TITLE
feat: add simulation loop scheduler and event bus

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.6.0
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -2116,6 +2119,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -4721,6 +4727,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -4977,8 +4987,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.3",
+    "rxjs": "^7.8.2",
     "zod": "^3.23.8"
   }
 }

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -5,8 +5,11 @@ import { BlueprintRepository } from '../data/index.js';
 
 export * from './state/models.js';
 export * from './lib/rng.js';
+export * from './lib/eventBus.js';
 export * from './state/serialization.js';
 export * from './stateFactory.js';
+export * from './sim/loop.js';
+export * from './sim/simScheduler.js';
 
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
 

--- a/src/backend/src/lib/eventBus.test.ts
+++ b/src/backend/src/lib/eventBus.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventBus, SimulationEvent } from './eventBus.js';
+
+describe('EventBus', () => {
+  let bus: EventBus;
+
+  beforeEach(() => {
+    bus = new EventBus();
+  });
+
+  afterEach(() => {
+    bus.complete();
+    vi.useRealTimers();
+  });
+
+  it('broadcasts events to multiple subscribers', () => {
+    const receivedA: SimulationEvent[] = [];
+    const receivedB: SimulationEvent[] = [];
+
+    const subscriptionA = bus.events().subscribe((event) => receivedA.push(event));
+    const subscriptionB = bus.events().subscribe((event) => receivedB.push(event));
+
+    bus.emit({ type: 'sim.tickCompleted', tick: 1 });
+
+    expect(receivedA).toHaveLength(1);
+    expect(receivedB).toHaveLength(1);
+    expect(receivedA[0].tick).toBe(1);
+    expect(typeof receivedA[0].ts).toBe('number');
+
+    subscriptionA.unsubscribe();
+    subscriptionB.unsubscribe();
+  });
+
+  it('filters events by wildcard type', () => {
+    const received: SimulationEvent[] = [];
+    const subscription = bus.events({ type: 'plant.*' }).subscribe((event) => received.push(event));
+
+    bus.emit({ type: 'plant.stageChanged', tick: 2 });
+    bus.emit({ type: 'sim.tickCompleted', tick: 2 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('plant.stageChanged');
+
+    subscription.unsubscribe();
+  });
+
+  it('buffers events over a time window', async () => {
+    vi.useFakeTimers();
+    const batches: SimulationEvent[][] = [];
+    const subscription = bus.buffered({ timeMs: 100 }).subscribe((batch) => batches.push(batch));
+
+    bus.emit({ type: 'plant.stageChanged', tick: 3 });
+    bus.emit({ type: 'plant.harvested', tick: 3 });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[0][0].type).toBe('plant.stageChanged');
+    expect(batches[0][1].type).toBe('plant.harvested');
+
+    subscription.unsubscribe();
+  });
+});

--- a/src/backend/src/lib/eventBus.ts
+++ b/src/backend/src/lib/eventBus.ts
@@ -1,0 +1,160 @@
+import { Observable, Subject, bufferTime, filter as rxFilter, share } from 'rxjs';
+
+type MaybeArray<T> = T | T[];
+
+export type EventLevel = 'debug' | 'info' | 'warning' | 'error';
+
+export interface SimulationEvent<T = unknown> {
+  type: string;
+  payload?: T;
+  tick?: number;
+  ts?: number;
+  level?: EventLevel;
+  tags?: string[];
+}
+
+export type EventFilterPredicate = (event: SimulationEvent) => boolean;
+
+export interface EventFilterObject {
+  type?: MaybeArray<string | RegExp>;
+  level?: MaybeArray<EventLevel>;
+  predicate?: EventFilterPredicate;
+}
+
+export type EventFilter = string | RegExp | EventFilterPredicate | EventFilterObject;
+
+export interface EventBufferOptions {
+  timeMs?: number;
+  maxBufferSize?: number;
+  filter?: EventFilter;
+}
+
+export interface EventCollector {
+  readonly size: number;
+  queue(event: SimulationEvent): void;
+  queueMany(events: Iterable<SimulationEvent>): void;
+}
+
+const STAR_PLACEHOLDER = '__WB_STAR__';
+
+const wildcardToRegExp = (pattern: string): RegExp => {
+  const withPlaceholder = pattern.replace(/\*/g, STAR_PLACEHOLDER);
+  const escaped = withPlaceholder.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const source = escaped.replace(new RegExp(STAR_PLACEHOLDER, 'g'), '.*');
+  return new RegExp(`^${source}$`);
+};
+
+const asRegExp = (pattern: string | RegExp): RegExp => {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+  if (pattern.includes('*')) {
+    return wildcardToRegExp(pattern);
+  }
+  return new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
+};
+
+const normaliseArray = <T>(value: MaybeArray<T> | undefined): T[] => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const createFilterPredicate = (filter?: EventFilter): EventFilterPredicate => {
+  if (!filter) {
+    return () => true;
+  }
+
+  if (typeof filter === 'function') {
+    return filter;
+  }
+
+  if (typeof filter === 'string' || filter instanceof RegExp) {
+    const matcher = asRegExp(filter);
+    return (event) => matcher.test(event.type);
+  }
+
+  const types = normaliseArray(filter.type).map(asRegExp);
+  const levels = normaliseArray(filter.level);
+  const predicate = filter.predicate ?? (() => true);
+
+  return (event) => {
+    const matchesType = types.length === 0 || types.some((matcher) => matcher.test(event.type));
+    if (!matchesType) {
+      return false;
+    }
+    const matchesLevel =
+      levels.length === 0 || (event.level ? levels.includes(event.level) : false);
+    if (!matchesLevel) {
+      return false;
+    }
+    return predicate(event);
+  };
+};
+
+export class EventBus {
+  private readonly subject = new Subject<SimulationEvent>();
+
+  private readonly broadcast$ = this.subject
+    .asObservable()
+    .pipe(share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }));
+
+  emit(event: SimulationEvent): void {
+    const enriched: SimulationEvent = {
+      ...event,
+      ts: event.ts ?? Date.now(),
+    };
+    this.subject.next(enriched);
+  }
+
+  emitMany(events: Iterable<SimulationEvent>): void {
+    for (const event of events) {
+      this.emit(event);
+    }
+  }
+
+  events(filter?: EventFilter): Observable<SimulationEvent> {
+    const predicate = createFilterPredicate(filter);
+    return this.broadcast$.pipe(rxFilter(predicate));
+  }
+
+  buffered(options?: EventBufferOptions): Observable<SimulationEvent[]> {
+    const { timeMs = 250, maxBufferSize, filter } = options ?? {};
+    const stream = this.events(filter);
+    return stream.pipe(
+      bufferTime(timeMs, undefined, maxBufferSize),
+      rxFilter((batch) => batch.length > 0),
+    );
+  }
+
+  asObservable(): Observable<SimulationEvent> {
+    return this.broadcast$;
+  }
+
+  complete(): void {
+    this.subject.complete();
+  }
+}
+
+export const createEventCollector = (buffer: SimulationEvent[], tick: number): EventCollector => {
+  return {
+    get size() {
+      return buffer.length;
+    },
+    queue: (event: SimulationEvent) => {
+      buffer.push({
+        ...event,
+        tick: event.tick ?? tick,
+      });
+    },
+    queueMany: (events: Iterable<SimulationEvent>) => {
+      for (const event of events) {
+        buffer.push({
+          ...event,
+          tick: event.tick ?? tick,
+        });
+      }
+    },
+  };
+};

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '../lib/eventBus.js';
+import type { GameState } from '../state/models.js';
+import { SimulationLoop, TICK_PHASES, type SimulationPhaseContext } from './loop.js';
+
+const createGameState = (): GameState => {
+  const createdAt = new Date().toISOString();
+  return {
+    metadata: {
+      gameId: 'game-1',
+      createdAt,
+      seed: 'seed',
+      difficulty: 'easy',
+      simulationVersion: '0.0.0',
+      tickLengthMinutes: 60,
+      economics: {
+        initialCapital: 0,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0,
+        rentPerSqmRoomPerTick: 0,
+      },
+    },
+    clock: {
+      tick: 0,
+      isPaused: false,
+      startedAt: createdAt,
+      lastUpdatedAt: createdAt,
+      targetTickRate: 1,
+    },
+    structures: [],
+    inventory: {
+      resources: {
+        waterLiters: 0,
+        nutrientsGrams: 0,
+        co2Kg: 0,
+        substrateKg: 0,
+        packagingUnits: 0,
+        sparePartsValue: 0,
+      },
+      seeds: [],
+      devices: [],
+      harvest: [],
+      consumables: {},
+    },
+    finances: {
+      cashOnHand: 0,
+      reservedCash: 0,
+      outstandingLoans: [],
+      ledger: [],
+      summary: {
+        totalRevenue: 0,
+        totalExpenses: 0,
+        totalPayroll: 0,
+        totalMaintenance: 0,
+        netIncome: 0,
+        lastTickRevenue: 0,
+        lastTickExpenses: 0,
+      },
+    },
+    personnel: {
+      employees: [],
+      applicants: [],
+      trainingPrograms: [],
+      overallMorale: 0,
+    },
+    tasks: {
+      backlog: [],
+      active: [],
+      completed: [],
+      cancelled: [],
+    },
+    notes: [],
+  };
+};
+
+describe('SimulationLoop', () => {
+  it('executes phases in order and emits events after commit', async () => {
+    const state = createGameState();
+    const bus = new EventBus();
+    const executed: string[] = [];
+    const loop = new SimulationLoop({
+      state,
+      eventBus: bus,
+      phases: {
+        applyDevices: (ctx) => {
+          executed.push(ctx.phase);
+          ctx.events.queue({ type: 'device.applied', level: 'info' });
+        },
+        deriveEnvironment: (ctx) => executed.push(ctx.phase),
+        irrigationAndNutrients: (ctx) => {
+          executed.push(ctx.phase);
+          ctx.events.queue({ type: 'env.irrigated', payload: { liters: 10 } });
+        },
+        updatePlants: (ctx) => executed.push(ctx.phase),
+        harvestAndInventory: (ctx) => executed.push(ctx.phase),
+        accounting: (ctx) => executed.push(ctx.phase),
+        commit: (ctx) => executed.push(ctx.phase),
+      },
+    });
+
+    const received: string[] = [];
+    const subscription = bus.events().subscribe((event) => received.push(event.type));
+
+    const result = await loop.processTick();
+
+    expect(executed).toEqual(TICK_PHASES);
+    expect(state.clock.tick).toBe(1);
+    expect(result.events.map((event) => event.type)).toEqual(['device.applied', 'env.irrigated']);
+    expect(received).toEqual(['device.applied', 'env.irrigated', 'sim.tickCompleted']);
+
+    subscription.unsubscribe();
+  });
+
+  it('increments tick numbers across multiple runs', async () => {
+    const state = createGameState();
+    const bus = new EventBus();
+    const loop = new SimulationLoop({
+      state,
+      eventBus: bus,
+      phases: {
+        applyDevices: (ctx: SimulationPhaseContext) => {
+          ctx.events.queue({
+            type: 'phase.entered',
+            payload: { phase: ctx.phase, tick: ctx.tick },
+          });
+        },
+      },
+    });
+
+    const ticks: number[] = [];
+    const subscription = bus.events({ type: 'phase.entered' }).subscribe((event) => {
+      if (event.tick !== undefined) {
+        ticks.push(event.tick);
+      }
+    });
+
+    const first = await loop.processTick();
+    const second = await loop.processTick();
+
+    expect(first.tick).toBe(1);
+    expect(second.tick).toBe(2);
+    expect(state.clock.tick).toBe(2);
+    expect(ticks).toEqual([1, 2]);
+
+    subscription.unsubscribe();
+  });
+});

--- a/src/backend/src/sim/loop.ts
+++ b/src/backend/src/sim/loop.ts
@@ -1,0 +1,259 @@
+import { performance } from 'node:perf_hooks';
+import type { GameState } from '../state/models.js';
+import type { EventCollector, SimulationEvent } from '../lib/eventBus.js';
+import { EventBus, createEventCollector } from '../lib/eventBus.js';
+
+export const TICK_PHASES = [
+  'applyDevices',
+  'deriveEnvironment',
+  'irrigationAndNutrients',
+  'updatePlants',
+  'harvestAndInventory',
+  'accounting',
+  'commit',
+] as const;
+
+export type TickPhase = (typeof TICK_PHASES)[number];
+
+export interface PhaseTiming {
+  startedAt: number;
+  completedAt: number;
+  durationMs: number;
+}
+
+export interface TickCompletedPayload {
+  tick: number;
+  durationMs: number;
+  eventCount: number;
+  phaseTimings: Record<TickPhase, PhaseTiming>;
+  events: SimulationEvent[];
+}
+
+export interface TickResult {
+  tick: number;
+  startedAt: number;
+  completedAt: number;
+  events: SimulationEvent[];
+  phaseTimings: Record<TickPhase, PhaseTiming>;
+}
+
+export interface SimulationPhaseContext {
+  readonly state: GameState;
+  readonly tick: number;
+  readonly tickLengthMinutes: number;
+  readonly phase: TickPhase;
+  readonly events: EventCollector;
+}
+
+export type SimulationPhaseHandler = (context: SimulationPhaseContext) => void | Promise<void>;
+
+export type SimulationPhaseHandlers = Partial<Record<TickPhase, SimulationPhaseHandler>>;
+
+type NonCommitPhase = Exclude<TickPhase, 'commit'>;
+
+type MachineState =
+  | { status: 'idle' }
+  | { status: 'running'; phaseIndex: number; tick: number }
+  | { status: 'completed'; tick: number }
+  | { status: 'failed'; tick?: number; error: unknown };
+
+const NOOP_PHASE: SimulationPhaseHandler = () => undefined;
+
+class TickStateMachine {
+  private state: MachineState = { status: 'idle' };
+
+  start(tick: number): void {
+    if (this.state.status === 'running') {
+      throw new Error('Cannot start a new tick while another tick is running.');
+    }
+    this.state = { status: 'running', phaseIndex: 0, tick };
+  }
+
+  currentPhase(): TickPhase {
+    if (this.state.status !== 'running') {
+      throw new Error('Tick state machine is not running.');
+    }
+    return TICK_PHASES[this.state.phaseIndex];
+  }
+
+  advance(): MachineState {
+    if (this.state.status !== 'running') {
+      throw new Error('Cannot advance tick state machine when it is not running.');
+    }
+    const nextIndex = this.state.phaseIndex + 1;
+    if (nextIndex >= TICK_PHASES.length) {
+      this.state = { status: 'completed', tick: this.state.tick };
+    } else {
+      this.state = { status: 'running', phaseIndex: nextIndex, tick: this.state.tick };
+    }
+    return this.state;
+  }
+
+  fail(error: unknown): void {
+    const tick =
+      this.state.status === 'running' || this.state.status === 'completed'
+        ? this.state.tick
+        : undefined;
+    this.state = { status: 'failed', tick, error };
+  }
+
+  isRunning(): boolean {
+    return this.state.status === 'running';
+  }
+
+  getState(): MachineState {
+    return this.state;
+  }
+
+  reset(): void {
+    this.state = { status: 'idle' };
+  }
+}
+
+export interface SimulationLoopOptions {
+  state: GameState;
+  eventBus: EventBus;
+  phases?: SimulationPhaseHandlers;
+}
+
+export class SimulationLoop {
+  private readonly state: GameState;
+
+  private readonly eventBus: EventBus;
+
+  private readonly phaseHandlers: Record<NonCommitPhase, SimulationPhaseHandler>;
+
+  private readonly commitHook?: SimulationPhaseHandler;
+
+  private readonly machine = new TickStateMachine();
+
+  constructor(options: SimulationLoopOptions) {
+    this.state = options.state;
+    this.eventBus = options.eventBus;
+    const phases = options.phases ?? {};
+    this.phaseHandlers = {
+      applyDevices: phases.applyDevices ?? NOOP_PHASE,
+      deriveEnvironment: phases.deriveEnvironment ?? NOOP_PHASE,
+      irrigationAndNutrients: phases.irrigationAndNutrients ?? NOOP_PHASE,
+      updatePlants: phases.updatePlants ?? NOOP_PHASE,
+      harvestAndInventory: phases.harvestAndInventory ?? NOOP_PHASE,
+      accounting: phases.accounting ?? NOOP_PHASE,
+    };
+    this.commitHook = phases.commit;
+  }
+
+  async processTick(): Promise<TickResult> {
+    if (this.machine.isRunning()) {
+      throw new Error('A tick is already being processed.');
+    }
+
+    const tickNumber = this.state.clock.tick + 1;
+    const tickLengthMinutes = this.state.metadata.tickLengthMinutes;
+    const tickStartMonotonic = performance.now();
+    const eventBuffer: SimulationEvent[] = [];
+    const collector = createEventCollector(eventBuffer, tickNumber);
+
+    const timings: Partial<Record<TickPhase, PhaseTiming>> = {};
+    let commitTimestamp: number | undefined;
+
+    this.machine.start(tickNumber);
+
+    try {
+      while (this.machine.isRunning()) {
+        const phase = this.machine.currentPhase();
+        const phaseStart = performance.now();
+        const context: SimulationPhaseContext = {
+          state: this.state,
+          tick: tickNumber,
+          tickLengthMinutes,
+          phase,
+          events: collector,
+        };
+
+        if (phase === 'commit') {
+          commitTimestamp = await this.executeCommit(context, tickNumber);
+        } else {
+          const handler = this.phaseHandlers[phase as NonCommitPhase];
+          await handler(context);
+        }
+
+        const phaseEnd = performance.now();
+        timings[phase] = {
+          startedAt: phaseStart - tickStartMonotonic,
+          completedAt: phaseEnd - tickStartMonotonic,
+          durationMs: phaseEnd - phaseStart,
+        };
+
+        this.machine.advance();
+      }
+    } catch (error) {
+      this.machine.fail(error);
+      throw error;
+    }
+
+    const state = this.machine.getState();
+    if (state.status !== 'completed') {
+      throw new Error('Tick did not reach a completed state.');
+    }
+
+    this.machine.reset();
+
+    const commitTime = commitTimestamp ?? Date.now();
+    const enrichedEvents = eventBuffer.map((event) => ({
+      ...event,
+      tick: event.tick ?? tickNumber,
+      ts: event.ts ?? commitTime,
+    }));
+
+    const orderedTimings: Record<TickPhase, PhaseTiming> = {} as Record<TickPhase, PhaseTiming>;
+    for (const phase of TICK_PHASES) {
+      const timing = timings[phase];
+      if (!timing) {
+        throw new Error(`Missing timing information for phase ${phase}`);
+      }
+      orderedTimings[phase] = timing;
+    }
+
+    const tickEndMonotonic = performance.now();
+    const result: TickResult = {
+      tick: tickNumber,
+      startedAt: tickStartMonotonic,
+      completedAt: tickEndMonotonic,
+      events: enrichedEvents,
+      phaseTimings: orderedTimings,
+    };
+
+    if (enrichedEvents.length > 0) {
+      this.eventBus.emitMany(enrichedEvents);
+    }
+
+    const tickCompletedEvent: SimulationEvent<TickCompletedPayload> = {
+      type: 'sim.tickCompleted',
+      tick: tickNumber,
+      ts: commitTime,
+      level: 'info',
+      payload: {
+        tick: tickNumber,
+        durationMs: tickEndMonotonic - tickStartMonotonic,
+        eventCount: enrichedEvents.length,
+        phaseTimings: orderedTimings,
+        events: enrichedEvents,
+      },
+    };
+
+    this.eventBus.emit(tickCompletedEvent);
+
+    return result;
+  }
+
+  private async executeCommit(context: SimulationPhaseContext, tick: number): Promise<number> {
+    if (this.commitHook) {
+      await this.commitHook(context);
+    }
+
+    const commitTimestamp = Date.now();
+    context.state.clock.tick = tick;
+    context.state.clock.lastUpdatedAt = new Date(commitTimestamp).toISOString();
+    return commitTimestamp;
+  }
+}

--- a/src/backend/src/sim/simScheduler.test.ts
+++ b/src/backend/src/sim/simScheduler.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SimulationClockState } from '../state/models.js';
+import { SimulationScheduler } from './simScheduler.js';
+
+type FrameCallback = () => void;
+
+const createFrameController = () => {
+  const callbacks: FrameCallback[] = [];
+  return {
+    schedule(callback: FrameCallback) {
+      callbacks.push(callback);
+      return callbacks.length - 1;
+    },
+    cancel(handle: unknown) {
+      if (typeof handle === 'number' && callbacks[handle]) {
+        callbacks[handle] = () => {};
+      }
+    },
+    async flush() {
+      const callback = callbacks.shift();
+      if (callback) {
+        callback();
+        await Promise.resolve();
+      }
+    },
+    clear() {
+      callbacks.length = 0;
+    },
+    get pending() {
+      return callbacks.length;
+    },
+  };
+};
+
+describe('SimulationScheduler', () => {
+  it('processes accumulated time with catch-up', async () => {
+    const times = [0, 0, 350, 350, 350];
+    const controller = createFrameController();
+    const executor = vi.fn();
+    const scheduler = new SimulationScheduler(executor, {
+      tickIntervalMs: 100,
+      maxTicksPerFrame: 5,
+      timeProvider: () => times.shift() ?? 350,
+      frameScheduler: controller.schedule,
+      frameCanceler: controller.cancel,
+    });
+
+    scheduler.start();
+    await controller.flush(); // initial frame
+    expect(executor).toHaveBeenCalledTimes(0);
+
+    await controller.flush(); // catch-up frame
+    expect(executor).toHaveBeenCalledTimes(3);
+
+    await controller.flush();
+    expect(executor).toHaveBeenCalledTimes(3);
+
+    scheduler.stop();
+    controller.clear();
+  });
+
+  it('supports stepping while paused', async () => {
+    const times = [0, 0, 0, 0, 0];
+    const controller = createFrameController();
+    const executor = vi.fn();
+    const scheduler = new SimulationScheduler(executor, {
+      tickIntervalMs: 100,
+      timeProvider: () => times.shift() ?? 0,
+      frameScheduler: controller.schedule,
+      frameCanceler: controller.cancel,
+    });
+
+    scheduler.start();
+    await controller.flush();
+
+    scheduler.pause();
+    await controller.flush();
+
+    await scheduler.step(2);
+    await controller.flush();
+    expect(executor).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+    controller.clear();
+  });
+
+  it('mirrors scheduler state to the simulation clock', async () => {
+    const times = [0, 0, 0, 0];
+    const controller = createFrameController();
+    const clock: SimulationClockState = {
+      tick: 0,
+      isPaused: true,
+      startedAt: new Date().toISOString(),
+      lastUpdatedAt: new Date().toISOString(),
+      targetTickRate: 1,
+    };
+    const scheduler = new SimulationScheduler(() => undefined, {
+      tickIntervalMs: 100,
+      clock,
+      frameScheduler: controller.schedule,
+      frameCanceler: controller.cancel,
+      timeProvider: () => times.shift() ?? 0,
+    });
+
+    scheduler.start();
+    expect(clock.isPaused).toBe(false);
+    expect(clock.targetTickRate).toBe(1);
+
+    scheduler.pause();
+    expect(clock.isPaused).toBe(true);
+
+    scheduler.setSpeed(2);
+    expect(clock.targetTickRate).toBe(2);
+
+    scheduler.resume();
+    expect(clock.isPaused).toBe(false);
+
+    scheduler.stop();
+    expect(clock.isPaused).toBe(true);
+
+    controller.clear();
+  });
+});

--- a/src/backend/src/sim/simScheduler.ts
+++ b/src/backend/src/sim/simScheduler.ts
@@ -1,0 +1,238 @@
+import { performance } from 'node:perf_hooks';
+import type { SimulationClockState } from '../state/models.js';
+
+export type TickExecutor = () => void | Promise<void>;
+
+export interface SimulationSchedulerOptions {
+  tickIntervalMs: number;
+  maxTicksPerFrame?: number;
+  speed?: number;
+  clock?: SimulationClockState;
+  timeProvider?: () => number;
+  frameScheduler?: (callback: () => void) => unknown;
+  frameCanceler?: (handle: unknown) => void;
+  onError?: (error: unknown) => void;
+}
+
+type SchedulerHandle = unknown;
+
+const clampPositive = (value: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error('Speed multiplier must be a finite number greater than zero.');
+  }
+  return value;
+};
+
+export class SimulationScheduler {
+  private readonly tickExecutor: TickExecutor;
+
+  private readonly tickIntervalMs: number;
+
+  private readonly maxTicksPerFrame: number;
+
+  private readonly timeProvider: () => number;
+
+  private readonly frameScheduler: (callback: () => void) => SchedulerHandle;
+
+  private readonly frameCanceler: (handle: SchedulerHandle) => void;
+
+  private readonly onError?: (error: unknown) => void;
+
+  private readonly clock?: SimulationClockState;
+
+  private running = false;
+
+  private paused = true;
+
+  private speed: number;
+
+  private accumulator = 0;
+
+  private pendingSteps = 0;
+
+  private lastTimestamp = 0;
+
+  private frameHandle: SchedulerHandle | null = null;
+
+  constructor(tickExecutor: TickExecutor, options: SimulationSchedulerOptions) {
+    this.tickExecutor = tickExecutor;
+    this.tickIntervalMs = options.tickIntervalMs;
+    this.maxTicksPerFrame = options.maxTicksPerFrame ?? 5;
+    this.timeProvider = options.timeProvider ?? (() => performance.now());
+    this.frameScheduler = options.frameScheduler ?? ((callback) => setImmediate(callback));
+    this.frameCanceler =
+      options.frameCanceler ?? ((handle) => clearImmediate(handle as NodeJS.Immediate));
+    this.onError = options.onError;
+    this.clock = options.clock;
+    this.speed = clampPositive(options.speed ?? 1);
+    this.updateClockTargetRate();
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.paused = false;
+    this.accumulator = 0;
+    this.pendingSteps = 0;
+    this.lastTimestamp = this.timeProvider();
+    this.updateClockPausedState(false);
+    this.scheduleNextFrame();
+  }
+
+  stop(): void {
+    if (!this.running) {
+      return;
+    }
+    this.running = false;
+    this.paused = true;
+    this.accumulator = 0;
+    this.pendingSteps = 0;
+    if (this.frameHandle !== null) {
+      this.frameCanceler(this.frameHandle);
+      this.frameHandle = null;
+    }
+    this.updateClockPausedState(true);
+  }
+
+  pause(): void {
+    if (!this.running || this.paused) {
+      return;
+    }
+    this.paused = true;
+    this.updateClockPausedState(true);
+  }
+
+  resume(): void {
+    if (!this.running) {
+      this.start();
+      return;
+    }
+    if (!this.paused) {
+      return;
+    }
+    this.paused = false;
+    this.lastTimestamp = this.timeProvider();
+    this.updateClockPausedState(false);
+  }
+
+  setSpeed(multiplier: number): void {
+    this.speed = clampPositive(multiplier);
+    this.updateClockTargetRate();
+  }
+
+  async step(count = 1): Promise<void> {
+    const steps = Math.max(0, Math.floor(count));
+    if (steps === 0) {
+      return;
+    }
+    if (!this.running) {
+      for (let index = 0; index < steps; index += 1) {
+        await this.executeTick();
+      }
+      return;
+    }
+    this.pendingSteps += steps;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  getSpeed(): number {
+    return this.speed;
+  }
+
+  private scheduleNextFrame(): void {
+    if (!this.running || this.frameHandle !== null) {
+      return;
+    }
+    this.frameHandle = this.frameScheduler(() => {
+      this.frameHandle = null;
+      this.processFrame().catch((error) => {
+        this.handleError(error);
+      });
+    });
+  }
+
+  private async processFrame(): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+
+    const now = this.timeProvider();
+    const delta = Math.max(0, now - this.lastTimestamp);
+    this.lastTimestamp = now;
+
+    if (!this.paused) {
+      this.accumulator += delta * this.speed;
+    }
+
+    let ticksExecuted = 0;
+    while (
+      this.running &&
+      (this.pendingSteps > 0 || (!this.paused && this.accumulator >= this.tickIntervalMs)) &&
+      ticksExecuted < this.maxTicksPerFrame
+    ) {
+      if (this.pendingSteps > 0) {
+        this.pendingSteps -= 1;
+      } else {
+        this.accumulator -= this.tickIntervalMs;
+      }
+      ticksExecuted += 1;
+      const tickResult = this.executeTick();
+      if (tickResult instanceof Promise) {
+        try {
+          await tickResult;
+        } catch (error) {
+          this.handleError(error);
+          return;
+        }
+      }
+    }
+
+    if (this.running) {
+      this.scheduleNextFrame();
+    }
+  }
+
+  private executeTick(): void | Promise<void> {
+    try {
+      return this.tickExecutor();
+    } catch (error) {
+      this.handleError(error);
+      return undefined;
+    }
+  }
+
+  private updateClockPausedState(paused: boolean): void {
+    if (this.clock) {
+      this.clock.isPaused = paused;
+    }
+  }
+
+  private updateClockTargetRate(): void {
+    if (this.clock) {
+      this.clock.targetTickRate = this.speed;
+    }
+  }
+
+  private handleError(error: unknown): void {
+    this.stop();
+    if (this.onError) {
+      this.onError(error);
+      return;
+    }
+    queueMicrotask(() => {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(String(error));
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an RxJS-backed event bus with filtering, buffering, and broadcast helpers plus tests
- implement the simulation tick state machine that wires the mutation context and emits aggregated events after commit
- create a real-time scheduler with pause/step/speed controls and hook exports for downstream consumers

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cec11b4a388325a49b4a4ab5858246