### PR TITLE
Implement health engine for disease and pest management

### DIFF
--- a/src/backend/src/engine/environment/deviceEffects.test.ts
+++ b/src/backend/src/engine/environment/deviceEffects.test.ts
@@ -3,6 +3,7 @@ import { computeZoneDeviceDeltas } from './deviceEffects.js';
 import type {
   DeviceInstanceState,
   ZoneEnvironmentState,
+  ZoneHealthState,
   ZoneMetricState,
   ZoneResourceState,
   ZoneState,
@@ -34,6 +35,12 @@ const createMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
   averagePpfd: environment.ppfd,
   stressLevel: 0,
   lastUpdatedTick: 0,
+});
+
+const createHealth = (): ZoneHealthState => ({
+  plantHealth: {},
+  pendingTreatments: [],
+  appliedTreatments: [],
 });
 
 const createDevice = (
@@ -74,6 +81,7 @@ const createZone = (
     plants: [],
     devices,
     metrics: createMetrics(env),
+    health: createHealth(),
     activeTaskIds: [],
   };
 };

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -7,6 +7,7 @@ import type {
   RoomState,
   StructureState,
   ZoneEnvironmentState,
+  ZoneHealthState,
   ZoneMetricState,
   ZoneResourceState,
   ZoneState,
@@ -38,6 +39,12 @@ const createMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
   averagePpfd: environment.ppfd,
   stressLevel: 0.2,
   lastUpdatedTick: 0,
+});
+
+const createHealth = (): ZoneHealthState => ({
+  plantHealth: {},
+  pendingTreatments: [],
+  appliedTreatments: [],
 });
 
 const createDevice = (
@@ -77,6 +84,7 @@ const createZone = (
   plants: [],
   devices,
   metrics: createMetrics(environment),
+  health: createHealth(),
   activeTaskIds: [],
 });
 

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from 'vitest';
+import { PlantHealthEngine } from './healthEngine.js';
+import type { DiseaseBalancingConfig, PestBalancingConfig, TreatmentOption } from './models.js';
+import { createEventCollector, type SimulationEvent } from '../../lib/eventBus.js';
+import type {
+  DiseaseState,
+  GameState,
+  PestState,
+  PlantState,
+  RoomState,
+  StructureState,
+  ZoneEnvironmentState,
+  ZoneHealthState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneState,
+} from '../../state/models.js';
+import type { SimulationPhaseContext } from '../../sim/loop.js';
+
+const diseaseBalancing: DiseaseBalancingConfig = {
+  global: {
+    baseDailyInfectionMultiplier: 1,
+    baseRecoveryMultiplier: 1,
+    maxConcurrentDiseases: 2,
+    symptomDelayDays: { min: 1, max: 1 },
+  },
+  phaseMultipliers: {
+    seedling: { infection: 1, degeneration: 1, recovery: 1 },
+    vegetation: { infection: 1, degeneration: 1, recovery: 1 },
+    earlyFlower: { infection: 1.1, degeneration: 1.1, recovery: 0.95 },
+    lateFlower: { infection: 1.3, degeneration: 1.4, recovery: 0.8 },
+    ripening: { infection: 1.05, degeneration: 1.2, recovery: 0.85 },
+  },
+  treatmentEfficacy: {
+    biological: { infectionMultiplier: 0.85, degenerationMultiplier: 0.9, recoveryMultiplier: 1.1 },
+    cultural: { infectionMultiplier: 0.95, degenerationMultiplier: 1, recoveryMultiplier: 1 },
+    mechanical: {
+      infectionMultiplier: 0.9,
+      degenerationMultiplier: 0.95,
+      recoveryMultiplier: 1.05,
+    },
+    chemical: { infectionMultiplier: 0.7, degenerationMultiplier: 0.8, recoveryMultiplier: 1.15 },
+    physical: { infectionMultiplier: 0.9, degenerationMultiplier: 0.95, recoveryMultiplier: 1.05 },
+  },
+  caps: {
+    minDailyDegeneration: 0,
+    maxDailyDegeneration: 0.3,
+    minDailyRecovery: 0,
+    maxDailyRecovery: 0.3,
+  },
+};
+
+const pestBalancing: PestBalancingConfig = {
+  global: {
+    baseDailyReproductionMultiplier: 1,
+    baseDailyMortalityMultiplier: 1,
+    baseDamageMultiplier: 1,
+    maxConcurrentPests: 2,
+  },
+  phaseMultipliers: {
+    seedling: { reproduction: 1.05, mortality: 0.95, damage: 1.05 },
+    vegetation: { reproduction: 1, mortality: 1, damage: 1 },
+    earlyFlower: { reproduction: 1.05, mortality: 0.95, damage: 1.15 },
+    lateFlower: { reproduction: 1.1, mortality: 0.9, damage: 1.3 },
+    ripening: { reproduction: 0.95, mortality: 0.95, damage: 1.25 },
+  },
+  controlEfficacy: {
+    biological: { reproductionMultiplier: 0.8, mortalityMultiplier: 1.2, damageMultiplier: 0.9 },
+    cultural: { reproductionMultiplier: 0.9, mortalityMultiplier: 1.05, damageMultiplier: 0.95 },
+    mechanical: { reproductionMultiplier: 0.85, mortalityMultiplier: 1.1, damageMultiplier: 0.9 },
+    chemical: { reproductionMultiplier: 0.7, mortalityMultiplier: 1.3, damageMultiplier: 0.8 },
+    physical: { reproductionMultiplier: 0.9, mortalityMultiplier: 1.05, damageMultiplier: 0.95 },
+  },
+  caps: {
+    minDailyReproduction: 0,
+    maxDailyReproduction: 0.6,
+    minDailyMortality: 0,
+    maxDailyMortality: 0.6,
+    minDailyDamage: 0,
+    maxDailyDamage: 0.4,
+  },
+};
+
+const treatmentOptions: TreatmentOption[] = [
+  {
+    id: 'bio-boost',
+    name: 'Predator release',
+    category: 'biological',
+    targets: ['disease', 'pest'],
+    efficacy: {
+      disease: {
+        infectionMultiplier: 0.5,
+        degenerationMultiplier: 0.6,
+        recoveryMultiplier: 1.5,
+      },
+      pest: {
+        reproductionMultiplier: 0.6,
+        mortalityMultiplier: 1.4,
+        damageMultiplier: 0.7,
+      },
+    },
+    cooldownDays: 1,
+    effectDurationDays: 1,
+    reentryIntervalTicks: 4,
+    preHarvestIntervalTicks: 6,
+  },
+];
+
+const createEnvironment = (): ZoneEnvironmentState => ({
+  temperature: 25,
+  relativeHumidity: 0.6,
+  co2: 800,
+  ppfd: 600,
+  vpd: 1.2,
+});
+
+const createResources = (): ZoneResourceState => ({
+  waterLiters: 500,
+  nutrientSolutionLiters: 250,
+  nutrientStrength: 1,
+  substrateHealth: 1,
+  reservoirLevel: 0.6,
+});
+
+const createMetrics = (environment: ZoneEnvironmentState): ZoneMetricState => ({
+  averageTemperature: environment.temperature,
+  averageHumidity: environment.relativeHumidity,
+  averageCo2: environment.co2,
+  averagePpfd: environment.ppfd,
+  stressLevel: 0.1,
+  lastUpdatedTick: 0,
+});
+
+const createPlant = (overrides: Partial<PlantState> = {}): PlantState => ({
+  id: overrides.id ?? 'plant-1',
+  strainId: 'strain-1',
+  zoneId: 'zone-1',
+  stage: 'flowering',
+  plantedAtTick: 0,
+  ageInHours: 0,
+  health: 0.85,
+  stress: 0.15,
+  biomassDryGrams: 120,
+  heightMeters: 0.6,
+  canopyCover: 0.3,
+  yieldDryGrams: 0,
+  quality: 0.8,
+  lastMeasurementTick: 0,
+  ...overrides,
+});
+
+const createZoneHealth = (plants: PlantState[]): ZoneHealthState => {
+  const plantHealth = Object.fromEntries(
+    plants.map((plant) => [plant.id, { diseases: [], pests: [] }]),
+  );
+  return {
+    plantHealth,
+    pendingTreatments: [],
+    appliedTreatments: [],
+  } satisfies ZoneHealthState;
+};
+
+const createGameState = (): GameState => {
+  const createdAt = '2024-01-01T00:00:00.000Z';
+  const environment = createEnvironment();
+  const plantA = createPlant({ id: 'plant-a' });
+  const plantB = createPlant({ id: 'plant-b' });
+  const plants = [plantA, plantB];
+  const zone: ZoneState = {
+    id: 'zone-1',
+    roomId: 'room-1',
+    name: 'Zone 1',
+    cultivationMethodId: 'method-1',
+    strainId: 'strain-1',
+    environment,
+    resources: createResources(),
+    plants,
+    devices: [],
+    metrics: createMetrics(environment),
+    health: createZoneHealth(plants),
+    activeTaskIds: [],
+  };
+  const room: RoomState = {
+    id: 'room-1',
+    structureId: 'structure-1',
+    name: 'Grow Room',
+    purposeId: 'growroom',
+    area: 40,
+    height: 3,
+    volume: 120,
+    zones: [zone],
+    cleanliness: 0.9,
+    maintenanceLevel: 0.9,
+  };
+  const structure: StructureState = {
+    id: 'structure-1',
+    blueprintId: 'structure-blueprint',
+    name: 'Structure One',
+    status: 'active',
+    footprint: {
+      length: 10,
+      width: 4,
+      height: 3,
+      area: 40,
+      volume: 120,
+    },
+    rooms: [room],
+    rentPerTick: 0,
+    upfrontCostPaid: 0,
+  };
+
+  return {
+    metadata: {
+      gameId: 'game-1',
+      createdAt,
+      seed: 'seed',
+      difficulty: 'normal',
+      simulationVersion: '0.0.0',
+      tickLengthMinutes: 60,
+      economics: {
+        initialCapital: 0,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0,
+        rentPerSqmRoomPerTick: 0,
+      },
+    },
+    clock: {
+      tick: 0,
+      isPaused: false,
+      startedAt: createdAt,
+      lastUpdatedAt: createdAt,
+      targetTickRate: 1,
+    },
+    structures: [structure],
+    inventory: {
+      resources: {
+        waterLiters: 0,
+        nutrientsGrams: 0,
+        co2Kg: 0,
+        substrateKg: 0,
+        packagingUnits: 0,
+        sparePartsValue: 0,
+      },
+      seeds: [],
+      devices: [],
+      harvest: [],
+      consumables: {},
+    },
+    finances: {
+      cashOnHand: 0,
+      reservedCash: 0,
+      outstandingLoans: [],
+      ledger: [],
+      summary: {
+        totalRevenue: 0,
+        totalExpenses: 0,
+        totalPayroll: 0,
+        totalMaintenance: 0,
+        netIncome: 0,
+        lastTickRevenue: 0,
+        lastTickExpenses: 0,
+      },
+    },
+    personnel: {
+      employees: [],
+      applicants: [],
+      trainingPrograms: [],
+      overallMorale: 0,
+    },
+    tasks: {
+      backlog: [],
+      active: [],
+      completed: [],
+      cancelled: [],
+    },
+    notes: [],
+  } satisfies GameState;
+};
+
+const createContext = (
+  state: GameState,
+  tick: number,
+  events: SimulationEvent[],
+): SimulationPhaseContext => ({
+  state,
+  tick,
+  tickLengthMinutes: state.metadata.tickLengthMinutes,
+  phase: 'updatePlants',
+  events: createEventCollector(events, tick),
+});
+
+describe('PlantHealthEngine', () => {
+  it('runs detection → progression → treatment → recovery and enforces restrictions', () => {
+    const state = createGameState();
+    const zone = state.structures[0].rooms[0].zones[0];
+    const plant = zone.plants[0];
+    const secondaryPlant = zone.plants[1];
+    const disease: DiseaseState = {
+      id: 'disease-1',
+      pathogenId: 'powdery-mildew',
+      severity: 0.2,
+      infection: 0.4,
+      detected: false,
+      symptomTimerTicks: 0,
+      spreadCooldownTicks: 1,
+      baseInfectionRatePerDay: 0.3,
+      baseRecoveryRatePerDay: 0.05,
+      baseDegenerationRatePerDay: 0.1,
+      phaseOverride: 'lateFlower',
+      activeTreatments: [],
+    };
+    const pest: PestState = {
+      id: 'pest-1',
+      pestId: 'spider-mites',
+      population: 0.6,
+      damage: 0.2,
+      detected: false,
+      symptomTimerTicks: 0,
+      spreadCooldownTicks: 1,
+      baseReproductionRatePerDay: 0.25,
+      baseMortalityRatePerDay: 0.08,
+      baseDamageRatePerDay: 0.12,
+      phaseOverride: 'lateFlower',
+      activeTreatments: [],
+    };
+
+    zone.health.plantHealth[plant.id] = { diseases: [disease], pests: [pest] };
+    zone.health.plantHealth[secondaryPlant.id] = { diseases: [], pests: [] };
+
+    const engine = new PlantHealthEngine({
+      diseaseBalancing,
+      pestBalancing,
+      treatmentOptions,
+    });
+
+    const tick1Events: SimulationEvent[] = [];
+    const context1 = createContext(state, 1, tick1Events);
+    engine.runDetection(context1);
+    expect(tick1Events.some((event) => event.type === 'pest.detected')).toBe(true);
+
+    engine.runProgression(context1);
+    const infectionAfterTick1 = disease.infection;
+    const severityAfterTick1 = disease.severity;
+    const pestPopulationAfterTick1 = pest.population;
+    expect(infectionAfterTick1).toBeGreaterThan(0.4);
+    expect(severityAfterTick1).toBeGreaterThan(0.2);
+    expect(pestPopulationAfterTick1).toBeGreaterThan(0.6);
+
+    zone.health.pendingTreatments.push({
+      optionId: 'bio-boost',
+      target: 'disease',
+      plantIds: [plant.id],
+      scheduledTick: 2,
+    });
+    zone.health.pendingTreatments.push({
+      optionId: 'bio-boost',
+      target: 'pest',
+      plantIds: [plant.id],
+      scheduledTick: 2,
+    });
+
+    const tick2Events: SimulationEvent[] = [];
+    const context2 = createContext(state, 2, tick2Events);
+    engine.runDetection(context2);
+    engine.runProgression(context2);
+    const infectionBeforeTreatment = disease.infection;
+    const pestBeforeTreatment = pest.population;
+
+    engine.runTreatmentApplication(context2);
+    expect(tick2Events.some((event) => event.type === 'treatment.applied')).toBe(true);
+    expect(zone.health.reentryRestrictedUntilTick).toBe(2 + 4);
+    expect(zone.health.preHarvestRestrictedUntilTick).toBe(2 + 6);
+    expect(zone.health.appliedTreatments).toHaveLength(2);
+    expect(zone.health.pendingTreatments).toHaveLength(0);
+
+    const tick3Events: SimulationEvent[] = [];
+    const context3 = createContext(state, 3, tick3Events);
+    engine.runProgression(context3);
+    const infectionAfterTreatment = disease.infection;
+    const pestAfterTreatment = pest.population;
+
+    const infectionDeltaBefore = infectionBeforeTreatment - infectionAfterTick1;
+    const infectionDeltaAfter = infectionAfterTreatment - infectionBeforeTreatment;
+    expect(infectionDeltaAfter).toBeLessThan(infectionDeltaBefore);
+
+    const pestDeltaBefore = pestBeforeTreatment - pestPopulationAfterTick1;
+    const pestDeltaAfter = pestAfterTreatment - pestBeforeTreatment;
+    expect(pestDeltaAfter).toBeLessThan(pestDeltaBefore);
+
+    disease.infection = 0.8;
+    disease.lastSpreadTick = 0;
+    pest.population = 0.8;
+    pest.lastSpreadTick = 0;
+
+    engine.runSpread(context3);
+
+    const secondaryHealth = zone.health.plantHealth[secondaryPlant.id];
+    expect(secondaryHealth.diseases.length).toBeGreaterThan(0);
+    expect(secondaryHealth.pests.length).toBeGreaterThan(0);
+    expect(secondaryHealth.diseases[0].detected).toBe(false);
+    expect(secondaryHealth.pests[0].detected).toBe(false);
+  });
+});

--- a/src/backend/src/engine/health/healthEngine.ts
+++ b/src/backend/src/engine/health/healthEngine.ts
@@ -1,0 +1,715 @@
+import type { SimulationPhaseContext } from '../../sim/loop.js';
+import type {
+  AppliedTreatmentRecord,
+  DiseaseState,
+  DiseaseTreatmentEffectState,
+  HealthTarget,
+  PendingTreatmentApplication,
+  PestState,
+  PestTreatmentEffectState,
+  PlantHealthState,
+  PlantState,
+  ZoneHealthState,
+  ZoneState,
+} from '../../state/models.js';
+import {
+  clamp,
+  mapStageToHealthPhase,
+  type DiseaseBalancingConfig,
+  type DiseasePhaseKey,
+  type PestBalancingConfig,
+  type PestPhaseKey,
+  type TreatmentOption,
+  type TreatmentOptionIndex,
+} from './models.js';
+
+const DISEASE_DETECTION_THRESHOLD = 0.18;
+const PEST_DETECTION_THRESHOLD = 0.22;
+const DISEASE_SPREAD_THRESHOLD = 0.6;
+const PEST_SPREAD_THRESHOLD = 0.6;
+
+interface CombinedDiseaseTreatmentEffect {
+  infection: number;
+  degeneration: number;
+  recovery: number;
+}
+
+interface CombinedPestTreatmentEffect {
+  reproduction: number;
+  mortality: number;
+  damage: number;
+}
+
+export interface PlantHealthEngineOptions {
+  diseaseBalancing: DiseaseBalancingConfig;
+  pestBalancing: PestBalancingConfig;
+  treatmentOptions: TreatmentOption[] | TreatmentOptionIndex;
+}
+
+const DEFAULT_DISEASE_PHASE: Record<
+  DiseasePhaseKey,
+  { infection: number; degeneration: number; recovery: number }
+> = {
+  seedling: { infection: 1, degeneration: 1, recovery: 1 },
+  vegetation: { infection: 1, degeneration: 1, recovery: 1 },
+  earlyFlower: { infection: 1, degeneration: 1, recovery: 1 },
+  lateFlower: { infection: 1, degeneration: 1, recovery: 1 },
+  ripening: { infection: 1, degeneration: 1, recovery: 1 },
+};
+
+const DEFAULT_PEST_PHASE: Record<
+  PestPhaseKey,
+  { reproduction: number; mortality: number; damage: number }
+> = {
+  seedling: { reproduction: 1, mortality: 1, damage: 1 },
+  vegetation: { reproduction: 1, mortality: 1, damage: 1 },
+  earlyFlower: { reproduction: 1, mortality: 1, damage: 1 },
+  lateFlower: { reproduction: 1, mortality: 1, damage: 1 },
+  ripening: { reproduction: 1, mortality: 1, damage: 1 },
+};
+
+const DEFAULT_TREATMENT_DURATION_DAYS = 1;
+const MIN_EFFECTIVE_RATE = 0;
+const MAX_EFFECTIVE_RATE = 10;
+
+const ensureOptionsIndex = (
+  options: TreatmentOption[] | TreatmentOptionIndex,
+): TreatmentOptionIndex => {
+  if (options instanceof Map) {
+    return options;
+  }
+  const map = new Map<string, TreatmentOption>();
+  for (const option of options) {
+    map.set(option.id, option);
+  }
+  return map;
+};
+
+export class PlantHealthEngine {
+  private readonly diseaseBalancing: DiseaseBalancingConfig;
+
+  private readonly pestBalancing: PestBalancingConfig;
+
+  private readonly treatmentOptions: TreatmentOptionIndex;
+
+  constructor(options: PlantHealthEngineOptions) {
+    this.diseaseBalancing = options.diseaseBalancing;
+    this.pestBalancing = options.pestBalancing;
+    this.treatmentOptions = ensureOptionsIndex(options.treatmentOptions);
+  }
+
+  createDetectionPhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.runDetection(context);
+    };
+  }
+
+  createProgressionPhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.runProgression(context);
+    };
+  }
+
+  createSpreadPhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.runSpread(context);
+    };
+  }
+
+  createTreatmentPhaseHandler() {
+    return (context: SimulationPhaseContext) => {
+      this.runTreatmentApplication(context);
+    };
+  }
+
+  runDetection(context: SimulationPhaseContext): void {
+    const tick = context.tick;
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          this.syncZoneHealth(zone);
+          const zoneHealth = zone.health;
+
+          for (const plant of zone.plants) {
+            const health = this.ensurePlantHealth(zone, plant);
+
+            for (const disease of health.diseases) {
+              if (disease.infection <= 0) {
+                continue;
+              }
+              disease.symptomTimerTicks = Math.max(disease.symptomTimerTicks - 1, 0);
+              if (disease.detected) {
+                continue;
+              }
+              if (
+                disease.symptomTimerTicks <= 0 ||
+                disease.severity >= DISEASE_DETECTION_THRESHOLD
+              ) {
+                disease.detected = true;
+                disease.detectionTick = tick;
+              }
+            }
+
+            for (const pest of health.pests) {
+              if (pest.population <= 0) {
+                continue;
+              }
+              pest.symptomTimerTicks = Math.max(pest.symptomTimerTicks - 1, 0);
+              if (pest.detected) {
+                continue;
+              }
+              if (pest.symptomTimerTicks <= 0 || pest.population >= PEST_DETECTION_THRESHOLD) {
+                pest.detected = true;
+                pest.detectionTick = tick;
+                context.events.queue({
+                  type: 'pest.detected',
+                  payload: {
+                    zoneId: zone.id,
+                    plantId: plant.id,
+                    pestId: pest.pestId,
+                    infestationId: pest.id,
+                  },
+                  tick,
+                });
+              }
+            }
+
+            zoneHealth.plantHealth[plant.id] = health;
+          }
+        }
+      }
+    }
+  }
+
+  runProgression(context: SimulationPhaseContext): void {
+    const tickFraction = this.computeTickFractionOfDay(context.tickLengthMinutes);
+    if (tickFraction <= 0) {
+      return;
+    }
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          this.syncZoneHealth(zone);
+
+          for (const plant of zone.plants) {
+            const health = this.ensurePlantHealth(zone, plant);
+
+            for (const disease of health.diseases) {
+              this.cleanupDiseaseTreatments(disease, context.tick);
+              this.progressDisease(disease, plant, tickFraction);
+            }
+
+            for (const pest of health.pests) {
+              this.cleanupPestTreatments(pest, context.tick);
+              this.progressPest(pest, plant, tickFraction);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  runSpread(context: SimulationPhaseContext): void {
+    const ticksPerDay = this.computeTicksPerDay(context.tickLengthMinutes);
+    const diseaseSymptomDelayTicks = this.computeSymptomDelayTicks(ticksPerDay);
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          this.syncZoneHealth(zone);
+          const zoneHealth = zone.health;
+
+          for (const plant of zone.plants) {
+            const health = this.ensurePlantHealth(zone, plant);
+
+            for (const disease of health.diseases) {
+              if (disease.infection < DISEASE_SPREAD_THRESHOLD) {
+                continue;
+              }
+              if (
+                !this.canSpread(disease.lastSpreadTick, disease.spreadCooldownTicks, context.tick)
+              ) {
+                continue;
+              }
+              const target = this.findSpreadTarget(
+                zone,
+                plant.id,
+                zoneHealth,
+                'disease',
+                this.diseaseBalancing.global.maxConcurrentDiseases,
+                (targetHealth) =>
+                  targetHealth.diseases.some((item) => item.pathogenId === disease.pathogenId),
+              );
+              if (!target) {
+                continue;
+              }
+              const targetHealth = this.ensurePlantHealth(zone, target);
+              targetHealth.diseases.push({
+                id: `${disease.pathogenId}-${target.id}-${context.tick}`,
+                pathogenId: disease.pathogenId,
+                severity: 0.05,
+                infection: 0.12,
+                detected: false,
+                symptomTimerTicks: diseaseSymptomDelayTicks,
+                spreadCooldownTicks: disease.spreadCooldownTicks,
+                baseInfectionRatePerDay: disease.baseInfectionRatePerDay,
+                baseRecoveryRatePerDay: disease.baseRecoveryRatePerDay,
+                baseDegenerationRatePerDay: disease.baseDegenerationRatePerDay,
+                phaseOverride: disease.phaseOverride,
+                activeTreatments: [],
+              });
+              disease.lastSpreadTick = context.tick;
+            }
+
+            for (const pest of health.pests) {
+              if (pest.population < PEST_SPREAD_THRESHOLD) {
+                continue;
+              }
+              if (!this.canSpread(pest.lastSpreadTick, pest.spreadCooldownTicks, context.tick)) {
+                continue;
+              }
+              const target = this.findSpreadTarget(
+                zone,
+                plant.id,
+                zoneHealth,
+                'pest',
+                this.pestBalancing.global.maxConcurrentPests,
+                (targetHealth) => targetHealth.pests.some((item) => item.pestId === pest.pestId),
+              );
+              if (!target) {
+                continue;
+              }
+              const targetHealth = this.ensurePlantHealth(zone, target);
+              targetHealth.pests.push({
+                id: `${pest.pestId}-${target.id}-${context.tick}`,
+                pestId: pest.pestId,
+                population: 0.15,
+                damage: 0.05,
+                detected: false,
+                symptomTimerTicks: Math.max(1, Math.round(ticksPerDay * 0.5)),
+                spreadCooldownTicks: pest.spreadCooldownTicks,
+                baseReproductionRatePerDay: pest.baseReproductionRatePerDay,
+                baseMortalityRatePerDay: pest.baseMortalityRatePerDay,
+                baseDamageRatePerDay: pest.baseDamageRatePerDay,
+                phaseOverride: pest.phaseOverride,
+                activeTreatments: [],
+              });
+              pest.lastSpreadTick = context.tick;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  runTreatmentApplication(context: SimulationPhaseContext): void {
+    const ticksPerDay = this.computeTicksPerDay(context.tickLengthMinutes);
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          this.syncZoneHealth(zone);
+          const zoneHealth = zone.health;
+          const remaining: PendingTreatmentApplication[] = [];
+
+          for (const pending of zoneHealth.pendingTreatments) {
+            if (pending.scheduledTick > context.tick) {
+              remaining.push(pending);
+              continue;
+            }
+            const option = this.treatmentOptions.get(pending.optionId);
+            if (!option) {
+              continue;
+            }
+            if (!option.targets.includes(pending.target)) {
+              continue;
+            }
+            const durationTicks = this.computeEffectDurationTicks(option, ticksPerDay);
+            const reentryTicks = pending.reentryIntervalTicks ?? option.reentryIntervalTicks ?? 0;
+            const harvestTicks =
+              pending.preHarvestIntervalTicks ?? option.preHarvestIntervalTicks ?? 0;
+
+            const treatedPlants = this.applyTreatmentToZone(
+              zone,
+              pending,
+              option,
+              durationTicks,
+              context.tick,
+            );
+
+            if (treatedPlants.length > 0) {
+              if (reentryTicks > 0) {
+                const until = context.tick + reentryTicks;
+                zoneHealth.reentryRestrictedUntilTick = Math.max(
+                  zoneHealth.reentryRestrictedUntilTick ?? 0,
+                  until,
+                );
+              }
+              if (harvestTicks > 0) {
+                const until = context.tick + harvestTicks;
+                zoneHealth.preHarvestRestrictedUntilTick = Math.max(
+                  zoneHealth.preHarvestRestrictedUntilTick ?? 0,
+                  until,
+                );
+              }
+
+              const record: AppliedTreatmentRecord = {
+                optionId: option.id,
+                target: pending.target,
+                plantIds: treatedPlants,
+                appliedTick: context.tick,
+                reentryRestrictedUntilTick:
+                  reentryTicks > 0 ? context.tick + reentryTicks : undefined,
+                preHarvestRestrictedUntilTick:
+                  harvestTicks > 0 ? context.tick + harvestTicks : undefined,
+              };
+              zoneHealth.appliedTreatments.push(record);
+
+              context.events.queue({
+                type: 'treatment.applied',
+                payload: {
+                  zoneId: zone.id,
+                  plantIds: treatedPlants,
+                  optionId: option.id,
+                  target: pending.target,
+                  reentryRestrictedUntilTick: zoneHealth.reentryRestrictedUntilTick,
+                  preHarvestRestrictedUntilTick: zoneHealth.preHarvestRestrictedUntilTick,
+                },
+                tick: context.tick,
+              });
+            }
+          }
+
+          zoneHealth.pendingTreatments = remaining;
+        }
+      }
+    }
+  }
+
+  private syncZoneHealth(zone: ZoneState): void {
+    const zoneHealth = zone.health;
+    for (const plant of zone.plants) {
+      if (!zoneHealth.plantHealth[plant.id]) {
+        zoneHealth.plantHealth[plant.id] = { diseases: [], pests: [] } satisfies PlantHealthState;
+      }
+    }
+  }
+
+  private ensurePlantHealth(zone: ZoneState, plant: PlantState): PlantHealthState {
+    const state = zone.health.plantHealth[plant.id];
+    if (state) {
+      return state;
+    }
+    const created: PlantHealthState = { diseases: [], pests: [] };
+    zone.health.plantHealth[plant.id] = created;
+    return created;
+  }
+
+  private cleanupDiseaseTreatments(disease: DiseaseState, tick: number): void {
+    disease.activeTreatments = disease.activeTreatments.filter(
+      (effect) => effect.expiresTick > tick,
+    );
+  }
+
+  private cleanupPestTreatments(pest: PestState, tick: number): void {
+    pest.activeTreatments = pest.activeTreatments.filter((effect) => effect.expiresTick > tick);
+  }
+
+  private progressDisease(disease: DiseaseState, plant: PlantState, tickFraction: number): void {
+    if (tickFraction <= 0) {
+      return;
+    }
+    const phaseKey =
+      (disease.phaseOverride as DiseasePhaseKey | undefined) ?? mapStageToHealthPhase(plant.stage);
+    const phase =
+      this.diseaseBalancing.phaseMultipliers[phaseKey] ?? DEFAULT_DISEASE_PHASE[phaseKey];
+    const treatment = this.combineDiseaseTreatments(disease.activeTreatments);
+
+    const infectionRatePerDay = clamp(
+      disease.baseInfectionRatePerDay *
+        this.diseaseBalancing.global.baseDailyInfectionMultiplier *
+        phase.infection *
+        treatment.infection,
+      MIN_EFFECTIVE_RATE,
+      MAX_EFFECTIVE_RATE,
+    );
+
+    const recoveryRatePerDay = clamp(
+      disease.baseRecoveryRatePerDay *
+        this.diseaseBalancing.global.baseRecoveryMultiplier *
+        phase.recovery *
+        treatment.recovery,
+      this.diseaseBalancing.caps.minDailyRecovery,
+      this.diseaseBalancing.caps.maxDailyRecovery,
+    );
+
+    const degenerationRatePerDay = clamp(
+      disease.baseDegenerationRatePerDay * phase.degeneration * treatment.degeneration,
+      this.diseaseBalancing.caps.minDailyDegeneration,
+      this.diseaseBalancing.caps.maxDailyDegeneration,
+    );
+
+    const infectionGrowth = infectionRatePerDay * (1 - disease.infection);
+    const infectionReduction = recoveryRatePerDay * disease.infection;
+    const infectionDelta = (infectionGrowth - infectionReduction) * tickFraction;
+    disease.infection = clamp(disease.infection + infectionDelta, 0, 1);
+
+    const severityDelta =
+      (degenerationRatePerDay * disease.infection - recoveryRatePerDay) * tickFraction;
+    disease.severity = clamp(disease.severity + severityDelta, 0, 1);
+  }
+
+  private progressPest(pest: PestState, plant: PlantState, tickFraction: number): void {
+    if (tickFraction <= 0) {
+      return;
+    }
+    const phaseKey =
+      (pest.phaseOverride as PestPhaseKey | undefined) ?? mapStageToHealthPhase(plant.stage);
+    const phase = this.pestBalancing.phaseMultipliers[phaseKey] ?? DEFAULT_PEST_PHASE[phaseKey];
+    const treatment = this.combinePestTreatments(pest.activeTreatments);
+
+    const reproductionRatePerDay = clamp(
+      pest.baseReproductionRatePerDay *
+        this.pestBalancing.global.baseDailyReproductionMultiplier *
+        phase.reproduction *
+        treatment.reproduction,
+      this.pestBalancing.caps.minDailyReproduction,
+      this.pestBalancing.caps.maxDailyReproduction,
+    );
+
+    const mortalityRatePerDay = clamp(
+      pest.baseMortalityRatePerDay *
+        this.pestBalancing.global.baseDailyMortalityMultiplier *
+        phase.mortality *
+        treatment.mortality,
+      this.pestBalancing.caps.minDailyMortality,
+      this.pestBalancing.caps.maxDailyMortality,
+    );
+
+    const damageRatePerDay = clamp(
+      pest.baseDamageRatePerDay *
+        this.pestBalancing.global.baseDamageMultiplier *
+        phase.damage *
+        treatment.damage,
+      this.pestBalancing.caps.minDailyDamage,
+      this.pestBalancing.caps.maxDailyDamage,
+    );
+
+    const populationGrowth = reproductionRatePerDay * (1 - pest.population);
+    const populationReduction = mortalityRatePerDay * pest.population;
+    const populationDelta = (populationGrowth - populationReduction) * tickFraction;
+    pest.population = clamp(pest.population + populationDelta, 0, 1);
+
+    const damageDelta = damageRatePerDay * pest.population * tickFraction;
+    pest.damage = clamp(pest.damage + damageDelta, 0, 1);
+  }
+
+  private combineDiseaseTreatments(
+    effects: DiseaseTreatmentEffectState[],
+  ): CombinedDiseaseTreatmentEffect {
+    return effects.reduce<CombinedDiseaseTreatmentEffect>(
+      (acc, effect) => ({
+        infection: acc.infection * (effect.infectionMultiplier ?? 1),
+        degeneration: acc.degeneration * (effect.degenerationMultiplier ?? 1),
+        recovery: acc.recovery * (effect.recoveryMultiplier ?? 1),
+      }),
+      { infection: 1, degeneration: 1, recovery: 1 },
+    );
+  }
+
+  private combinePestTreatments(effects: PestTreatmentEffectState[]): CombinedPestTreatmentEffect {
+    return effects.reduce<CombinedPestTreatmentEffect>(
+      (acc, effect) => ({
+        reproduction: acc.reproduction * (effect.reproductionMultiplier ?? 1),
+        mortality: acc.mortality * (effect.mortalityMultiplier ?? 1),
+        damage: acc.damage * (effect.damageMultiplier ?? 1),
+      }),
+      { reproduction: 1, mortality: 1, damage: 1 },
+    );
+  }
+
+  private findSpreadTarget(
+    zone: ZoneState,
+    sourcePlantId: string,
+    zoneHealth: ZoneHealthState,
+    target: HealthTarget,
+    maxConcurrent: number,
+    hasMatching: (health: PlantHealthState) => boolean,
+  ): PlantState | undefined {
+    for (const candidate of zone.plants) {
+      if (candidate.id === sourcePlantId) {
+        continue;
+      }
+      const health = zoneHealth.plantHealth[candidate.id] ?? { diseases: [], pests: [] };
+      const currentCount = target === 'disease' ? health.diseases.length : health.pests.length;
+      if (currentCount >= maxConcurrent) {
+        continue;
+      }
+      if (hasMatching(health)) {
+        continue;
+      }
+      return candidate;
+    }
+    return undefined;
+  }
+
+  private canSpread(
+    lastSpreadTick: number | undefined,
+    cooldownTicks: number,
+    currentTick: number,
+  ): boolean {
+    if (cooldownTicks <= 0) {
+      return true;
+    }
+    if (lastSpreadTick === undefined) {
+      return true;
+    }
+    return currentTick - lastSpreadTick >= cooldownTicks;
+  }
+
+  private applyTreatmentToZone(
+    zone: ZoneState,
+    pending: PendingTreatmentApplication,
+    option: TreatmentOption,
+    durationTicks: number,
+    tick: number,
+  ): string[] {
+    const treatedPlantIds: string[] = [];
+
+    for (const plantId of pending.plantIds) {
+      const plant = zone.plants.find((item) => item.id === plantId);
+      if (!plant) {
+        continue;
+      }
+      const plantHealth = this.ensurePlantHealth(zone, plant);
+      let applied = false;
+      if (pending.target === 'disease') {
+        applied = this.applyTreatmentToDiseases(plantHealth, pending, option, durationTicks, tick);
+      } else if (pending.target === 'pest') {
+        applied = this.applyTreatmentToPests(plantHealth, pending, option, durationTicks, tick);
+      }
+      if (applied) {
+        treatedPlantIds.push(plant.id);
+      }
+    }
+
+    return treatedPlantIds;
+  }
+
+  private applyTreatmentToDiseases(
+    plantHealth: PlantHealthState,
+    pending: PendingTreatmentApplication,
+    option: TreatmentOption,
+    durationTicks: number,
+    tick: number,
+  ): boolean {
+    const diseaseIds = pending.diseaseIds ?? [];
+    const targetDiseases =
+      diseaseIds.length > 0
+        ? plantHealth.diseases.filter(
+            (disease) => diseaseIds.includes(disease.id) || diseaseIds.includes(disease.pathogenId),
+          )
+        : plantHealth.diseases;
+    if (targetDiseases.length === 0) {
+      return false;
+    }
+
+    const balancingEffect = this.diseaseBalancing.treatmentEfficacy[option.category] ?? {};
+    const optionEffect = option.efficacy?.disease ?? {};
+    const effect: DiseaseTreatmentEffectState = {
+      optionId: option.id,
+      expiresTick: tick + durationTicks,
+      infectionMultiplier:
+        (balancingEffect.infectionMultiplier ?? 1) * (optionEffect.infectionMultiplier ?? 1),
+      degenerationMultiplier:
+        (balancingEffect.degenerationMultiplier ?? 1) * (optionEffect.degenerationMultiplier ?? 1),
+      recoveryMultiplier:
+        (balancingEffect.recoveryMultiplier ?? 1) * (optionEffect.recoveryMultiplier ?? 1),
+    };
+
+    for (const disease of targetDiseases) {
+      disease.activeTreatments.push({ ...effect });
+    }
+
+    return true;
+  }
+
+  private applyTreatmentToPests(
+    plantHealth: PlantHealthState,
+    pending: PendingTreatmentApplication,
+    option: TreatmentOption,
+    durationTicks: number,
+    tick: number,
+  ): boolean {
+    const pestIds = pending.pestIds ?? [];
+    const targetPests =
+      pestIds.length > 0
+        ? plantHealth.pests.filter(
+            (pest) => pestIds.includes(pest.id) || pestIds.includes(pest.pestId),
+          )
+        : plantHealth.pests;
+    if (targetPests.length === 0) {
+      return false;
+    }
+
+    const balancingEffect = this.pestBalancing.controlEfficacy[option.category] ?? {};
+    const optionEffect = option.efficacy?.pest ?? {};
+    const effect: PestTreatmentEffectState = {
+      optionId: option.id,
+      expiresTick: tick + durationTicks,
+      reproductionMultiplier:
+        (balancingEffect.reproductionMultiplier ?? 1) * (optionEffect.reproductionMultiplier ?? 1),
+      mortalityMultiplier:
+        (balancingEffect.mortalityMultiplier ?? 1) * (optionEffect.mortalityMultiplier ?? 1),
+      damageMultiplier:
+        (balancingEffect.damageMultiplier ?? 1) * (optionEffect.damageMultiplier ?? 1),
+    };
+
+    for (const pest of targetPests) {
+      pest.activeTreatments.push({ ...effect });
+    }
+
+    return true;
+  }
+
+  private computeTickFractionOfDay(tickLengthMinutes: number): number {
+    const hours = this.computeTickHours(tickLengthMinutes);
+    if (hours <= 0) {
+      return 0;
+    }
+    return hours / 24;
+  }
+
+  private computeTicksPerDay(tickLengthMinutes: number): number {
+    const hours = this.computeTickHours(tickLengthMinutes);
+    if (hours <= 0) {
+      return 24;
+    }
+    const ticks = 24 / hours;
+    return Math.max(1, Math.round(ticks));
+  }
+
+  private computeTickHours(tickLengthMinutes: number): number {
+    return Math.max(tickLengthMinutes, 0) / 60;
+  }
+
+  private computeEffectDurationTicks(option: TreatmentOption, ticksPerDay: number): number {
+    const durationDays =
+      option.effectDurationDays ?? option.cooldownDays ?? DEFAULT_TREATMENT_DURATION_DAYS;
+    if (ticksPerDay <= 0) {
+      return Math.max(1, Math.round(durationDays * 24));
+    }
+    return Math.max(1, Math.round(durationDays * ticksPerDay));
+  }
+
+  private computeSymptomDelayTicks(ticksPerDay: number): number {
+    const { min, max } = this.diseaseBalancing.global.symptomDelayDays;
+    const averageDays = clamp((min + max) / 2, 0, 30);
+    if (ticksPerDay <= 0) {
+      return Math.max(1, Math.round(averageDays * 24));
+    }
+    return Math.max(1, Math.round(averageDays * ticksPerDay));
+  }
+}

--- a/src/backend/src/engine/health/models.ts
+++ b/src/backend/src/engine/health/models.ts
@@ -1,0 +1,131 @@
+import type { PlantStage, TreatmentCategory, HealthTarget } from '../../state/models.js';
+
+export type DiseasePhaseKey = 'seedling' | 'vegetation' | 'earlyFlower' | 'lateFlower' | 'ripening';
+
+export interface DiseasePhaseMultipliers {
+  infection: number;
+  degeneration: number;
+  recovery: number;
+}
+
+export interface DiseaseTreatmentMultipliers {
+  infectionMultiplier?: number;
+  degenerationMultiplier?: number;
+  recoveryMultiplier?: number;
+}
+
+export interface DiseaseBalancingCaps {
+  minDailyDegeneration: number;
+  maxDailyDegeneration: number;
+  minDailyRecovery: number;
+  maxDailyRecovery: number;
+}
+
+export interface DiseaseBalancingConfig {
+  global: {
+    baseDailyInfectionMultiplier: number;
+    baseRecoveryMultiplier: number;
+    maxConcurrentDiseases: number;
+    symptomDelayDays: {
+      min: number;
+      max: number;
+    };
+  };
+  phaseMultipliers: Partial<Record<DiseasePhaseKey, DiseasePhaseMultipliers>>;
+  treatmentEfficacy: Partial<Record<TreatmentCategory, DiseaseTreatmentMultipliers>>;
+  caps: DiseaseBalancingCaps;
+}
+
+export type PestPhaseKey = DiseasePhaseKey;
+
+export interface PestPhaseMultipliers {
+  reproduction: number;
+  mortality: number;
+  damage: number;
+}
+
+export interface PestTreatmentMultipliers {
+  reproductionMultiplier?: number;
+  mortalityMultiplier?: number;
+  damageMultiplier?: number;
+}
+
+export interface PestBalancingCaps {
+  minDailyReproduction: number;
+  maxDailyReproduction: number;
+  minDailyMortality: number;
+  maxDailyMortality: number;
+  minDailyDamage: number;
+  maxDailyDamage: number;
+}
+
+export interface PestBalancingConfig {
+  global: {
+    baseDailyReproductionMultiplier: number;
+    baseDailyMortalityMultiplier: number;
+    baseDamageMultiplier: number;
+    maxConcurrentPests: number;
+  };
+  phaseMultipliers: Partial<Record<PestPhaseKey, PestPhaseMultipliers>>;
+  controlEfficacy: Partial<Record<TreatmentCategory, PestTreatmentMultipliers>>;
+  caps: PestBalancingCaps;
+}
+
+export interface TreatmentOptionDiseaseEffect {
+  infectionMultiplier?: number;
+  degenerationMultiplier?: number;
+  recoveryMultiplier?: number;
+}
+
+export interface TreatmentOptionPestEffect {
+  reproductionMultiplier?: number;
+  mortalityMultiplier?: number;
+  damageMultiplier?: number;
+}
+
+export interface TreatmentOption {
+  id: string;
+  name: string;
+  category: TreatmentCategory;
+  targets: HealthTarget[];
+  applicability?: string[];
+  efficacy?: {
+    disease?: TreatmentOptionDiseaseEffect;
+    pest?: TreatmentOptionPestEffect;
+  };
+  cooldownDays?: number;
+  effectDurationDays?: number;
+  reentryIntervalTicks?: number;
+  preHarvestIntervalTicks?: number;
+}
+
+export type TreatmentOptionIndex = Map<string, TreatmentOption>;
+
+export const mapStageToHealthPhase = (stage: PlantStage): DiseasePhaseKey => {
+  switch (stage) {
+    case 'seedling':
+      return 'seedling';
+    case 'vegetative':
+      return 'vegetation';
+    case 'flowering':
+      return 'earlyFlower';
+    case 'ripening':
+    case 'harvestReady':
+      return 'ripening';
+    default:
+      return 'lateFlower';
+  }
+};
+
+export const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};

--- a/src/backend/src/engine/index.ts
+++ b/src/backend/src/engine/index.ts
@@ -3,3 +3,5 @@ export * from './environment/zoneEnvironment.js';
 export * from './plants/phenology.js';
 export * from './plants/resourceDemand.js';
 export * from './plants/growthModel.js';
+export * from './health/models.js';
+export * from './health/healthEngine.js';

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -5,6 +5,7 @@ import type {
   GameState,
   StructureState,
   ZoneEnvironmentState,
+  ZoneHealthState,
   ZoneMetricState,
   ZoneResourceState,
   ZoneState,
@@ -171,6 +172,11 @@ const createGameStateWithZone = (): GameState => {
       stressLevel: 0.2,
       lastUpdatedTick: 0,
     } satisfies ZoneMetricState,
+    health: {
+      plantHealth: {},
+      pendingTreatments: [],
+      appliedTreatments: [],
+    } satisfies ZoneHealthState,
     activeTaskIds: [],
   } satisfies ZoneState;
 

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -122,6 +122,93 @@ export interface ZoneMetricState {
   lastUpdatedTick: number;
 }
 
+export type HealthTarget = 'disease' | 'pest';
+
+export type TreatmentCategory = 'cultural' | 'biological' | 'mechanical' | 'chemical' | 'physical';
+
+export interface DiseaseTreatmentEffectState {
+  optionId: string;
+  expiresTick: number;
+  infectionMultiplier: number;
+  degenerationMultiplier: number;
+  recoveryMultiplier: number;
+}
+
+export interface PestTreatmentEffectState {
+  optionId: string;
+  expiresTick: number;
+  reproductionMultiplier: number;
+  mortalityMultiplier: number;
+  damageMultiplier: number;
+}
+
+export interface DiseaseState {
+  id: string;
+  pathogenId: string;
+  severity: number;
+  infection: number;
+  detected: boolean;
+  detectionTick?: number;
+  symptomTimerTicks: number;
+  spreadCooldownTicks: number;
+  lastSpreadTick?: number;
+  baseInfectionRatePerDay: number;
+  baseRecoveryRatePerDay: number;
+  baseDegenerationRatePerDay: number;
+  phaseOverride?: string;
+  activeTreatments: DiseaseTreatmentEffectState[];
+}
+
+export interface PestState {
+  id: string;
+  pestId: string;
+  population: number;
+  damage: number;
+  detected: boolean;
+  detectionTick?: number;
+  symptomTimerTicks: number;
+  spreadCooldownTicks: number;
+  lastSpreadTick?: number;
+  baseReproductionRatePerDay: number;
+  baseMortalityRatePerDay: number;
+  baseDamageRatePerDay: number;
+  phaseOverride?: string;
+  activeTreatments: PestTreatmentEffectState[];
+}
+
+export interface PlantHealthState {
+  diseases: DiseaseState[];
+  pests: PestState[];
+}
+
+export interface PendingTreatmentApplication {
+  optionId: string;
+  target: HealthTarget;
+  plantIds: string[];
+  scheduledTick: number;
+  diseaseIds?: string[];
+  pestIds?: string[];
+  reentryIntervalTicks?: number;
+  preHarvestIntervalTicks?: number;
+}
+
+export interface AppliedTreatmentRecord {
+  optionId: string;
+  target: HealthTarget;
+  plantIds: string[];
+  appliedTick: number;
+  reentryRestrictedUntilTick?: number;
+  preHarvestRestrictedUntilTick?: number;
+}
+
+export interface ZoneHealthState {
+  plantHealth: Record<string, PlantHealthState>;
+  pendingTreatments: PendingTreatmentApplication[];
+  appliedTreatments: AppliedTreatmentRecord[];
+  reentryRestrictedUntilTick?: number;
+  preHarvestRestrictedUntilTick?: number;
+}
+
 export interface ZoneState {
   id: string;
   roomId: string;
@@ -133,6 +220,7 @@ export interface ZoneState {
   plants: PlantState[];
   devices: DeviceInstanceState[];
   metrics: ZoneMetricState;
+  health: ZoneHealthState;
   activeTaskIds: string[];
 }
 

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -37,7 +37,9 @@ import {
   TaskSystemState,
   ZoneEnvironmentState,
   ZoneMetricState,
+  ZoneHealthState,
   ZoneResourceState,
+  PlantHealthState,
 } from './state/models.js';
 import { RngService, RngStream } from './lib/rng.js';
 
@@ -362,6 +364,22 @@ const createZoneMetrics = (environment: ZoneEnvironmentState): ZoneMetricState =
   lastUpdatedTick: 0,
 });
 
+const createZoneHealth = (plants: PlantState[]): ZoneHealthState => {
+  const plantEntries = plants.map((plant) => [
+    plant.id,
+    {
+      diseases: [],
+      pests: [],
+    } satisfies PlantHealthState,
+  ]);
+
+  return {
+    plantHealth: Object.fromEntries(plantEntries),
+    pendingTreatments: [],
+    appliedTreatments: [],
+  } satisfies ZoneHealthState;
+};
+
 const drawUnique = <T>(items: readonly T[], count: number, stream: RngStream): T[] => {
   if (items.length === 0 || count <= 0) {
     return [];
@@ -458,6 +476,7 @@ const buildStructureState = (
     plants,
     devices: deviceInstances,
     metrics: createZoneMetrics(environment),
+    health: createZoneHealth(plants),
     activeTaskIds: [],
   };
 


### PR DESCRIPTION
## Summary
- add a plant health engine with detection, progression, spread, and treatment application that emits events and enforces access restrictions
- extend zone state with disease, pest, and treatment tracking and seed the data from the state factory
- cover outbreak to recovery with health engine tests and update supporting fixtures

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cedc426f0c8325a9148fc59ccfd92b