### PR TITLE
feat(engine): add zone environment device effects service

### DIFF
--- a/src/backend/src/engine/environment/deviceEffects.test.ts
+++ b/src/backend/src/engine/environment/deviceEffects.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { computeZoneDeviceDeltas } from './deviceEffects.js';
+import type {
+  DeviceInstanceState,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneState,
+} from '../../state/models.js';
+
+const createEnvironment = (
+  overrides: Partial<ZoneEnvironmentState> = {},
+): ZoneEnvironmentState => ({
+  temperature: 25,
+  relativeHumidity: 0.6,
+  co2: 800,
+  ppfd: 0,
+  vpd: 1,
+  ...overrides,
+});
+
+const createResources = (): ZoneResourceState => ({
+  waterLiters: 0,
+  nutrientSolutionLiters: 0,
+  nutrientStrength: 1,
+  substrateHealth: 1,
+  reservoirLevel: 0.5,
+});
+
+const createMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
+  averageTemperature: environment.temperature,
+  averageHumidity: environment.relativeHumidity,
+  averageCo2: environment.co2,
+  averagePpfd: environment.ppfd,
+  stressLevel: 0,
+  lastUpdatedTick: 0,
+});
+
+const createDevice = (
+  kind: string,
+  settings: Record<string, unknown>,
+  efficiency = 1,
+): DeviceInstanceState => ({
+  id: `${kind}-device`,
+  blueprintId: `${kind}-blueprint`,
+  kind,
+  name: `${kind} Unit`,
+  zoneId: 'zone-1',
+  status: 'operational',
+  efficiency,
+  runtimeHours: 0,
+  maintenance: {
+    lastServiceTick: 0,
+    nextDueTick: 1000,
+    condition: 1,
+    degradation: 0,
+  },
+  settings,
+});
+
+const createZone = (
+  devices: DeviceInstanceState[],
+  environment?: ZoneEnvironmentState,
+): ZoneState => {
+  const env = environment ?? createEnvironment();
+  return {
+    id: 'zone-1',
+    roomId: 'room-1',
+    name: 'Zone 1',
+    cultivationMethodId: 'method-1',
+    strainId: 'strain-1',
+    environment: env,
+    resources: createResources(),
+    plants: [],
+    devices,
+    metrics: createMetrics(env),
+    activeTaskIds: [],
+  };
+};
+
+describe('deviceEffects', () => {
+  it('computes temperature and light contribution for grow lights', () => {
+    const zone = createZone([
+      createDevice(
+        'Lamp',
+        {
+          power: 0.6,
+          heatFraction: 0.3,
+          coverageArea: 1.2,
+          ppfd: 800,
+        },
+        0.9,
+      ),
+    ]);
+
+    const deltas = computeZoneDeviceDeltas(zone, { area: 12, volume: 36 }, { tickHours: 0.25 });
+
+    expect(deltas.temperatureDelta).toBeCloseTo(0.84, 2);
+    expect(deltas.ppfdDelta).toBeCloseTo(72, 4);
+    expect(deltas.airflow).toBe(0);
+  });
+
+  it('cools zone temperature and contributes airflow for HVAC units', () => {
+    const zone = createZone(
+      [
+        createDevice(
+          'ClimateUnit',
+          {
+            coolingCapacity: 1.6,
+            airflow: 350,
+            targetTemperature: 24,
+            targetTemperatureRange: [23, 25],
+            fullPowerAtDeltaK: 2,
+          },
+          0.9,
+        ),
+      ],
+      createEnvironment({ temperature: 28 }),
+    );
+
+    const deltas = computeZoneDeviceDeltas(zone, { area: 40, volume: 120 }, { tickHours: 0.25 });
+
+    expect(deltas.temperatureDelta).toBeCloseTo(-4, 3);
+    expect(deltas.airflow).toBeCloseTo(315, 6);
+    expect(deltas.ppfdDelta).toBe(0);
+  });
+
+  it('injects CO2 when below target within safety bounds', () => {
+    const zone = createZone(
+      [
+        createDevice('CO2Injector', {
+          targetCO2: 1100,
+          targetCO2Range: [400, 1500],
+          hysteresis: 50,
+          pulsePpmPerTick: 150,
+        }),
+      ],
+      createEnvironment({ co2: 800 }),
+    );
+
+    const deltas = computeZoneDeviceDeltas(zone, { area: 30, volume: 90 }, { tickHours: 5 / 60 });
+
+    expect(deltas.co2Delta).toBeCloseTo(300, 5);
+    expect(deltas.temperatureDelta).toBe(0);
+    expect(deltas.airflow).toBe(0);
+  });
+});

--- a/src/backend/src/engine/environment/deviceEffects.ts
+++ b/src/backend/src/engine/environment/deviceEffects.ts
@@ -1,0 +1,279 @@
+import type { DeviceInstanceState, ZoneEnvironmentState, ZoneState } from '../../state/models.js';
+
+export interface ZoneGeometry {
+  area: number;
+  volume: number;
+}
+
+export interface DeviceEffect {
+  temperatureDelta: number;
+  humidityDelta: number;
+  co2Delta: number;
+  ppfdDelta: number;
+  airflow: number;
+}
+
+export interface DeviceEffectContext {
+  tickHours: number;
+}
+
+const DEFAULT_DEVICE_EFFECT: DeviceEffect = {
+  temperatureDelta: 0,
+  humidityDelta: 0,
+  co2Delta: 0,
+  ppfdDelta: 0,
+  airflow: 0,
+};
+
+const SPECIFIC_HEAT_AIR_KWH_PER_M3K = 0.000336;
+const MIN_HEAT_CAPACITY_KWH_PER_K = 0.0001;
+const LAMP_HEAT_TRANSFER_COEFFICIENT = 0.25;
+const HVAC_HEAT_TRANSFER_COEFFICIENT = 0.8;
+const DEFAULT_LIGHT_HEAT_FRACTION = 0.4;
+const DEFAULT_LIGHT_COVERAGE_M2 = 1;
+const DEFAULT_FULL_POWER_DELTA_K = 1;
+const DEFAULT_HYSTERESIS_K = 0.5;
+const DEFAULT_CO2_PULSE_MINUTES = 1;
+const DEFAULT_MAX_CO2_PPM = 1800;
+
+const LIGHT_KINDS = new Set(['GrowLight', 'Lamp', 'Light']);
+const HVAC_KINDS = new Set([
+  'ClimateUnit',
+  'HVAC',
+  'HumidityControlUnit',
+  'Dehumidifier',
+  'ExhaustFan',
+]);
+const CO2_KINDS = new Set(['CO2Injector']);
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  return fallback;
+};
+
+const toNumberTuple = (value: unknown): [number, number] | undefined => {
+  if (!Array.isArray(value) || value.length !== 2) {
+    return undefined;
+  }
+  const [first, second] = value;
+  if (typeof first !== 'number' || typeof second !== 'number') {
+    return undefined;
+  }
+  return [first, second];
+};
+
+const energyToTemperatureDelta = (energyKwh: number, volume: number): number => {
+  if (energyKwh === 0) {
+    return 0;
+  }
+  const capacity = Math.max(volume * SPECIFIC_HEAT_AIR_KWH_PER_M3K, MIN_HEAT_CAPACITY_KWH_PER_K);
+  return energyKwh / capacity;
+};
+
+const computeGrowLightEffect = (
+  device: DeviceInstanceState,
+  geometry: ZoneGeometry,
+  context: DeviceEffectContext,
+): DeviceEffect => {
+  const settings = device.settings;
+  const powerKw = toNumber(settings.power, 0);
+  const heatFraction = clamp(toNumber(settings.heatFraction, DEFAULT_LIGHT_HEAT_FRACTION), 0, 1);
+  const coverage = Math.max(toNumber(settings.coverageArea, DEFAULT_LIGHT_COVERAGE_M2), 0.0001);
+  const ppfd = Math.max(toNumber(settings.ppfd, 0), 0);
+
+  if (powerKw <= 0 && ppfd === 0) {
+    return { ...DEFAULT_DEVICE_EFFECT };
+  }
+
+  const energy = powerKw * heatFraction * context.tickHours;
+  const baseDelta = energyToTemperatureDelta(energy, geometry.volume);
+  const temperatureDelta =
+    baseDelta * LAMP_HEAT_TRANSFER_COEFFICIENT * clamp(device.efficiency, 0, 1);
+
+  const coverageRatio = clamp(coverage / Math.max(geometry.area, 0.0001), 0, 1);
+  const ppfdDelta = ppfd * coverageRatio * clamp(device.efficiency, 0, 1);
+
+  return {
+    temperatureDelta,
+    humidityDelta: 0,
+    co2Delta: 0,
+    ppfdDelta,
+    airflow: 0,
+  };
+};
+
+const computeTargetBand = (
+  target: number,
+  range: [number, number] | undefined,
+  hysteresis: number,
+): [number, number] => {
+  if (range) {
+    const [low, high] = range;
+    if (Number.isFinite(low) && Number.isFinite(high) && low <= high) {
+      return [low, high];
+    }
+  }
+  const half = hysteresis / 2;
+  return [target - half, target + half];
+};
+
+const computeHvacTemperatureEffect = (
+  device: DeviceInstanceState,
+  environment: ZoneEnvironmentState,
+  geometry: ZoneGeometry,
+  context: DeviceEffectContext,
+): DeviceEffect => {
+  const settings = device.settings;
+  const efficiency = clamp(device.efficiency, 0, 1);
+  const targetTemperature = toNumber(settings.targetTemperature, environment.temperature);
+  const range = toNumberTuple(settings.targetTemperatureRange);
+  const hysteresis = Math.max(toNumber(settings.hysteresisK, DEFAULT_HYSTERESIS_K), 0);
+  const [lowerBound, upperBound] = computeTargetBand(
+    targetTemperature,
+    range,
+    hysteresis || DEFAULT_HYSTERESIS_K,
+  );
+
+  const needsCooling = environment.temperature > upperBound;
+  const needsHeating = environment.temperature < lowerBound;
+
+  if (!needsCooling && !needsHeating) {
+    return {
+      ...DEFAULT_DEVICE_EFFECT,
+      airflow: Math.max(toNumber(settings.airflow, 0), 0) * efficiency,
+    };
+  }
+
+  const capacityKey = needsCooling ? 'coolingCapacity' : 'heatingCapacity';
+  const capacityKw = Math.max(toNumber(settings[capacityKey], toNumber(settings.power, 0)), 0);
+  if (capacityKw <= 0 || context.tickHours <= 0) {
+    return {
+      ...DEFAULT_DEVICE_EFFECT,
+      airflow: Math.max(toNumber(settings.airflow, 0), 0) * efficiency,
+    };
+  }
+
+  const temperatureDifference = targetTemperature - environment.temperature;
+  const desiredDelta = needsCooling
+    ? Math.max(targetTemperature - environment.temperature, lowerBound - environment.temperature)
+    : Math.min(targetTemperature - environment.temperature, upperBound - environment.temperature);
+
+  const energy = capacityKw * context.tickHours;
+  const baseDelta = energyToTemperatureDelta(energy, geometry.volume);
+  const fullPowerDelta = Math.max(
+    toNumber(settings.fullPowerAtDeltaK, DEFAULT_FULL_POWER_DELTA_K),
+    0.0001,
+  );
+  const modulation = clamp(Math.abs(temperatureDifference) / fullPowerDelta, 0, 1);
+  const potentialDelta = baseDelta * HVAC_HEAT_TRANSFER_COEFFICIENT * efficiency * modulation;
+
+  const appliedDelta = Math.sign(desiredDelta) * Math.min(Math.abs(desiredDelta), potentialDelta);
+  const airflow = Math.max(toNumber(settings.airflow, 0), 0) * efficiency;
+
+  return {
+    temperatureDelta: appliedDelta,
+    humidityDelta: 0,
+    co2Delta: 0,
+    ppfdDelta: 0,
+    airflow,
+  };
+};
+
+const computeCo2Effect = (
+  device: DeviceInstanceState,
+  environment: ZoneEnvironmentState,
+  context: DeviceEffectContext,
+): DeviceEffect => {
+  const settings = device.settings;
+  const efficiency = clamp(device.efficiency, 0, 1);
+  const target = toNumber(settings.targetCO2, environment.co2);
+  const hysteresis = Math.max(toNumber(settings.hysteresis, 0), 0);
+  const range = toNumberTuple(settings.targetCO2Range);
+  const maxCo2 = range?.[1] ?? toNumber(settings.maxSafeCo2, DEFAULT_MAX_CO2_PPM);
+  const pulse = Math.max(toNumber(settings.pulsePpmPerTick, 0), 0);
+  if (pulse === 0 || context.tickHours <= 0) {
+    return { ...DEFAULT_DEVICE_EFFECT };
+  }
+
+  const tickMinutes = context.tickHours * 60;
+  const scaledPulse = pulse * (tickMinutes / DEFAULT_CO2_PULSE_MINUTES);
+
+  const lowerThreshold = target - hysteresis;
+  if (environment.co2 >= lowerThreshold) {
+    return { ...DEFAULT_DEVICE_EFFECT };
+  }
+
+  const desiredIncrease = target - environment.co2;
+  if (desiredIncrease <= 0) {
+    return { ...DEFAULT_DEVICE_EFFECT };
+  }
+
+  const appliedIncrease = Math.min(desiredIncrease, scaledPulse) * efficiency;
+  const safetyLimited = Math.min(appliedIncrease, Math.max(0, maxCo2 - environment.co2));
+
+  return {
+    temperatureDelta: 0,
+    humidityDelta: 0,
+    co2Delta: Math.max(0, safetyLimited),
+    ppfdDelta: 0,
+    airflow: 0,
+  };
+};
+
+const computeSingleDeviceEffect = (
+  device: DeviceInstanceState,
+  zone: ZoneEnvironmentState,
+  geometry: ZoneGeometry,
+  context: DeviceEffectContext,
+): DeviceEffect => {
+  if (device.status !== 'operational') {
+    return { ...DEFAULT_DEVICE_EFFECT };
+  }
+
+  if (LIGHT_KINDS.has(device.kind)) {
+    return computeGrowLightEffect(device, geometry, context);
+  }
+
+  if (HVAC_KINDS.has(device.kind)) {
+    return computeHvacTemperatureEffect(device, zone, geometry, context);
+  }
+
+  if (CO2_KINDS.has(device.kind)) {
+    return computeCo2Effect(device, zone, context);
+  }
+
+  return { ...DEFAULT_DEVICE_EFFECT };
+};
+
+export const computeZoneDeviceDeltas = (
+  zone: ZoneState,
+  geometry: ZoneGeometry,
+  context: DeviceEffectContext,
+): DeviceEffect => {
+  return zone.devices.reduce<DeviceEffect>(
+    (accumulator, device) => {
+      const effect = computeSingleDeviceEffect(device, zone.environment, geometry, context);
+      return {
+        temperatureDelta: accumulator.temperatureDelta + effect.temperatureDelta,
+        humidityDelta: accumulator.humidityDelta + effect.humidityDelta,
+        co2Delta: accumulator.co2Delta + effect.co2Delta,
+        ppfdDelta: accumulator.ppfdDelta + effect.ppfdDelta,
+        airflow: accumulator.airflow + effect.airflow,
+      };
+    },
+    { ...DEFAULT_DEVICE_EFFECT },
+  );
+};
+
+export const hasActiveDevices = (zone: ZoneState): boolean => {
+  return zone.devices.some((device) => device.status === 'operational');
+};

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import { ZoneEnvironmentService } from './zoneEnvironment.js';
+import type {
+  DeviceInstanceState,
+  FootprintDimensions,
+  GameState,
+  RoomState,
+  StructureState,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneState,
+} from '../../state/models.js';
+
+const createEnvironment = (
+  overrides: Partial<ZoneEnvironmentState> = {},
+): ZoneEnvironmentState => ({
+  temperature: 25,
+  relativeHumidity: 0.65,
+  co2: 800,
+  ppfd: 0,
+  vpd: 1,
+  ...overrides,
+});
+
+const createResources = (): ZoneResourceState => ({
+  waterLiters: 500,
+  nutrientSolutionLiters: 250,
+  nutrientStrength: 1,
+  substrateHealth: 1,
+  reservoirLevel: 0.6,
+});
+
+const createMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
+  averageTemperature: environment.temperature,
+  averageHumidity: environment.relativeHumidity,
+  averageCo2: environment.co2,
+  averagePpfd: environment.ppfd,
+  stressLevel: 0.2,
+  lastUpdatedTick: 0,
+});
+
+const createDevice = (
+  id: string,
+  kind: string,
+  settings: Record<string, unknown>,
+  efficiency = 1,
+): DeviceInstanceState => ({
+  id,
+  blueprintId: `${kind}-blueprint`,
+  kind,
+  name: `${kind} Device`,
+  zoneId: 'zone-1',
+  status: 'operational',
+  efficiency,
+  runtimeHours: 0,
+  maintenance: {
+    lastServiceTick: 0,
+    nextDueTick: 2000,
+    condition: 1,
+    degradation: 0,
+  },
+  settings,
+});
+
+const createZone = (
+  devices: DeviceInstanceState[],
+  environment: ZoneEnvironmentState,
+): ZoneState => ({
+  id: 'zone-1',
+  roomId: 'room-1',
+  name: 'Zone 1',
+  cultivationMethodId: 'method-1',
+  strainId: 'strain-1',
+  environment,
+  resources: createResources(),
+  plants: [],
+  devices,
+  metrics: createMetrics(environment),
+  activeTaskIds: [],
+});
+
+const createRoom = (zone: ZoneState): RoomState => ({
+  id: 'room-1',
+  structureId: 'structure-1',
+  name: 'Grow Room',
+  purposeId: 'growroom',
+  area: 40,
+  height: 3,
+  volume: 120,
+  zones: [zone],
+  cleanliness: 0.9,
+  maintenanceLevel: 0.9,
+});
+
+const createFootprint = (): FootprintDimensions => ({
+  length: 10,
+  width: 4,
+  height: 3,
+  area: 40,
+  volume: 120,
+});
+
+const createStructure = (room: RoomState): StructureState => ({
+  id: 'structure-1',
+  blueprintId: 'structure-blueprint',
+  name: 'Structure One',
+  status: 'active',
+  footprint: createFootprint(),
+  rooms: [room],
+  rentPerTick: 0,
+  upfrontCostPaid: 0,
+});
+
+const createGameState = (structure: StructureState): GameState => {
+  const createdAt = '2024-01-01T00:00:00.000Z';
+  return {
+    metadata: {
+      gameId: 'game-1',
+      createdAt,
+      seed: 'seed',
+      difficulty: 'easy',
+      simulationVersion: '0.0.0',
+      tickLengthMinutes: 15,
+      economics: {
+        initialCapital: 0,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0,
+        rentPerSqmRoomPerTick: 0,
+      },
+    },
+    clock: {
+      tick: 0,
+      isPaused: true,
+      startedAt: createdAt,
+      lastUpdatedAt: createdAt,
+      targetTickRate: 1,
+    },
+    structures: [structure],
+    inventory: {
+      resources: {
+        waterLiters: 0,
+        nutrientsGrams: 0,
+        co2Kg: 0,
+        substrateKg: 0,
+        packagingUnits: 0,
+        sparePartsValue: 0,
+      },
+      seeds: [],
+      devices: [],
+      harvest: [],
+      consumables: {},
+    },
+    finances: {
+      cashOnHand: 0,
+      reservedCash: 0,
+      outstandingLoans: [],
+      ledger: [],
+      summary: {
+        totalRevenue: 0,
+        totalExpenses: 0,
+        totalPayroll: 0,
+        totalMaintenance: 0,
+        netIncome: 0,
+        lastTickRevenue: 0,
+        lastTickExpenses: 0,
+      },
+    },
+    personnel: {
+      employees: [],
+      applicants: [],
+      trainingPrograms: [],
+      overallMorale: 0,
+    },
+    tasks: {
+      backlog: [],
+      active: [],
+      completed: [],
+      cancelled: [],
+    },
+    notes: [],
+  };
+};
+
+describe('ZoneEnvironmentService', () => {
+  it('applies device deltas and normalization per tick', () => {
+    const environment = createEnvironment();
+    const devices: DeviceInstanceState[] = [
+      createDevice(
+        'lamp-1',
+        'Lamp',
+        {
+          power: 0.6,
+          heatFraction: 0.3,
+          coverageArea: 1.2,
+          ppfd: 800,
+        },
+        0.9,
+      ),
+      createDevice(
+        'hvac-1',
+        'ClimateUnit',
+        {
+          coolingCapacity: 1.6,
+          airflow: 350,
+          targetTemperature: 24,
+          targetTemperatureRange: [23, 25],
+          fullPowerAtDeltaK: 2,
+        },
+        0.9,
+      ),
+      createDevice('co2-1', 'CO2Injector', {
+        targetCO2: 1100,
+        targetCO2Range: [400, 1500],
+        hysteresis: 50,
+        pulsePpmPerTick: 150,
+      }),
+    ];
+
+    const zone = createZone(devices, environment);
+    const room = createRoom(zone);
+    const structure = createStructure(room);
+    const state = createGameState(structure);
+
+    const service = new ZoneEnvironmentService();
+
+    service.applyDeviceDeltas(state, 15);
+
+    expect(zone.environment.temperature).toBeCloseTo(25.25, 2);
+    expect(zone.environment.ppfd).toBeCloseTo(21.6, 4);
+    expect(zone.environment.co2).toBeCloseTo(1100, 5);
+
+    service.normalize(state, 15);
+
+    expect(zone.environment.temperature).toBeCloseTo(24.28, 2);
+    expect(zone.environment.relativeHumidity).toBeCloseTo(0.63, 2);
+    expect(zone.environment.co2).toBeCloseTo(890, 0);
+    expect(zone.environment.ppfd).toBeCloseTo(21.6, 4);
+  });
+});

--- a/src/backend/src/engine/environment/zoneEnvironment.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.ts
@@ -1,0 +1,217 @@
+import { computeZoneDeviceDeltas, type ZoneGeometry } from './deviceEffects.js';
+import type { GameState, RoomState } from '../../state/models.js';
+import type { SimulationPhaseContext } from '../../sim/loop.js';
+
+export interface AmbientEnvironment {
+  temperature: number;
+  relativeHumidity: number;
+  co2: number;
+}
+
+export interface SafetyClamps {
+  minTemperature: number;
+  maxTemperature: number;
+  minHumidity: number;
+  maxHumidity: number;
+  minCo2: number;
+  maxCo2: number;
+}
+
+export interface NormalizationFactors {
+  temperatureRate: number;
+  humidityRate: number;
+  co2Rate: number;
+  airflowTemperatureFactor: number;
+  airflowHumidityFactor: number;
+  airflowCo2Factor: number;
+  passiveAirChangesPerHour: number;
+}
+
+export interface ZoneEnvironmentOptions {
+  ambient?: AmbientEnvironment;
+  safety?: Partial<SafetyClamps>;
+  normalization?: Partial<NormalizationFactors>;
+}
+
+interface DeviceEffectCacheEntry {
+  airflow: number;
+}
+
+const DEFAULT_AMBIENT: AmbientEnvironment = {
+  temperature: 20,
+  relativeHumidity: 0.5,
+  co2: 400,
+};
+
+const DEFAULT_SAFETY: SafetyClamps = {
+  minTemperature: 10,
+  maxTemperature: 40,
+  minHumidity: 0,
+  maxHumidity: 1,
+  minCo2: 300,
+  maxCo2: 1800,
+};
+
+const DEFAULT_NORMALIZATION: NormalizationFactors = {
+  temperatureRate: 0.12,
+  humidityRate: 0.08,
+  co2Rate: 0.18,
+  airflowTemperatureFactor: 0.25,
+  airflowHumidityFactor: 0.2,
+  airflowCo2Factor: 0.45,
+  passiveAirChangesPerHour: 0.15,
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const computeTickHours = (tickLengthMinutes: number): number => {
+  return Math.max(tickLengthMinutes, 0) / 60;
+};
+
+const computeZoneGeometry = (room: RoomState): ZoneGeometry => {
+  const zoneCount = Math.max(room.zones.length, 1);
+  const area = room.area / zoneCount;
+  const volume = room.volume / zoneCount;
+  return {
+    area: Math.max(area, 0.0001),
+    volume: Math.max(volume, 0.0001),
+  };
+};
+
+const exponentialMix = (
+  current: number,
+  target: number,
+  rate: number,
+  tickHours: number,
+): number => {
+  if (tickHours <= 0 || rate <= 0) {
+    return current;
+  }
+  const decay = Math.exp(-rate * tickHours);
+  return target + (current - target) * decay;
+};
+
+const computeAirChangesPerHour = (
+  airflow: number,
+  volume: number,
+  passiveAirChangesPerHour: number,
+): number => {
+  const ach = passiveAirChangesPerHour + airflow / Math.max(volume, 0.0001);
+  return Math.max(ach, 0);
+};
+
+export class ZoneEnvironmentService {
+  private readonly ambient: AmbientEnvironment;
+
+  private readonly safety: SafetyClamps;
+
+  private readonly normalization: NormalizationFactors;
+
+  private readonly deviceEffects = new Map<string, DeviceEffectCacheEntry>();
+
+  constructor(options: ZoneEnvironmentOptions = {}) {
+    this.ambient = {
+      ...DEFAULT_AMBIENT,
+      ...options.ambient,
+    };
+
+    this.safety = {
+      ...DEFAULT_SAFETY,
+      ...options.safety,
+    };
+
+    this.normalization = {
+      ...DEFAULT_NORMALIZATION,
+      ...options.normalization,
+    } as NormalizationFactors;
+  }
+
+  applyDeviceDeltas(state: GameState, tickLengthMinutes: number): void {
+    const tickHours = computeTickHours(tickLengthMinutes);
+
+    for (const structure of state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          const geometry = computeZoneGeometry(room);
+          const effect = computeZoneDeviceDeltas(zone, geometry, { tickHours });
+
+          zone.environment.temperature += effect.temperatureDelta;
+          zone.environment.relativeHumidity += effect.humidityDelta;
+          zone.environment.co2 += effect.co2Delta;
+          zone.environment.ppfd = Math.max(0, zone.environment.ppfd + effect.ppfdDelta);
+
+          this.deviceEffects.set(zone.id, { airflow: effect.airflow });
+        }
+      }
+    }
+  }
+
+  normalize(state: GameState, tickLengthMinutes: number): void {
+    const tickHours = computeTickHours(tickLengthMinutes);
+
+    for (const structure of state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          const geometry = computeZoneGeometry(room);
+          const effect = this.deviceEffects.get(zone.id);
+          const airflow = effect?.airflow ?? 0;
+          const ach = computeAirChangesPerHour(
+            airflow,
+            geometry.volume,
+            this.normalization.passiveAirChangesPerHour,
+          );
+
+          const temperatureRate =
+            this.normalization.temperatureRate + this.normalization.airflowTemperatureFactor * ach;
+          const humidityRate =
+            this.normalization.humidityRate + this.normalization.airflowHumidityFactor * ach;
+          const co2Rate = this.normalization.co2Rate + this.normalization.airflowCo2Factor * ach;
+
+          zone.environment.temperature = clamp(
+            exponentialMix(
+              zone.environment.temperature,
+              this.ambient.temperature,
+              temperatureRate,
+              tickHours,
+            ),
+            this.safety.minTemperature,
+            this.safety.maxTemperature,
+          );
+
+          zone.environment.relativeHumidity = clamp(
+            exponentialMix(
+              zone.environment.relativeHumidity,
+              this.ambient.relativeHumidity,
+              humidityRate,
+              tickHours,
+            ),
+            this.safety.minHumidity,
+            this.safety.maxHumidity,
+          );
+
+          zone.environment.co2 = clamp(
+            exponentialMix(zone.environment.co2, this.ambient.co2, co2Rate, tickHours),
+            this.safety.minCo2,
+            this.safety.maxCo2,
+          );
+        }
+      }
+    }
+
+    this.deviceEffects.clear();
+  }
+
+  createApplyDevicePhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.applyDeviceDeltas(context.state, context.tickLengthMinutes);
+    };
+  }
+
+  createNormalizationPhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.normalize(context.state, context.tickLengthMinutes);
+    };
+  }
+}

--- a/src/backend/src/engine/index.ts
+++ b/src/backend/src/engine/index.ts
@@ -1,3 +1,2 @@
-export const placeholderEngine = () => {
-  return 'engine-ready';
-};
+export * from './environment/deviceEffects.js';
+export * from './environment/zoneEnvironment.js';

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -176,6 +176,7 @@ export interface DeviceMaintenanceState {
 export interface DeviceInstanceState {
   id: string;
   blueprintId: string;
+  kind: string;
   name: string;
   zoneId: string;
   status: DeviceStatus;

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -321,6 +321,7 @@ const createDeviceInstances = (
   return blueprints.map((device) => ({
     id: generateId(idStream, 'device'),
     blueprintId: device.id,
+    kind: device.kind,
     name: device.name,
     zoneId,
     status: 'operational',


### PR DESCRIPTION
## Summary
- implement per-device delta calculations for grow lights, HVAC units, and CO₂ injectors
- add a zone environment service that applies device deltas, normalizes toward ambient, and hooks into the simulation loop
- persist device kind on instances and cover the new behavior with environment integration tests

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm --filter @weebbreed/backend exec eslint --max-warnings=0 src

------
https://chatgpt.com/codex/tasks/task_e_68cec50e16888325b6c24c1f575b39a5