### PR TITLE
feat: add plant growth modelling modules

### DIFF
--- a/src/backend/src/engine/index.ts
+++ b/src/backend/src/engine/index.ts
@@ -1,2 +1,5 @@
 export * from './environment/deviceEffects.js';
 export * from './environment/zoneEnvironment.js';
+export * from './plants/phenology.js';
+export * from './plants/resourceDemand.js';
+export * from './plants/growthModel.js';

--- a/src/backend/src/engine/plants/growthModel.test.ts
+++ b/src/backend/src/engine/plants/growthModel.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import type { PlantState, ZoneEnvironmentState } from '../../state/models.js';
+import type { StrainBlueprint } from '../../../data/schemas/strainsSchema.js';
+import { createInitialPhenologyState, createPhenologyConfig } from './phenology.js';
+import type { PhenologyState } from './phenology.js';
+import { updatePlantGrowth } from './growthModel.js';
+
+const createTestStrain = (): StrainBlueprint => ({
+  id: 'strain-test',
+  slug: 'test-strain',
+  name: 'Test Strain',
+  lineage: { parents: [] },
+  genotype: { sativa: 0.5, indica: 0.5, ruderalis: 0 },
+  generalResilience: 0.8,
+  germinationRate: 0.95,
+  chemotype: { thcContent: 0.2, cbdContent: 0.02 },
+  morphology: { growthRate: 1, yieldFactor: 1, leafAreaIndex: 3 },
+  growthModel: {
+    maxBiomassDry_g: 220,
+    baseLUE_gPerMol: 1.1,
+    maintenanceFracPerDay: 0.012,
+    dryMatterFraction: { vegetation: 0.25, flowering: 0.22 },
+    harvestIndex: { targetFlowering: 0.7 },
+    phaseCapMultiplier: { vegetation: 0.55, flowering: 1 },
+    temperature: { Q10: 2, T_ref_C: 25 },
+  },
+  environmentalPreferences: {
+    lightSpectrum: {},
+    lightIntensity: {
+      seedling: [200, 350],
+      vegetation: [350, 600],
+      flowering: [600, 900],
+    },
+    lightCycle: {
+      vegetation: [18, 6],
+      flowering: [12, 12],
+    },
+    idealTemperature: {
+      seedling: [21, 26],
+      vegetation: [23, 28],
+      flowering: [20, 26],
+    },
+    idealHumidity: {
+      seedling: [0.6, 0.7],
+      vegetation: [0.55, 0.65],
+      flowering: [0.45, 0.55],
+    },
+  },
+  nutrientDemand: {
+    dailyNutrientDemand: {
+      seedling: { nitrogen: 0.02, phosphorus: 0.015, potassium: 0.02 },
+      vegetation: { nitrogen: 0.1, phosphorus: 0.06, potassium: 0.11 },
+      flowering: { nitrogen: 0.05, phosphorus: 0.12, potassium: 0.12 },
+    },
+    npkTolerance: 0.2,
+    npkStressIncrement: 0.03,
+  },
+  waterDemand: {
+    dailyWaterUsagePerSquareMeter: {
+      seedling: 0.12,
+      vegetation: 0.32,
+      flowering: 0.5,
+    },
+    minimumFractionRequired: 0.2,
+  },
+  diseaseResistance: {
+    dailyInfectionIncrement: 0.02,
+    infectionThreshold: 0.5,
+    recoveryRate: 0.01,
+    degenerationRate: 0.01,
+    regenerationRate: 0.005,
+    fatalityThreshold: 0.95,
+  },
+  photoperiod: {
+    vegetationDays: 28,
+    floweringDays: 60,
+    transitionTriggerHours: 12,
+  },
+  stageChangeThresholds: {
+    vegetative: { minLightHours: 260, maxStressForStageChange: 0.4 },
+    flowering: { minLightHours: 620, maxStressForStageChange: 0.35 },
+    ripening: { minLightHours: 920, maxStressForStageChange: 0.3 },
+  },
+  harvestWindowInDays: [60, 72],
+  harvestProperties: {
+    ripeningTimeInHours: 48,
+    maxStorageTimeInHours: 120,
+    qualityDecayPerHour: 0.02,
+  },
+  meta: {},
+});
+
+const createPlant = (overrides: Partial<PlantState> = {}): PlantState => ({
+  id: 'plant-test',
+  strainId: 'strain-test',
+  zoneId: 'zone-1',
+  stage: 'seedling',
+  plantedAtTick: 0,
+  ageInHours: 0,
+  health: 0.9,
+  stress: 0.1,
+  biomassDryGrams: 18,
+  heightMeters: 0.35,
+  canopyCover: 0.2,
+  yieldDryGrams: 0,
+  quality: 0.8,
+  lastMeasurementTick: 0,
+  ...overrides,
+});
+
+const createEnvironment = (
+  overrides: Partial<ZoneEnvironmentState> = {},
+): ZoneEnvironmentState => ({
+  temperature: 25,
+  relativeHumidity: 0.6,
+  co2: 800,
+  ppfd: 500,
+  vpd: 1.1,
+  ...overrides,
+});
+
+describe('updatePlantGrowth', () => {
+  it('limits biomass gain when PPFD is zero and increases with light', () => {
+    const strain = createTestStrain();
+    const config = createPhenologyConfig(strain);
+    const plant = createPlant({ stage: 'vegetative' });
+
+    const darkResult = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ ppfd: 0 }),
+      tickHours: 1,
+      phenology: createInitialPhenologyState('vegetative'),
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+    });
+
+    const brightResult = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ ppfd: 650 }),
+      tickHours: 1,
+      phenology: createInitialPhenologyState('vegetative'),
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+    });
+
+    expect(darkResult.biomassDelta).toBeLessThan(brightResult.biomassDelta);
+    expect(brightResult.biomassDelta).toBeGreaterThan(0);
+  });
+
+  it('reduces growth when temperature deviates from the optimal band', () => {
+    const strain = createTestStrain();
+    const config = createPhenologyConfig(strain);
+    const plant = createPlant({ stage: 'vegetative' });
+
+    const optimal = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ temperature: 25, ppfd: 650 }),
+      tickHours: 1,
+      phenology: createInitialPhenologyState('vegetative'),
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+    });
+
+    const cold = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ temperature: 12, ppfd: 650 }),
+      tickHours: 1,
+      phenology: createInitialPhenologyState('vegetative'),
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+    });
+
+    expect(cold.metrics.temperature.response).toBeLessThan(optimal.metrics.temperature.response);
+    expect(cold.biomassDelta).toBeLessThan(optimal.biomassDelta);
+  });
+
+  it('increases stress and emits alerts under high VPD conditions', () => {
+    const strain = createTestStrain();
+    const config = createPhenologyConfig(strain);
+    const plant = createPlant({ stage: 'vegetative', health: 0.62 });
+
+    const result = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ temperature: 31, relativeHumidity: 0.28, ppfd: 550 }),
+      tickHours: 6,
+      phenology: createInitialPhenologyState('vegetative'),
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+      tick: 42,
+    });
+
+    expect(result.metrics.vpd.stress).toBeGreaterThan(0.4);
+    expect(result.plant.health).toBeLessThan(0.5);
+    expect(result.events.some((event) => event.type === 'plant.healthAlert')).toBe(true);
+  });
+
+  it('emits a stage change event when phenology requirements are met', () => {
+    const strain = createTestStrain();
+    const config = createPhenologyConfig(strain);
+    const requirement = config.stageLightRequirements.seedling ?? 0;
+
+    const phenology = {
+      ...createInitialPhenologyState('seedling'),
+      stageHours: (config.stageDurations.seedling ?? 200) - 2,
+      stageLightHours: Math.max(requirement - 2, 0),
+      totalLightHours: Math.max(requirement - 2, 0),
+    } satisfies PhenologyState;
+
+    const plant = createPlant({ stage: 'seedling', biomassDryGrams: 12 });
+
+    const result = updatePlantGrowth({
+      plant,
+      strain,
+      environment: createEnvironment({ ppfd: 600, temperature: 24, relativeHumidity: 0.6 }),
+      tickHours: 4,
+      phenology,
+      phenologyConfig: config,
+      resourceSupply: { waterSupplyFraction: 1, nutrientSupplyFraction: 1 },
+      tick: 100,
+    });
+
+    expect(result.plant.stage).toBe('vegetative');
+    expect(result.events.some((event) => event.type === 'plant.stageChanged')).toBe(true);
+  });
+});

--- a/src/backend/src/engine/plants/growthModel.ts
+++ b/src/backend/src/engine/plants/growthModel.ts
@@ -1,0 +1,413 @@
+import type { SimulationEvent } from '../../lib/eventBus.js';
+import type { PlantStage, PlantState, ZoneEnvironmentState } from '../../state/models.js';
+import type { StrainBlueprint } from '../../../data/schemas/strainsSchema.js';
+import {
+  advancePhenology,
+  createInitialPhenologyState,
+  createPhenologyConfig,
+  mapStageToGrowthPhase,
+  type PhenologyConfig,
+  type PhenologyState,
+} from './phenology.js';
+import {
+  calculateResourceDemand,
+  type ResourceDemandResult,
+  type ResourceSupply,
+} from './resourceDemand.js';
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const DEFAULT_LIGHT_HALF_SAT = 350;
+const DEFAULT_CO2_HALF_SAT = 600;
+const MIN_SIGMA = 0.05;
+
+const HEALTH_ALERT_THRESHOLDS = [
+  { threshold: 0.5, severity: 'warning' as const },
+  { threshold: 0.3, severity: 'critical' as const },
+];
+
+export const lightSaturationResponse = (
+  ppfd: number,
+  halfSaturation: number,
+  maxResponse = 1,
+): number => {
+  if (ppfd <= 0) {
+    return 0;
+  }
+  const half = Math.max(halfSaturation, 1);
+  const response = ppfd / (ppfd + half);
+  return clamp(response * maxResponse, 0, maxResponse);
+};
+
+export const gaussianResponse = (value: number, mean: number, sigma: number): number => {
+  if (!Number.isFinite(value) || !Number.isFinite(mean)) {
+    return 0;
+  }
+  const spread = Math.max(Math.abs(sigma), MIN_SIGMA);
+  const exponent = -0.5 * ((value - mean) / spread) ** 2;
+  return clamp(Math.exp(exponent), 0, 1);
+};
+
+export const co2HalfSaturationResponse = (co2: number, halfSaturation: number): number => {
+  if (co2 <= 0) {
+    return 0;
+  }
+  const half = Math.max(halfSaturation, 1);
+  const response = co2 / (co2 + half);
+  return clamp(response, 0, 1);
+};
+
+export const computeVpd = (temperatureC: number, relativeHumidity: number): number => {
+  const temp = clamp(temperatureC, -40, 60);
+  const rh = clamp(relativeHumidity, 0, 1);
+  const saturationVp = 0.6108 * Math.exp((17.27 * temp) / (temp + 237.3));
+  const actualVp = saturationVp * rh;
+  return Math.max(saturationVp - actualVp, 0);
+};
+
+const resolveLightHalfSaturation = (strain: StrainBlueprint, stage: PlantStage): number => {
+  const phase = mapStageToGrowthPhase(stage);
+  const range = strain.environmentalPreferences?.lightIntensity?.[phase];
+  if (!range) {
+    return DEFAULT_LIGHT_HALF_SAT;
+  }
+  const [low, high] = range;
+  if (!Number.isFinite(low) || !Number.isFinite(high) || low <= 0 || high <= 0) {
+    return DEFAULT_LIGHT_HALF_SAT;
+  }
+  return clamp((low + high) / 2, 50, 1200);
+};
+
+const resolveTemperatureResponse = (
+  strain: StrainBlueprint,
+  stage: PlantStage,
+  temperature: number,
+): number => {
+  const phase = mapStageToGrowthPhase(stage);
+  const range = strain.environmentalPreferences?.idealTemperature?.[phase];
+  if (!range) {
+    return gaussianResponse(temperature, 25, 6);
+  }
+  const [low, high] = range;
+  const mean = (low + high) / 2;
+  const sigma = Math.max((high - low) / 2, 3);
+  return gaussianResponse(temperature, mean, sigma);
+};
+
+const resolveVpdResponse = (
+  strain: StrainBlueprint,
+  stage: PlantStage,
+  temperature: number,
+  vpd: number,
+): number => {
+  const phase = mapStageToGrowthPhase(stage);
+  const humidityRange = strain.environmentalPreferences?.idealHumidity?.[phase];
+  if (!humidityRange) {
+    return gaussianResponse(vpd, 1.1, 0.6);
+  }
+  const lowRh = clamp(humidityRange[0], 0.2, 0.95);
+  const highRh = clamp(humidityRange[1], lowRh + 0.05, 0.98);
+  const midRh = (lowRh + highRh) / 2;
+  const vpdOpt = computeVpd(temperature, midRh);
+  const vpdLow = computeVpd(temperature, highRh);
+  const vpdHigh = computeVpd(temperature, lowRh);
+  const tolerance = Math.max(Math.abs(vpdHigh - vpdOpt), Math.abs(vpdOpt - vpdLow));
+  return gaussianResponse(vpd, vpdOpt, Math.max(tolerance / 2, MIN_SIGMA));
+};
+
+const resolveCo2HalfSaturation = (strain: StrainBlueprint): number => {
+  const growthRate = clamp(strain.morphology?.growthRate ?? 1, 0.3, 2);
+  return clamp(DEFAULT_CO2_HALF_SAT / growthRate, 350, 900);
+};
+
+const computeCanopyInterception = (strain: StrainBlueprint, canopyArea: number): number => {
+  const lai = clamp(strain.morphology?.leafAreaIndex ?? 2.5, 0.2, 6);
+  const referenceArea = Math.max(canopyArea, 0.05);
+  const extinctionCoefficient = 0.7;
+  return clamp(1 - Math.exp(-extinctionCoefficient * lai * referenceArea), 0, 1);
+};
+
+export interface DriverEvaluation {
+  response: number;
+  stress: number;
+}
+
+export interface VpdEvaluation extends DriverEvaluation {
+  value: number;
+}
+
+export interface GrowthDriverMetrics {
+  light: DriverEvaluation;
+  temperature: DriverEvaluation;
+  co2: DriverEvaluation;
+  vpd: VpdEvaluation;
+  water: DriverEvaluation;
+  nutrients: DriverEvaluation;
+  overallStress: number;
+  combinedResponse: number;
+}
+
+export interface PlantGrowthContext {
+  plant: PlantState;
+  strain: StrainBlueprint;
+  environment: ZoneEnvironmentState;
+  tickHours: number;
+  tick?: number;
+  phenology?: PhenologyState;
+  phenologyConfig?: PhenologyConfig;
+  resourceSupply?: ResourceSupply;
+  canopyAreaOverride?: number;
+}
+
+export interface PlantGrowthResult {
+  plant: PlantState;
+  phenology: PhenologyState;
+  biomassDelta: number;
+  healthDelta: number;
+  qualityDelta: number;
+  metrics: GrowthDriverMetrics;
+  resources: ResourceDemandResult;
+  events: SimulationEvent[];
+}
+
+const ensurePhenologyState = (stage: PlantStage, state?: PhenologyState): PhenologyState => {
+  if (state) {
+    return state;
+  }
+  return createInitialPhenologyState(stage);
+};
+
+const computeCombinedResponse = (responses: number[]): number => {
+  const bounded = responses.map((value) => clamp(value, 0, 1));
+  const product = bounded.reduce((acc, value) => acc * value, 1);
+  if (product <= 0) {
+    return 0;
+  }
+  return Math.pow(product, 1 / bounded.length);
+};
+
+const updateQuality = (
+  currentQuality: number,
+  newHealth: number,
+  stress: number,
+  tickHours: number,
+): { value: number; delta: number } => {
+  const qualityTarget = clamp(newHealth - stress * 0.4, 0, 1);
+  const adjustmentRate = clamp(tickHours / 24, 0, 1) * 0.5;
+  const delta = (qualityTarget - currentQuality) * adjustmentRate;
+  const value = clamp(currentQuality + delta, 0, 1);
+  return { value, delta };
+};
+
+const resolveStageCap = (
+  config: PhenologyConfig,
+  strain: StrainBlueprint,
+  stage: PlantStage,
+): number => {
+  const capFraction = config.stageCaps[stage] ?? 1;
+  const maxBiomass = Math.max(strain.growthModel?.maxBiomassDry_g ?? 0, 0);
+  return Math.max(maxBiomass * capFraction, 0);
+};
+
+const resolveHarvestIndex = (strain: StrainBlueprint): number => {
+  const harvestIndex = strain.growthModel?.harvestIndex?.targetFlowering;
+  if (typeof harvestIndex === 'number' && Number.isFinite(harvestIndex)) {
+    return clamp(harvestIndex, 0, 1);
+  }
+  return 0.65;
+};
+
+const shouldAccumulateYield = (stage: PlantStage): boolean => {
+  return stage === 'flowering' || stage === 'ripening' || stage === 'harvestReady';
+};
+
+const buildHealthEvents = (
+  plant: PlantState,
+  newHealth: number,
+  stress: number,
+  tick?: number,
+): SimulationEvent[] => {
+  const events: SimulationEvent[] = [];
+  for (const threshold of HEALTH_ALERT_THRESHOLDS) {
+    const previouslyHealthy = plant.health >= threshold.threshold;
+    const nowBelow = newHealth < threshold.threshold;
+    if (previouslyHealthy && nowBelow) {
+      events.push({
+        type: 'plant.healthAlert',
+        level: threshold.severity === 'critical' ? 'error' : 'warning',
+        tick,
+        payload: {
+          plantId: plant.id,
+          previousHealth: plant.health,
+          health: newHealth,
+          stress,
+          severity: threshold.severity,
+        },
+      });
+    }
+  }
+  return events;
+};
+
+const buildStageEvent = (
+  plant: PlantState,
+  previousStage: PlantStage,
+  nextStage: PlantStage,
+  tick?: number,
+): SimulationEvent => ({
+  type: 'plant.stageChanged',
+  level: 'info',
+  tick,
+  payload: {
+    plantId: plant.id,
+    from: previousStage,
+    to: nextStage,
+  },
+});
+
+export const updatePlantGrowth = (context: PlantGrowthContext): PlantGrowthResult => {
+  const { plant, strain, environment, tickHours, tick } = context;
+  const phenologyConfig = context.phenologyConfig ?? createPhenologyConfig(strain);
+  const phenologyState = ensurePhenologyState(plant.stage, context.phenology);
+  const canopyArea = Math.max(context.canopyAreaOverride ?? plant.canopyCover ?? 0.1, 0.05);
+
+  const resources = calculateResourceDemand({
+    strain,
+    stage: phenologyState.stage,
+    canopyArea,
+    tickHours,
+    supply: context.resourceSupply,
+  });
+
+  const lightResponse = lightSaturationResponse(
+    environment.ppfd,
+    resolveLightHalfSaturation(strain, phenologyState.stage),
+  );
+  const temperatureResponse = resolveTemperatureResponse(
+    strain,
+    phenologyState.stage,
+    environment.temperature,
+  );
+  const co2Response = co2HalfSaturationResponse(environment.co2, resolveCo2HalfSaturation(strain));
+  const vpd = computeVpd(environment.temperature, environment.relativeHumidity);
+  const vpdResponse = resolveVpdResponse(
+    strain,
+    phenologyState.stage,
+    environment.temperature,
+    vpd,
+  );
+  const waterResponse = 1 - resources.waterStress;
+  const nutrientResponse = 1 - resources.nutrientStress;
+  const resourceResponse = Math.min(waterResponse, nutrientResponse, resources.resourceResponse);
+
+  const combinedResponse = computeCombinedResponse([
+    lightResponse,
+    temperatureResponse,
+    co2Response,
+    vpdResponse,
+    resourceResponse,
+  ]);
+
+  const resilience = clamp(strain.generalResilience ?? 0.5, 0, 1);
+  const overallStress = clamp(1 - combinedResponse, 0, 1);
+  const effectiveStress = clamp(overallStress - (resilience - 0.5) * 0.3, 0, 1);
+
+  const healthTarget = clamp(1 - effectiveStress, 0, 1);
+  const adjustmentRate = clamp(tickHours / 24, 0, 1) * (0.6 + resilience * 0.4);
+  const healthDelta = (healthTarget - plant.health) * adjustmentRate;
+  const newHealth = clamp(plant.health + healthDelta, 0, 1);
+
+  const { value: newQuality, delta: qualityDelta } = updateQuality(
+    plant.quality,
+    newHealth,
+    effectiveStress,
+    tickHours,
+  );
+
+  const canopyInterception = computeCanopyInterception(strain, canopyArea);
+  const absorbedMol =
+    environment.ppfd * 1e-6 * Math.max(tickHours, 0) * 3600 * canopyInterception * lightResponse;
+  const q10 = strain.growthModel?.temperature?.Q10;
+  const tref = strain.growthModel?.temperature?.T_ref_C ?? 25;
+  const q10Factor = q10 ? Math.pow(q10, (environment.temperature - tref) / 10) : 1;
+  const lue = (strain.growthModel?.baseLUE_gPerMol ?? 0.9) * q10Factor;
+  const grossBiomass = absorbedMol * lue * combinedResponse;
+  const maintenance =
+    plant.biomassDryGrams * (strain.growthModel?.maintenanceFracPerDay ?? 0) * (tickHours / 24);
+  const netBiomassDelta = grossBiomass - maintenance;
+
+  const stageCap = resolveStageCap(phenologyConfig, strain, phenologyState.stage);
+  const unclampedBiomass = plant.biomassDryGrams + netBiomassDelta;
+  const newBiomass = clamp(unclampedBiomass, 0, stageCap);
+  const biomassDelta = newBiomass - plant.biomassDryGrams;
+
+  const harvestIndex = resolveHarvestIndex(strain);
+  const yieldDelta =
+    shouldAccumulateYield(phenologyState.stage) && biomassDelta > 0
+      ? biomassDelta * harvestIndex
+      : 0;
+  const maxYield = resolveStageCap(phenologyConfig, strain, 'harvestReady') * harvestIndex;
+  const newYield = clamp(plant.yieldDryGrams + yieldDelta, 0, maxYield || Number.POSITIVE_INFINITY);
+
+  const phenologyUpdate = advancePhenology(
+    phenologyState,
+    {
+      tickHours,
+      lightHours: tickHours * clamp(lightResponse, 0, 1),
+      stress: effectiveStress,
+    },
+    phenologyConfig,
+  );
+
+  const updatedStage = phenologyUpdate.state.stage;
+  const events: SimulationEvent[] = [];
+
+  if (phenologyUpdate.stageChanged) {
+    events.push(buildStageEvent(plant, phenologyState.stage, updatedStage, tick));
+  }
+
+  events.push(...buildHealthEvents(plant, newHealth, effectiveStress, tick));
+
+  const metrics: GrowthDriverMetrics = {
+    light: { response: lightResponse, stress: 1 - lightResponse },
+    temperature: { response: temperatureResponse, stress: 1 - temperatureResponse },
+    co2: { response: co2Response, stress: 1 - co2Response },
+    vpd: { value: vpd, response: vpdResponse, stress: 1 - vpdResponse },
+    water: { response: clamp(waterResponse, 0, 1), stress: clamp(1 - waterResponse, 0, 1) },
+    nutrients: {
+      response: clamp(nutrientResponse, 0, 1),
+      stress: clamp(1 - nutrientResponse, 0, 1),
+    },
+    overallStress: effectiveStress,
+    combinedResponse,
+  };
+
+  const updatedPlant: PlantState = {
+    ...plant,
+    stage: updatedStage,
+    ageInHours: plant.ageInHours + tickHours,
+    biomassDryGrams: newBiomass,
+    yieldDryGrams: newYield,
+    health: newHealth,
+    stress: effectiveStress,
+    quality: newQuality,
+    heightMeters: Math.max(
+      plant.heightMeters + Math.max(0, biomassDelta) * 0.002,
+      plant.heightMeters,
+    ),
+    lastMeasurementTick: tick ?? plant.lastMeasurementTick,
+  };
+
+  return {
+    plant: updatedPlant,
+    phenology: phenologyUpdate.state,
+    biomassDelta,
+    healthDelta,
+    qualityDelta,
+    metrics,
+    resources,
+    events,
+  };
+};

--- a/src/backend/src/engine/plants/phenology.ts
+++ b/src/backend/src/engine/plants/phenology.ts
@@ -1,0 +1,274 @@
+import type { PlantStage } from '../../state/models.js';
+import type { StrainBlueprint } from '../../../data/schemas/strainsSchema.js';
+
+export const PHENOLOGY_STAGE_ORDER: PlantStage[] = [
+  'seedling',
+  'vegetative',
+  'flowering',
+  'ripening',
+  'harvestReady',
+];
+
+export type GrowthPhaseKey = 'seedling' | 'vegetation' | 'flowering' | 'ripening';
+
+const DEFAULT_SEEDLING_HOURS = 14 * 24;
+const DEFAULT_RIPENING_HOURS = 72;
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const normaliseResilience = (value: number | undefined): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0.5;
+  }
+  return clamp(value, 0, 1);
+};
+
+export const mapStageToGrowthPhase = (stage: PlantStage): GrowthPhaseKey => {
+  switch (stage) {
+    case 'seedling':
+      return 'seedling';
+    case 'vegetative':
+      return 'vegetation';
+    case 'flowering':
+    case 'ripening':
+    case 'harvestReady':
+      return 'flowering';
+    default:
+      return 'flowering';
+  }
+};
+
+const mapGrowthPhaseToStage = (phase: string): PlantStage | undefined => {
+  switch (phase) {
+    case 'seedling':
+      return 'seedling';
+    case 'vegetation':
+      return 'vegetative';
+    case 'flowering':
+      return 'flowering';
+    case 'ripening':
+      return 'ripening';
+    default:
+      return undefined;
+  }
+};
+
+export interface PhenologyConfig {
+  readonly stageOrder: PlantStage[];
+  readonly stageDurations: Partial<Record<PlantStage, number>>;
+  readonly stageLightRequirements: Partial<Record<PlantStage, number>>;
+  readonly stageStressThresholds: Partial<Record<PlantStage, number>>;
+  readonly stageCaps: Partial<Record<PlantStage, number>>;
+  readonly resilience: number;
+}
+
+export interface PhenologyState {
+  stage: PlantStage;
+  stageHours: number;
+  stageLightHours: number;
+  totalLightHours: number;
+  stressIntegral: number;
+  stressDuration: number;
+}
+
+export interface PhenologyTickInput {
+  tickHours: number;
+  lightHours: number;
+  stress: number;
+}
+
+export interface PhenologyUpdateResult {
+  readonly state: PhenologyState;
+  readonly stageChanged: boolean;
+  readonly previousStage: PlantStage;
+  readonly stageProgress: number;
+  readonly stageCapFraction: number;
+}
+
+const resolveStageDuration = (stage: PlantStage, strain: StrainBlueprint): number | undefined => {
+  switch (stage) {
+    case 'seedling':
+      return strain.stageChangeThresholds?.vegetative?.minLightHours ?? DEFAULT_SEEDLING_HOURS;
+    case 'vegetative':
+      return strain.photoperiod.vegetationDays * 24;
+    case 'flowering':
+      return strain.photoperiod.floweringDays * 24;
+    case 'ripening':
+      return strain.harvestProperties?.ripeningTimeInHours ?? DEFAULT_RIPENING_HOURS;
+    default:
+      return undefined;
+  }
+};
+
+const resolveStageLightRequirement = (
+  stage: PlantStage,
+  strain: StrainBlueprint,
+): number | undefined => {
+  const nextStageKey = mapStageToGrowthPhase(stage);
+  const thresholds = strain.stageChangeThresholds ?? {};
+  switch (stage) {
+    case 'seedling':
+      return thresholds.vegetative?.minLightHours;
+    case 'vegetative':
+      return thresholds.flowering?.minLightHours;
+    case 'flowering':
+      return thresholds.ripening?.minLightHours;
+    default:
+      return thresholds[nextStageKey]?.minLightHours;
+  }
+};
+
+const resolveStageStressThreshold = (
+  stage: PlantStage,
+  strain: StrainBlueprint,
+): number | undefined => {
+  const thresholds = strain.stageChangeThresholds ?? {};
+  switch (stage) {
+    case 'seedling':
+      return thresholds.vegetative?.maxStressForStageChange;
+    case 'vegetative':
+      return thresholds.flowering?.maxStressForStageChange;
+    case 'flowering':
+      return thresholds.ripening?.maxStressForStageChange;
+    default:
+      return undefined;
+  }
+};
+
+export const createPhenologyConfig = (strain: StrainBlueprint): PhenologyConfig => {
+  const stageDurations: Partial<Record<PlantStage, number>> = {};
+  const stageLightRequirements: Partial<Record<PlantStage, number>> = {};
+  const stageStressThresholds: Partial<Record<PlantStage, number>> = {};
+
+  for (const stage of PHENOLOGY_STAGE_ORDER) {
+    const duration = resolveStageDuration(stage, strain);
+    if (duration !== undefined) {
+      stageDurations[stage] = duration;
+    }
+    const lightRequirement = resolveStageLightRequirement(stage, strain);
+    if (lightRequirement !== undefined) {
+      stageLightRequirements[stage] = lightRequirement;
+    }
+    const stressThreshold = resolveStageStressThreshold(stage, strain);
+    if (stressThreshold !== undefined) {
+      stageStressThresholds[stage] = stressThreshold;
+    }
+  }
+
+  const stageCaps: Partial<Record<PlantStage, number>> = {};
+  const phaseCaps = strain.growthModel?.phaseCapMultiplier ?? {};
+  for (const [phase, cap] of Object.entries(phaseCaps)) {
+    const stage = mapGrowthPhaseToStage(phase);
+    if (!stage) {
+      continue;
+    }
+    if (typeof cap === 'number' && Number.isFinite(cap)) {
+      stageCaps[stage] = cap;
+    }
+  }
+
+  return {
+    stageOrder: [...PHENOLOGY_STAGE_ORDER],
+    stageDurations,
+    stageLightRequirements,
+    stageStressThresholds,
+    stageCaps,
+    resilience: normaliseResilience(strain.generalResilience),
+  };
+};
+
+export const createInitialPhenologyState = (stage: PlantStage): PhenologyState => ({
+  stage,
+  stageHours: 0,
+  stageLightHours: 0,
+  totalLightHours: 0,
+  stressIntegral: 0,
+  stressDuration: 0,
+});
+
+export const advancePhenology = (
+  state: PhenologyState,
+  input: PhenologyTickInput,
+  config: PhenologyConfig,
+): PhenologyUpdateResult => {
+  const updatedHours = state.stageHours + input.tickHours;
+  const updatedLight = state.stageLightHours + input.lightHours;
+  const updatedTotalLight = state.totalLightHours + input.lightHours;
+  const updatedStressIntegral = state.stressIntegral + input.stress * input.tickHours;
+  const updatedStressDuration = state.stressDuration + input.tickHours;
+
+  const currentStageIndex = config.stageOrder.indexOf(state.stage);
+  const currentStageDuration = config.stageDurations[state.stage] ?? 0;
+  const stageCapFraction = config.stageCaps[state.stage] ?? 1;
+
+  if (currentStageIndex === -1 || currentStageIndex >= config.stageOrder.length - 1) {
+    return {
+      state: {
+        ...state,
+        stageHours: updatedHours,
+        stageLightHours: updatedLight,
+        totalLightHours: updatedTotalLight,
+        stressIntegral: updatedStressIntegral,
+        stressDuration: updatedStressDuration,
+      },
+      stageChanged: false,
+      previousStage: state.stage,
+      stageProgress:
+        currentStageDuration > 0 ? clamp(updatedHours / currentStageDuration, 0, 1) : 1,
+      stageCapFraction,
+    };
+  }
+
+  const nextStage = config.stageOrder[currentStageIndex + 1];
+  const requiredHours = config.stageDurations[state.stage] ?? 0;
+  const requiredLight = config.stageLightRequirements[state.stage] ?? 0;
+  const stressThreshold = config.stageStressThresholds[state.stage];
+
+  const stressSamples = updatedStressDuration > 0 ? updatedStressDuration : input.tickHours;
+  const averageStress =
+    stressSamples > 0 ? updatedStressIntegral / stressSamples : clamp(input.stress, 0, 1);
+
+  const resilienceBonus = 1 + (config.resilience - 0.5) * 0.5;
+  const effectiveStressThreshold =
+    stressThreshold === undefined ? undefined : clamp(stressThreshold * resilienceBonus, 0, 1);
+
+  const meetsHours = requiredHours === 0 || updatedHours >= requiredHours;
+  const meetsLight = requiredLight === 0 || updatedTotalLight >= requiredLight;
+  const meetsStress =
+    effectiveStressThreshold === undefined || averageStress <= effectiveStressThreshold;
+
+  if (meetsHours && meetsLight && meetsStress) {
+    const nextStageCap = config.stageCaps[nextStage] ?? 1;
+    return {
+      state: {
+        stage: nextStage,
+        stageHours: 0,
+        stageLightHours: 0,
+        totalLightHours: updatedTotalLight,
+        stressIntegral: 0,
+        stressDuration: 0,
+      },
+      stageChanged: true,
+      previousStage: state.stage,
+      stageProgress: 0,
+      stageCapFraction: nextStageCap,
+    };
+  }
+
+  return {
+    state: {
+      stage: state.stage,
+      stageHours: updatedHours,
+      stageLightHours: updatedLight,
+      totalLightHours: updatedTotalLight,
+      stressIntegral: updatedStressIntegral,
+      stressDuration: updatedStressDuration,
+    },
+    stageChanged: false,
+    previousStage: state.stage,
+    stageProgress: currentStageDuration > 0 ? clamp(updatedHours / currentStageDuration, 0, 1) : 1,
+    stageCapFraction,
+  };
+};

--- a/src/backend/src/engine/plants/resourceDemand.ts
+++ b/src/backend/src/engine/plants/resourceDemand.ts
@@ -1,0 +1,234 @@
+import type { PlantStage } from '../../state/models.js';
+import type { StrainBlueprint } from '../../../data/schemas/strainsSchema.js';
+import { mapStageToGrowthPhase } from './phenology.js';
+
+export interface NutrientDemand {
+  nitrogen: number;
+  phosphorus: number;
+  potassium: number;
+}
+
+export interface ResourceSupply {
+  availableWaterLiters?: number;
+  waterSupplyFraction?: number;
+  availableNutrients?: Partial<NutrientDemand>;
+  nutrientSupplyFraction?: number;
+  nutrientSolutionRatio?: number;
+}
+
+export interface ResourceDemandInput {
+  strain: StrainBlueprint;
+  stage: PlantStage;
+  canopyArea: number;
+  tickHours: number;
+  supply?: ResourceSupply;
+}
+
+export interface ResourceDemandResult {
+  waterDemandLiters: number;
+  availableWaterLiters: number;
+  waterSupplyFraction: number;
+  waterStress: number;
+  nutrientDemand: NutrientDemand;
+  availableNutrients: NutrientDemand;
+  nutrientSupplyFraction: number;
+  nutrientStress: number;
+  resourceResponse: number;
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const demandKeyForStage = (
+  stage: PlantStage,
+): keyof StrainBlueprint['waterDemand']['dailyWaterUsagePerSquareMeter'] => {
+  const phase = mapStageToGrowthPhase(stage);
+  switch (phase) {
+    case 'seedling':
+      return 'seedling';
+    case 'vegetation':
+      return 'vegetation';
+    case 'flowering':
+    case 'ripening':
+    default:
+      return 'flowering';
+  }
+};
+
+const createZeroDemand = (): NutrientDemand => ({
+  nitrogen: 0,
+  phosphorus: 0,
+  potassium: 0,
+});
+
+const multiplyDemand = (demand: NutrientDemand, factor: number): NutrientDemand => ({
+  nitrogen: demand.nitrogen * factor,
+  phosphorus: demand.phosphorus * factor,
+  potassium: demand.potassium * factor,
+});
+
+const minDemand = (a: NutrientDemand, b: NutrientDemand): NutrientDemand => ({
+  nitrogen: Math.min(a.nitrogen, b.nitrogen),
+  phosphorus: Math.min(a.phosphorus, b.phosphorus),
+  potassium: Math.min(a.potassium, b.potassium),
+});
+
+const resolveWaterDemand = (
+  strain: StrainBlueprint,
+  stage: PlantStage,
+  canopyArea: number,
+  tickHours: number,
+): number => {
+  const key = demandKeyForStage(stage);
+  const dailyPerSqm = strain.waterDemand.dailyWaterUsagePerSquareMeter[key] ?? 0;
+  const area = Math.max(canopyArea, 0);
+  const hours = Math.max(tickHours, 0);
+  return (dailyPerSqm * area * hours) / 24;
+};
+
+const resolveNutrientDemand = (
+  strain: StrainBlueprint,
+  stage: PlantStage,
+  tickHours: number,
+): NutrientDemand => {
+  const key = demandKeyForStage(stage);
+  const dailyDemand = strain.nutrientDemand.dailyNutrientDemand[key];
+  if (!dailyDemand) {
+    return createZeroDemand();
+  }
+  const factor = Math.max(tickHours, 0) / 24;
+  return {
+    nitrogen: dailyDemand.nitrogen * factor,
+    phosphorus: dailyDemand.phosphorus * factor,
+    potassium: dailyDemand.potassium * factor,
+  };
+};
+
+const computeWaterStress = (
+  demand: number,
+  supplyFraction: number,
+  minimumFraction: number,
+): number => {
+  if (demand <= 0) {
+    return 0;
+  }
+  const minFraction = clamp(minimumFraction, 0, 1);
+  if (supplyFraction >= 1) {
+    return 0;
+  }
+  if (supplyFraction <= minFraction) {
+    return 1;
+  }
+  const usableRange = 1 - minFraction;
+  if (usableRange <= 0) {
+    return clamp(1 - supplyFraction, 0, 1);
+  }
+  const scaled = (supplyFraction - minFraction) / usableRange;
+  return clamp(1 - scaled, 0, 1);
+};
+
+const computeNutrientSupplyFraction = (
+  demand: NutrientDemand,
+  supply: ResourceSupply | undefined,
+): { fraction: number; available: NutrientDemand } => {
+  if (!supply) {
+    return {
+      fraction: 1,
+      available: { ...demand },
+    };
+  }
+
+  const desired = demand;
+  const baseRatio = supply.nutrientSupplyFraction ?? 1;
+  const concentration = supply.nutrientSolutionRatio ?? 1;
+
+  let fraction = Math.min(baseRatio, concentration);
+  let available: NutrientDemand = demand;
+
+  if (supply.availableNutrients) {
+    const supplied: NutrientDemand = {
+      nitrogen:
+        supply.availableNutrients.nitrogen ?? desired.nitrogen * fraction ?? desired.nitrogen,
+      phosphorus:
+        supply.availableNutrients.phosphorus ?? desired.phosphorus * fraction ?? desired.phosphorus,
+      potassium:
+        supply.availableNutrients.potassium ?? desired.potassium * fraction ?? desired.potassium,
+    };
+
+    const ratios = [
+      desired.nitrogen > 0 ? supplied.nitrogen / desired.nitrogen : Number.POSITIVE_INFINITY,
+      desired.phosphorus > 0 ? supplied.phosphorus / desired.phosphorus : Number.POSITIVE_INFINITY,
+      desired.potassium > 0 ? supplied.potassium / desired.potassium : Number.POSITIVE_INFINITY,
+    ].filter((value) => Number.isFinite(value));
+
+    if (ratios.length > 0) {
+      fraction = Math.min(fraction, ...ratios);
+    }
+
+    available = minDemand(desired, supplied);
+  } else {
+    available = multiplyDemand(desired, clamp(fraction, 0, 1));
+  }
+
+  if (!Number.isFinite(fraction)) {
+    fraction = 1;
+  }
+
+  const boundedFraction = clamp(fraction, 0, 1);
+  return {
+    fraction: boundedFraction,
+    available: {
+      nitrogen: available.nitrogen,
+      phosphorus: available.phosphorus,
+      potassium: available.potassium,
+    },
+  };
+};
+
+const computeNutrientStress = (supplyFraction: number, tolerance: number): number => {
+  if (supplyFraction >= 1) {
+    return 0;
+  }
+  const effective = clamp(supplyFraction + tolerance, 0, 1);
+  return clamp(1 - effective, 0, 1);
+};
+
+export const calculateResourceDemand = (input: ResourceDemandInput): ResourceDemandResult => {
+  const { strain, stage, canopyArea, tickHours, supply } = input;
+  const waterDemand = resolveWaterDemand(strain, stage, canopyArea, tickHours);
+  const nutrientDemand = resolveNutrientDemand(strain, stage, tickHours);
+
+  const suppliedWaterLiters = supply?.availableWaterLiters;
+  const supplyFractionFromLiters =
+    suppliedWaterLiters !== undefined && waterDemand > 0 ? suppliedWaterLiters / waterDemand : 1;
+  const waterSupplyFraction = clamp(
+    supply?.waterSupplyFraction ?? supplyFractionFromLiters ?? 1,
+    0,
+    Number.POSITIVE_INFINITY,
+  );
+  const boundedWaterFraction = waterDemand > 0 ? clamp(waterSupplyFraction, 0, 1) : 1;
+  const minimumFraction = strain.waterDemand.minimumFractionRequired ?? 0;
+  const waterStress = computeWaterStress(waterDemand, boundedWaterFraction, minimumFraction);
+  const availableWaterLiters = waterDemand * boundedWaterFraction;
+
+  const nutrientSupply = computeNutrientSupplyFraction(nutrientDemand, supply);
+  const nutrientStress = computeNutrientStress(
+    nutrientSupply.fraction,
+    strain.nutrientDemand.npkTolerance ?? 0,
+  );
+
+  const resourceResponse = 1 - (waterStress + nutrientStress) / 2;
+
+  return {
+    waterDemandLiters: waterDemand,
+    availableWaterLiters,
+    waterSupplyFraction: boundedWaterFraction,
+    waterStress,
+    nutrientDemand,
+    availableNutrients: nutrientSupply.available,
+    nutrientSupplyFraction: nutrientSupply.fraction,
+    nutrientStress,
+    resourceResponse: clamp(resourceResponse, 0, 1),
+  };
+};


### PR DESCRIPTION
## Summary
- add phenology utilities for stage progression, light requirements and resilience-aware caps
- implement plant resource demand and stress calculations
- create growth model integrating response curves, biomass/health updates and event emission with targeted tests

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68ced284db348325ae8ac0d888cd2d5e