### PR TITLE
feat: add Socket.IO gateway with command handling and batching

### DIFF
--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -1,0 +1,220 @@
+# Socket Protocol — Simulation Gateway
+
+The Socket.IO gateway exposes the simulation façade over a bidirectional socket
+channel. The contract is intentionally small and optimised for realtime UI
+consumers. All payloads are JSON and use SI units unless stated otherwise.
+
+## Connection & Handshake
+
+1. The client connects to the single Socket.IO namespace (`/`).
+2. Immediately after the connection the gateway emits:
+   - `gateway.protocol` – `{ version: 1 }` to allow clients to negotiate
+     breaking changes.
+   - `time.status` – `{ status: TimeStatus }`, mirroring the façade scheduler
+     state (running/paused, tick, speed, targetTickRate).
+   - `simulationUpdate` – a seed payload containing the latest snapshot. The
+     structure is identical to the regular update batches documented below and
+     always contains exactly one entry.
+
+## Outgoing Events
+
+### `simulationUpdate`
+
+Batched snapshot diff and event bundles. Payload:
+
+```json
+{
+  "updates": [
+    {
+      "tick": 123,
+      "ts": 1725712345678,
+      "durationMs": 8.1,
+      "phaseTimings": {
+        "applyDevices": { "startedAt": 0, "completedAt": 1.1, "durationMs": 1.1 },
+        "deriveEnvironment": { "startedAt": 1.1, "completedAt": 2.6, "durationMs": 1.5 },
+        "irrigationAndNutrients": { "startedAt": 2.6, "completedAt": 3.7, "durationMs": 1.1 },
+        "updatePlants": { "startedAt": 3.7, "completedAt": 5.0, "durationMs": 1.3 },
+        "harvestAndInventory": { "startedAt": 5.0, "completedAt": 6.6, "durationMs": 1.6 },
+        "accounting": { "startedAt": 6.6, "completedAt": 7.6, "durationMs": 1.0 },
+        "commit": { "startedAt": 7.6, "completedAt": 8.1, "durationMs": 0.5 }
+      },
+      "events": [
+        {
+          "type": "plant.stageChanged",
+          "tick": 123,
+          "ts": 1725712345678,
+          "payload": { "plantId": "plant-1", "from": "vegetative", "to": "flowering" }
+        }
+      ],
+      "snapshot": {
+        "tick": 123,
+        "clock": { "tick": 123, "isPaused": false, "targetTickRate": 1 },
+        "zones": [
+          {
+            "id": "zone-1",
+            "name": "North Bloom",
+            "structureId": "structure-1",
+            "roomId": "room-1",
+            "environment": {
+              "temperature": 24.1,
+              "relativeHumidity": 0.52,
+              "co2": 980,
+              "ppfd": 540,
+              "vpd": 1.28
+            },
+            "metrics": {
+              "averageTemperature": 23.8,
+              "averageHumidity": 0.53,
+              "averageCo2": 960,
+              "averagePpfd": 530,
+              "stressLevel": 0.12,
+              "lastUpdatedTick": 123
+            },
+            "plants": [
+              {
+                "id": "plant-1",
+                "strainId": "strain-1",
+                "stage": "flowering",
+                "health": 0.93,
+                "stress": 0.1,
+                "biomassDryGrams": 152.4,
+                "yieldDryGrams": 45.2
+              }
+            ]
+          }
+        ]
+      },
+      "time": { "running": true, "paused": false, "speed": 1, "tick": 123, "targetTickRate": 1 }
+    }
+  ]
+}
+```
+
+- Batching window defaults to **120 ms** (configurable) or a maximum of five
+  ticks before the buffer flushes.
+- `snapshot` is a light-weight view focusing on zone telemetry and plant status.
+  UI consumers should treat it as ephemeral state (never mutate in place).
+- The `events` array repeats the domain events emitted during the tick for
+  convenience and matches the structure forwarded via `domainEvents`.
+
+### `sim.tickCompleted`
+
+A raw forwarding of the façade event. Each entry contains:
+
+```json
+{
+  "tick": 123,
+  "ts": 1725712345678,
+  "durationMs": 8.1,
+  "eventCount": 4,
+  "phaseTimings": {
+    /* same as above */
+  },
+  "events": [
+    /* domain events for that tick */
+  ]
+}
+```
+
+The gateway always emits this message after the corresponding `simulationUpdate`
+flush to keep telemetry ordering deterministic.
+
+### `domainEvents`
+
+Bundled domain-level notifications (plant/device/zone/market/finance/health,
+including pests/diseases). Payload:
+
+```json
+{
+  "events": [
+    {
+      "type": "plant.stageChanged",
+      "tick": 123,
+      "ts": 1725712345678,
+      "payload": { "plantId": "plant-1", "from": "vegetative", "to": "flowering" }
+    },
+    {
+      "type": "device.degraded",
+      "tick": 123,
+      "ts": 1725712345685,
+      "level": "warning",
+      "payload": { "deviceId": "lamp-1", "severity": "warning" }
+    }
+  ]
+}
+```
+
+- Default throttling window: **250 ms** with a maximum batch size of 25 events.
+- Every individual event is also re-emitted using the event’s `type` as the
+  Socket.IO channel for legacy listeners (e.g. `plant.stageChanged`).
+
+## Incoming Commands
+
+### Common Envelope
+
+Every command payload may include an optional `requestId` string. When present it
+is mirrored in the corresponding `*.result` response message and in the
+acknowledgement callback.
+
+Responses follow the façade’s `CommandResult<T>` structure:
+
+```json
+{
+  "requestId": "cmd-1",
+  "ok": false,
+  "warnings": ["Speed multiplier unchanged."],
+  "errors": [
+    { "code": "ERR_VALIDATION", "message": "ticks must be greater than zero.", "path": ["ticks"] }
+  ]
+}
+```
+
+### `simulationControl`
+
+Discriminated union on `action`:
+
+| Action        | Payload fields                    | Delegated façade call              |
+| ------------- | --------------------------------- | ---------------------------------- |
+| `play`        | `gameSpeed?`, `maxTicksPerFrame?` | `start()` (or `resume` if running) |
+| `pause`       | –                                 | `pause()`                          |
+| `resume`      | –                                 | `resume()`                         |
+| `step`        | `ticks?`                          | `step()`                           |
+| `fastForward` | `multiplier`                      | `setSpeed()`                       |
+
+All payloads are validated with Zod before the façade command is executed. If
+validation fails the façade is not touched and the client receives an
+`ERR_VALIDATION` response immediately.
+
+### `config.update`
+
+Currently supported targets:
+
+| Type         | Payload fields              | Behaviour                                                                                    |
+| ------------ | --------------------------- | -------------------------------------------------------------------------------------------- |
+| `tickLength` | `minutes` (> 0)             | Reconfigures the scheduler (restarts if required) and emits a `sim.tickLengthChanged` event. |
+| `setpoint`   | `zoneId`, `metric`, `value` | Not yet implemented – returns `ERR_INVALID_STATE`.                                           |
+
+Additional configuration mutations can be layered onto the same endpoint in the
+future without breaking existing clients.
+
+## Error Handling
+
+- Validation errors (`ERR_VALIDATION`) map 1:1 to the offending field path.
+- Internal failures (`ERR_INTERNAL`) surface the error message and the command
+  path. The gateway never throws – failures are returned via the Socket.IO ACK
+  callback and the mirrored `*.result` event.
+- Unsupported commands yield `ERR_INVALID_STATE`.
+
+## Batching Guarantees
+
+- Simulation updates are emitted in tick order. No batch spans ticks out of
+  order and the gateway never drops ticks – throttling only coalesces them.
+- Domain events preserve emission order inside each batch.
+- Closing the gateway (`SocketGateway.close()`) flushes pending timers and
+  detaches all façade subscriptions.
+
+## Versioning
+
+The protocol version is incremented when payload structures change in a
+non-backwards-compatible way. Clients should subscribe to `gateway.protocol` and
+fail fast if an unknown version is announced.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      socket.io:
+        specifier: ^4.8.1
+        version: 4.8.1
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -615,6 +621,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -856,6 +865,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -952,6 +965,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.8.6:
     resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
@@ -1054,6 +1071,14 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1215,6 +1240,10 @@ packages:
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.4:
+    resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
+    engines: {node: '>=10.2.0'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1867,6 +1896,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
@@ -2209,6 +2242,9 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  socket.io-adapter@2.5.5:
+    resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
+
   socket.io-client@4.8.1:
     resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
     engines: {node: '>=10.0.0'}
@@ -2216,6 +2252,10 @@ packages:
   socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.1:
+    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+    engines: {node: '>=10.2.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2416,6 +2456,10 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
@@ -3059,6 +3103,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 20.19.17
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3300,6 +3348,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3406,6 +3459,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64id@2.0.0: {}
+
   baseline-browser-mapping@2.8.6: {}
 
   binary-extensions@2.3.0: {}
@@ -3511,6 +3566,13 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -3664,6 +3726,22 @@ snapshots:
       - utf-8-validate
 
   engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.4:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 20.19.17
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   entities@6.0.1: {}
 
@@ -4452,6 +4530,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   node-releases@2.0.21: {}
 
   normalize-path@3.0.0: {}
@@ -4836,6 +4916,15 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  socket.io-adapter@2.5.5:
+    dependencies:
+      debug: 4.3.7
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-client@4.8.1:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -4853,6 +4942,20 @@ snapshots:
       debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
+
+  socket.io@4.8.1:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io: 6.6.4
+      socket.io-adapter: 2.5.5
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   source-map-js@1.2.1: {}
 
@@ -5085,6 +5188,8 @@ snapshots:
       react: 18.3.1
 
   v8-compile-cache-lib@3.0.1: {}
+
+  vary@1.1.2: {}
 
   victory-vendor@36.9.2:
     dependencies:

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "chokidar": "^3.5.3",
     "rxjs": "^7.8.2",
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1",
     "zod": "^3.23.8"
   }
 }

--- a/src/backend/server/socketGateway.test.ts
+++ b/src/backend/server/socketGateway.test.ts
@@ -1,0 +1,486 @@
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { io as createClient, type Socket as ClientSocket } from 'socket.io-client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  CommandResult,
+  EventFilter,
+  TimeStartIntent,
+  TimeStatus,
+  TimeStepIntent,
+  SetSpeedIntent,
+  Unsubscribe,
+} from '../facade/index.js';
+import { EventBus, type SimulationEvent } from '../src/lib/eventBus.js';
+import { TICK_PHASES, type PhaseTiming, type TickCompletedPayload } from '../src/sim/loop.js';
+import type { GameState } from '../src/state/models.js';
+import { SocketGateway } from './socketGateway.js';
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 1000): Promise<void> => {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error('Timed out waiting for condition.'));
+        return;
+      }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+};
+
+const createPhaseTimings = (durationMs = 5): Record<(typeof TICK_PHASES)[number], PhaseTiming> => {
+  return TICK_PHASES.reduce(
+    (accumulator, phase, index) => {
+      const startedAt = index * durationMs;
+      accumulator[phase] = {
+        startedAt,
+        completedAt: startedAt + durationMs,
+        durationMs,
+      };
+      return accumulator;
+    },
+    {} as Record<(typeof TICK_PHASES)[number], PhaseTiming>,
+  );
+};
+
+const createTestState = (): GameState => {
+  const timestamp = new Date(0).toISOString();
+  return {
+    metadata: {
+      gameId: 'game-1',
+      createdAt: timestamp,
+      seed: 'seed-1',
+      difficulty: 'normal',
+      simulationVersion: '1.0.0',
+      tickLengthMinutes: 60,
+      economics: {
+        initialCapital: 1_000_000,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0.1,
+        rentPerSqmRoomPerTick: 0.2,
+      },
+    },
+    clock: {
+      tick: 0,
+      isPaused: true,
+      startedAt: timestamp,
+      lastUpdatedAt: timestamp,
+      targetTickRate: 1,
+    },
+    structures: [
+      {
+        id: 'structure-1',
+        blueprintId: 'structure-blueprint',
+        name: 'Structure',
+        status: 'active',
+        footprint: { length: 10, width: 10, height: 4, area: 100, volume: 400 },
+        rooms: [
+          {
+            id: 'room-1',
+            structureId: 'structure-1',
+            name: 'Room',
+            purposeId: 'grow',
+            area: 100,
+            height: 4,
+            volume: 400,
+            cleanliness: 0.95,
+            maintenanceLevel: 0.9,
+            zones: [
+              {
+                id: 'zone-1',
+                roomId: 'room-1',
+                name: 'Zone',
+                cultivationMethodId: 'method-1',
+                strainId: 'strain-1',
+                environment: {
+                  temperature: 22,
+                  relativeHumidity: 0.55,
+                  co2: 900,
+                  ppfd: 500,
+                  vpd: 1.2,
+                },
+                resources: {
+                  waterLiters: 100,
+                  nutrientSolutionLiters: 50,
+                  nutrientStrength: 1,
+                  substrateHealth: 0.9,
+                  reservoirLevel: 0.8,
+                },
+                plants: [
+                  {
+                    id: 'plant-1',
+                    strainId: 'strain-1',
+                    zoneId: 'zone-1',
+                    stage: 'vegetative',
+                    plantedAtTick: 0,
+                    ageInHours: 24,
+                    health: 0.9,
+                    stress: 0.1,
+                    biomassDryGrams: 12,
+                    heightMeters: 0.5,
+                    canopyCover: 0.7,
+                    yieldDryGrams: 0,
+                    quality: 0.85,
+                    lastMeasurementTick: 0,
+                  },
+                ],
+                devices: [],
+                metrics: {
+                  averageTemperature: 22,
+                  averageHumidity: 0.55,
+                  averageCo2: 900,
+                  averagePpfd: 500,
+                  stressLevel: 0.1,
+                  lastUpdatedTick: 0,
+                },
+                health: {
+                  plantHealth: {},
+                  pendingTreatments: [],
+                  appliedTreatments: [],
+                },
+                activeTaskIds: [],
+              },
+            ],
+          },
+        ],
+        rentPerTick: 0,
+        upfrontCostPaid: 0,
+      },
+    ],
+    inventory: {
+      resources: {
+        waterLiters: 1_000,
+        nutrientsGrams: 100,
+        co2Kg: 10,
+        substrateKg: 500,
+        packagingUnits: 0,
+        sparePartsValue: 0,
+      },
+      seeds: [],
+      devices: [],
+      harvest: [],
+      consumables: {},
+    },
+    finances: {
+      cashOnHand: 100_000,
+      reservedCash: 0,
+      outstandingLoans: [],
+      ledger: [],
+      summary: {
+        totalRevenue: 0,
+        totalExpenses: 0,
+        totalPayroll: 0,
+        totalMaintenance: 0,
+        netIncome: 0,
+        lastTickRevenue: 0,
+        lastTickExpenses: 0,
+      },
+    },
+    personnel: {
+      employees: [],
+      applicants: [],
+      trainingPrograms: [],
+      overallMorale: 1,
+    },
+    tasks: {
+      backlog: [],
+      active: [],
+      completed: [],
+      cancelled: [],
+    },
+    notes: [],
+  };
+};
+
+const simulationUpdates: Array<{ updates: { tick: number }[] }> = [];
+const domainEvents: SimulationEvent[][] = [];
+
+class StubFacade {
+  public readonly eventBus = new EventBus();
+
+  public state: GameState;
+
+  public status: TimeStatus = {
+    running: false,
+    paused: true,
+    speed: 1,
+    tick: 0,
+    targetTickRate: 1,
+  };
+
+  public startInvocations = 0;
+
+  public pauseInvocations = 0;
+
+  public resumeInvocations = 0;
+
+  public stepInvocations = 0;
+
+  public setSpeedInvocations = 0;
+
+  public setTickLengthInvocations = 0;
+
+  private readonly listeners: Unsubscribe[] = [];
+
+  constructor(state: GameState) {
+    this.state = state;
+  }
+
+  select<T>(selector: (state: GameState) => T): T {
+    return selector(this.state);
+  }
+
+  subscribe(filter: EventFilter, handler: (event: SimulationEvent) => void): Unsubscribe;
+  subscribe(handler: (event: SimulationEvent) => void): Unsubscribe;
+  subscribe(
+    filterOrHandler: EventFilter | ((event: SimulationEvent) => void),
+    handler?: (event: SimulationEvent) => void,
+  ): Unsubscribe {
+    if (typeof filterOrHandler === 'function') {
+      const subscription = this.eventBus
+        .asObservable()
+        .subscribe((event) => filterOrHandler(event));
+      const unsubscribe = () => subscription.unsubscribe();
+      this.listeners.push(unsubscribe);
+      return unsubscribe;
+    }
+    if (!handler) {
+      throw new Error('Handler is required when subscribing with a filter.');
+    }
+    const subscription = this.eventBus.events(filterOrHandler).subscribe((event) => handler(event));
+    const unsubscribe = () => subscription.unsubscribe();
+    this.listeners.push(unsubscribe);
+    return unsubscribe;
+  }
+
+  start(intent: TimeStartIntent = {}): Promise<CommandResult<TimeStatus>> {
+    this.startInvocations += 1;
+    this.status = {
+      ...this.status,
+      running: true,
+      paused: false,
+      speed: intent.gameSpeed ?? this.status.speed,
+    };
+    return Promise.resolve({ ok: true, data: this.status });
+  }
+
+  pause(): Promise<CommandResult<TimeStatus>> {
+    this.pauseInvocations += 1;
+    this.status = { ...this.status, running: true, paused: true };
+    return Promise.resolve({ ok: true, data: this.status });
+  }
+
+  resume(): Promise<CommandResult<TimeStatus>> {
+    this.resumeInvocations += 1;
+    this.status = { ...this.status, running: true, paused: false };
+    return Promise.resolve({ ok: true, data: this.status });
+  }
+
+  step(intent?: TimeStepIntent): Promise<CommandResult<TimeStatus>> {
+    this.stepInvocations += 1;
+    const increment = intent?.ticks ?? 1;
+    this.status = { ...this.status, tick: this.status.tick + increment };
+    this.state.clock.tick = this.status.tick;
+    this.state.clock.lastUpdatedAt = new Date().toISOString();
+    return Promise.resolve({ ok: true, data: this.status });
+  }
+
+  setSpeed(intent: SetSpeedIntent): Promise<CommandResult<TimeStatus>> {
+    this.setSpeedInvocations += 1;
+    this.status = { ...this.status, speed: intent.multiplier };
+    return Promise.resolve({ ok: true, data: this.status });
+  }
+
+  setTickLength(minutes: number): CommandResult<TimeStatus> {
+    this.setTickLengthInvocations += 1;
+    this.state.metadata.tickLengthMinutes = minutes;
+    return { ok: true, data: this.status };
+  }
+
+  getTimeStatus(): TimeStatus {
+    return { ...this.status };
+  }
+
+  emit(event: SimulationEvent): void {
+    this.eventBus.emit(event);
+  }
+
+  emitTickCompleted(tick: number, events: SimulationEvent[] = []): void {
+    this.status = { ...this.status, tick };
+    this.state.clock.tick = tick;
+    this.state.clock.lastUpdatedAt = new Date().toISOString();
+    const payload: TickCompletedPayload = {
+      tick,
+      durationMs: 10,
+      eventCount: events.length,
+      phaseTimings: createPhaseTimings(),
+      events,
+    };
+    this.eventBus.emit({
+      type: 'sim.tickCompleted',
+      tick,
+      ts: Date.now(),
+      level: 'info',
+      payload,
+    });
+  }
+
+  dispose(): void {
+    for (const unsubscribe of this.listeners.splice(0)) {
+      unsubscribe();
+    }
+  }
+}
+
+describe('SocketGateway', () => {
+  let server: HttpServer;
+  let port: number;
+  let facade: StubFacade;
+  let gateway: SocketGateway;
+  let client: ClientSocket;
+
+  beforeEach(async () => {
+    simulationUpdates.length = 0;
+    domainEvents.length = 0;
+    server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    port = (server.address() as AddressInfo).port;
+    facade = new StubFacade(createTestState());
+    gateway = new SocketGateway({
+      httpServer: server,
+      facade,
+      simulationBatchIntervalMs: 30,
+      domainBatchIntervalMs: 30,
+    });
+    client = createClient(`http://127.0.0.1:${port}`, {
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    client.on('simulationUpdate', (payload) => {
+      simulationUpdates.push(payload);
+    });
+    client.on('domainEvents', (payload) => {
+      domainEvents.push(payload.events);
+    });
+    await new Promise<void>((resolve) => client.on('connect', () => resolve()));
+    // Drain initial handshake update
+    await waitFor(() => simulationUpdates.length > 0, 200).catch(() => undefined);
+    simulationUpdates.length = 0;
+    domainEvents.length = 0;
+  });
+
+  afterEach(async () => {
+    client.removeAllListeners();
+    client.disconnect();
+    gateway.close();
+    facade.dispose();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('batches simulation updates before emitting', async () => {
+    facade.state.structures[0].rooms[0].zones[0].environment.temperature = 23;
+    facade.emitTickCompleted(1, [
+      { type: 'plant.stageChanged', tick: 1, ts: Date.now(), payload: { plantId: 'plant-1' } },
+    ]);
+    facade.state.structures[0].rooms[0].zones[0].environment.temperature = 24;
+    facade.emitTickCompleted(2, []);
+
+    await waitFor(() => simulationUpdates.length >= 1);
+
+    expect(simulationUpdates).toHaveLength(1);
+    const batch = simulationUpdates[0];
+    expect(batch.updates).toHaveLength(2);
+    expect(batch.updates[0].tick).toBe(1);
+    expect(batch.updates[1].tick).toBe(2);
+  });
+
+  it('aggregates domain events using throttling', async () => {
+    facade.emit({
+      type: 'plant.stageChanged',
+      tick: 1,
+      ts: Date.now(),
+      payload: { plantId: 'plant-1', from: 'vegetative', to: 'flowering' },
+    });
+    facade.emit({
+      type: 'device.degraded',
+      tick: 1,
+      ts: Date.now(),
+      payload: { deviceId: 'device-1', severity: 'warning' },
+    });
+
+    await waitFor(() => domainEvents.length >= 1);
+
+    expect(domainEvents).toHaveLength(1);
+    expect(domainEvents[0]).toHaveLength(2);
+    expect(domainEvents[0][0].type).toBe('plant.stageChanged');
+    expect(domainEvents[0][1].type).toBe('device.degraded');
+  });
+
+  it('validates and executes simulation control commands', async () => {
+    const response = await new Promise<CommandResult<TimeStatus>>((resolve) => {
+      client.emit(
+        'simulationControl',
+        { requestId: 'cmd-1', action: 'play' },
+        (payload: CommandResult<TimeStatus>) => {
+          resolve(payload);
+        },
+      );
+    });
+
+    expect(response.ok).toBe(true);
+    expect(facade.startInvocations).toBe(1);
+
+    const invalid = await new Promise<CommandResult<TimeStatus>>((resolve) => {
+      client.emit(
+        'simulationControl',
+        { requestId: 'cmd-2', action: 'step', ticks: 0 },
+        (payload: CommandResult<TimeStatus>) => {
+          resolve(payload);
+        },
+      );
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors?.[0].code).toBe('ERR_VALIDATION');
+  });
+
+  it('updates configuration via config.update', async () => {
+    const response = await new Promise<CommandResult<TimeStatus>>((resolve) => {
+      client.emit(
+        'config.update',
+        { requestId: 'cfg-1', type: 'tickLength', minutes: 15 },
+        (payload: CommandResult<TimeStatus>) => {
+          resolve(payload);
+        },
+      );
+    });
+
+    expect(response.ok).toBe(true);
+    expect(facade.state.metadata.tickLengthMinutes).toBe(15);
+    expect(facade.setTickLengthInvocations).toBe(1);
+
+    const unsupported = await new Promise<CommandResult<TimeStatus>>((resolve) => {
+      client.emit(
+        'config.update',
+        {
+          requestId: 'cfg-2',
+          type: 'setpoint',
+          zoneId: '11111111-1111-1111-1111-111111111111',
+          metric: 'temperature',
+          value: 25,
+        },
+        (payload: CommandResult<TimeStatus>) => resolve(payload),
+      );
+    });
+
+    expect(unsupported.ok).toBe(false);
+    expect(unsupported.errors?.[0].code).toBe('ERR_INVALID_STATE');
+  });
+});

--- a/src/backend/server/socketGateway.ts
+++ b/src/backend/server/socketGateway.ts
@@ -1,0 +1,631 @@
+import type { Server as HttpServer } from 'node:http';
+import { Server as IOServer, type ServerOptions as IOServerOptions, type Socket } from 'socket.io';
+import { z, type ZodError } from 'zod';
+import type {
+  CommandError,
+  CommandResult,
+  EventFilter,
+  SimulationFacade,
+  TimeStartIntent,
+  TimeStatus,
+  TimeStepIntent,
+  SetSpeedIntent,
+  Unsubscribe,
+} from '../facade/index.js';
+import type { SimulationEvent } from '../src/lib/eventBus.js';
+import type { TickCompletedPayload } from '../src/sim/loop.js';
+import type {
+  GameState,
+  PlantState,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+} from '../src/state/models.js';
+
+const DEFAULT_SIMULATION_BATCH_INTERVAL_MS = 120;
+const DEFAULT_SIMULATION_BATCH_MAX_SIZE = 5;
+const DEFAULT_DOMAIN_BATCH_INTERVAL_MS = 250;
+const DEFAULT_DOMAIN_BATCH_MAX_SIZE = 25;
+
+const DOMAIN_EVENT_PATTERN =
+  /^(plant|device|zone|market|finance|env|pest|disease|task|hr|world|health)\./;
+
+interface SimulationControlPlay {
+  action: 'play';
+  gameSpeed?: number;
+  maxTicksPerFrame?: number;
+}
+
+interface SimulationControlPause {
+  action: 'pause';
+}
+
+interface SimulationControlResume {
+  action: 'resume';
+}
+
+interface SimulationControlStep {
+  action: 'step';
+  ticks?: number;
+}
+
+interface SimulationControlFastForward {
+  action: 'fastForward';
+  multiplier: number;
+}
+
+type SimulationControlCommand =
+  | SimulationControlPlay
+  | SimulationControlPause
+  | SimulationControlResume
+  | SimulationControlStep
+  | SimulationControlFastForward;
+
+interface TickLengthConfig {
+  type: 'tickLength';
+  minutes: number;
+}
+
+interface SetpointConfig {
+  type: 'setpoint';
+  zoneId: string;
+  metric: 'temperature' | 'relativeHumidity' | 'co2' | 'ppfd' | 'vpd';
+  value: number;
+}
+
+type ConfigUpdateCommand = TickLengthConfig | SetpointConfig;
+
+interface CommandResponse<T> extends CommandResult<T> {
+  requestId?: string;
+}
+
+interface SimulationEventEnvelope<T = unknown> {
+  event: SimulationEvent<T>;
+  snapshot: SimulationSnapshot;
+}
+
+interface SimulationSnapshot {
+  tick: number;
+  clock: {
+    tick: number;
+    isPaused: boolean;
+    targetTickRate: number;
+  };
+  zones: ZoneSnapshot[];
+}
+
+interface ZoneSnapshot {
+  id: string;
+  name: string;
+  structureId: string;
+  roomId: string;
+  environment: ZoneEnvironmentState;
+  metrics: ZoneMetricState;
+  plants: PlantSnapshot[];
+}
+
+interface PlantSnapshot {
+  id: string;
+  strainId: string;
+  stage: PlantState['stage'];
+  health: number;
+  stress: number;
+  biomassDryGrams: number;
+  yieldDryGrams: number;
+}
+
+interface SimulationUpdateEntry {
+  tick: number;
+  ts: number;
+  durationMs?: number;
+  phaseTimings?: TickCompletedPayload['phaseTimings'];
+  events: SimulationEvent[];
+  snapshot: SimulationSnapshot;
+  time: TimeStatus;
+}
+
+interface SimulationUpdateMessage {
+  updates: SimulationUpdateEntry[];
+}
+
+interface DomainEventMessage {
+  events: SimulationEvent[];
+}
+
+const requestMetadataSchema = z.object({
+  requestId: z.string().trim().min(1).optional(),
+});
+
+const positiveNumberSchema = z
+  .number({ invalid_type_error: 'Value must be a number.' })
+  .refine((value) => Number.isFinite(value) && value > 0, {
+    message: 'Value must be a finite number greater than zero.',
+  });
+
+const positiveIntegerSchema = z
+  .number({ invalid_type_error: 'Value must be a number.' })
+  .int({ message: 'Value must be an integer.' })
+  .refine((value) => value > 0, { message: 'Value must be greater than zero.' });
+
+const simulationControlSchema = requestMetadataSchema.and(
+  z.discriminatedUnion('action', [
+    z.object({
+      action: z.literal('play'),
+      gameSpeed: positiveNumberSchema.optional(),
+      maxTicksPerFrame: positiveIntegerSchema.optional(),
+    }),
+    z.object({ action: z.literal('pause') }),
+    z.object({ action: z.literal('resume') }),
+    z.object({
+      action: z.literal('step'),
+      ticks: positiveIntegerSchema.optional(),
+    }),
+    z.object({
+      action: z.literal('fastForward'),
+      multiplier: positiveNumberSchema,
+    }),
+  ]),
+);
+
+const configUpdateSchema = requestMetadataSchema.and(
+  z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('tickLength'),
+      minutes: positiveNumberSchema,
+    }),
+    z.object({
+      type: z.literal('setpoint'),
+      zoneId: z.string().uuid({ message: 'zoneId must be a UUID.' }),
+      metric: z.enum(['temperature', 'relativeHumidity', 'co2', 'ppfd', 'vpd']),
+      value: z.number({ invalid_type_error: 'Value must be a number.' }),
+    }),
+  ]),
+);
+
+export interface SocketGatewayOptions {
+  httpServer: HttpServer;
+  facade: SimulationFacade;
+  serverOptions?: Partial<IOServerOptions>;
+  simulationBatchIntervalMs?: number;
+  simulationBatchMaxSize?: number;
+  domainBatchIntervalMs?: number;
+  domainBatchMaxSize?: number;
+}
+
+type AckCallback<T> = (response: CommandResponse<T>) => void;
+
+const sanitizeEvent = (event: SimulationEvent): SimulationEvent => ({
+  type: event.type,
+  payload: event.payload,
+  tick: event.tick,
+  ts: event.ts ?? Date.now(),
+  level: event.level,
+  tags: event.tags ? [...event.tags] : undefined,
+});
+
+const buildSnapshot = (state: GameState): SimulationSnapshot => {
+  const zones: ZoneSnapshot[] = [];
+
+  for (const structure of state.structures) {
+    for (const room of structure.rooms) {
+      for (const zone of room.zones) {
+        zones.push({
+          id: zone.id,
+          name: zone.name,
+          structureId: structure.id,
+          roomId: room.id,
+          environment: { ...zone.environment },
+          metrics: { ...zone.metrics },
+          plants: zone.plants.map((plant) => ({
+            id: plant.id,
+            strainId: plant.strainId,
+            stage: plant.stage,
+            health: plant.health,
+            stress: plant.stress,
+            biomassDryGrams: plant.biomassDryGrams,
+            yieldDryGrams: plant.yieldDryGrams,
+          })),
+        });
+      }
+    }
+  }
+
+  return {
+    tick: state.clock.tick,
+    clock: {
+      tick: state.clock.tick,
+      isPaused: state.clock.isPaused,
+      targetTickRate: state.clock.targetTickRate,
+    },
+    zones,
+  };
+};
+
+export class SocketGateway {
+  private readonly facade: SimulationFacade;
+
+  private readonly io: IOServer;
+
+  private readonly simulationBatchInterval: number;
+
+  private readonly simulationBatchMaxSize: number;
+
+  private readonly domainBatchInterval: number;
+
+  private readonly domainBatchMaxSize: number;
+
+  private readonly simulationQueue: SimulationEventEnvelope<TickCompletedPayload>[] = [];
+
+  private readonly domainQueue: SimulationEvent[] = [];
+
+  private simulationFlushTimer: NodeJS.Timeout | null = null;
+
+  private domainFlushTimer: NodeJS.Timeout | null = null;
+
+  private readonly subscriptions: Unsubscribe[] = [];
+
+  private disposed = false;
+
+  constructor(options: SocketGatewayOptions) {
+    this.facade = options.facade;
+    this.simulationBatchInterval =
+      options.simulationBatchIntervalMs ?? DEFAULT_SIMULATION_BATCH_INTERVAL_MS;
+    this.simulationBatchMaxSize =
+      options.simulationBatchMaxSize ?? DEFAULT_SIMULATION_BATCH_MAX_SIZE;
+    this.domainBatchInterval = options.domainBatchIntervalMs ?? DEFAULT_DOMAIN_BATCH_INTERVAL_MS;
+    this.domainBatchMaxSize = options.domainBatchMaxSize ?? DEFAULT_DOMAIN_BATCH_MAX_SIZE;
+
+    this.io = new IOServer(options.httpServer, {
+      cors: { origin: '*' },
+      ...options.serverOptions,
+    });
+
+    this.io.on('connection', (socket) => this.handleConnection(socket));
+
+    this.subscriptions.push(
+      this.facade.subscribe('sim.tickCompleted', (event) =>
+        this.queueSimulationEvent(event as SimulationEvent<TickCompletedPayload>),
+      ),
+    );
+
+    const domainFilter: EventFilter = {
+      predicate: (event) => DOMAIN_EVENT_PATTERN.test(event.type),
+    };
+
+    this.subscriptions.push(
+      this.facade.subscribe(domainFilter, (event) => this.queueDomainEvent(event)),
+    );
+  }
+
+  close(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    for (const unsubscribe of this.subscriptions.splice(0)) {
+      unsubscribe();
+    }
+    if (this.simulationFlushTimer) {
+      clearTimeout(this.simulationFlushTimer);
+      this.simulationFlushTimer = null;
+    }
+    if (this.domainFlushTimer) {
+      clearTimeout(this.domainFlushTimer);
+      this.domainFlushTimer = null;
+    }
+    this.io.removeAllListeners();
+    this.io.disconnectSockets(true);
+    this.io.close();
+  }
+
+  private handleConnection(socket: Socket): void {
+    const snapshot = this.facade.select((state) => buildSnapshot(state));
+    const time = this.facade.getTimeStatus();
+
+    socket.emit('gateway.protocol', { version: 1 });
+    socket.emit('time.status', { status: time });
+
+    socket.emit('simulationUpdate', {
+      updates: [
+        {
+          tick: snapshot.tick,
+          ts: Date.now(),
+          events: [],
+          snapshot,
+          time,
+        } satisfies SimulationUpdateEntry,
+      ],
+    } satisfies SimulationUpdateMessage);
+
+    socket.on('simulationControl', (payload, ack) =>
+      this.handleSimulationControl(socket, payload, ack as AckCallback<TimeStatus> | undefined),
+    );
+    socket.on('config.update', (payload, ack) =>
+      this.handleConfigUpdate(socket, payload, ack as AckCallback<TimeStatus> | undefined),
+    );
+  }
+
+  private queueSimulationEvent(event: SimulationEvent<TickCompletedPayload>): void {
+    if (this.disposed) {
+      return;
+    }
+    const snapshot = this.facade.select((state) => buildSnapshot(state));
+    this.simulationQueue.push({ event, snapshot });
+
+    if (this.simulationQueue.length >= this.simulationBatchMaxSize) {
+      this.flushSimulationQueue();
+      return;
+    }
+
+    if (!this.simulationFlushTimer) {
+      this.simulationFlushTimer = setTimeout(() => {
+        this.simulationFlushTimer = null;
+        this.flushSimulationQueue();
+      }, this.simulationBatchInterval);
+    }
+  }
+
+  private queueDomainEvent(event: SimulationEvent): void {
+    if (this.disposed) {
+      return;
+    }
+    this.domainQueue.push(event);
+
+    if (this.domainQueue.length >= this.domainBatchMaxSize) {
+      this.flushDomainQueue();
+      return;
+    }
+
+    if (!this.domainFlushTimer) {
+      this.domainFlushTimer = setTimeout(() => {
+        this.domainFlushTimer = null;
+        this.flushDomainQueue();
+      }, this.domainBatchInterval);
+    }
+  }
+
+  private flushSimulationQueue(): void {
+    if (this.simulationQueue.length === 0) {
+      return;
+    }
+    const entries = this.simulationQueue.splice(0);
+    const timeStatus = this.facade.getTimeStatus();
+
+    const updates: SimulationUpdateEntry[] = entries.map(({ event, snapshot }) => {
+      const payload = event.payload;
+      const events = Array.isArray(payload?.events) ? payload!.events.map(sanitizeEvent) : [];
+      const update: SimulationUpdateEntry = {
+        tick: event.tick ?? payload?.tick ?? snapshot.tick,
+        ts: event.ts ?? Date.now(),
+        durationMs: payload?.durationMs,
+        phaseTimings: payload?.phaseTimings,
+        events,
+        snapshot,
+        time: timeStatus,
+      };
+      return update;
+    });
+
+    this.io.emit('simulationUpdate', { updates } satisfies SimulationUpdateMessage);
+
+    for (const { event } of entries) {
+      this.io.emit('sim.tickCompleted', {
+        tick: event.tick ?? event.payload?.tick,
+        ts: event.ts ?? Date.now(),
+        durationMs: event.payload?.durationMs,
+        eventCount: event.payload?.eventCount ?? event.payload?.events?.length ?? updates.length,
+        phaseTimings: event.payload?.phaseTimings,
+        events: Array.isArray(event.payload?.events)
+          ? event.payload!.events.map(sanitizeEvent)
+          : [],
+      });
+    }
+  }
+
+  private flushDomainQueue(): void {
+    if (this.domainQueue.length === 0) {
+      return;
+    }
+    const events = this.domainQueue.splice(0).map(sanitizeEvent);
+    this.io.emit('domainEvents', { events } satisfies DomainEventMessage);
+
+    for (const event of events) {
+      this.io.emit(event.type, event.payload ?? null);
+    }
+  }
+
+  private async handleSimulationControl(
+    socket: Socket,
+    payload: unknown,
+    ack?: AckCallback<TimeStatus>,
+  ): Promise<void> {
+    const requestId = this.extractRequestId(payload);
+    const parsed = simulationControlSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const response = this.buildValidationResult(parsed.error, requestId);
+      this.emitCommandResponse(socket, 'simulationControl.result', response, ack);
+      return;
+    }
+
+    const { requestId: parsedRequestId, ...command } = parsed.data;
+    let result: CommandResult<TimeStatus>;
+
+    try {
+      result = await this.executeSimulationControl(command);
+    } catch (error) {
+      result = this.buildInternalError('simulationControl', error);
+    }
+
+    this.emitCommandResponse(
+      socket,
+      'simulationControl.result',
+      {
+        requestId: parsedRequestId,
+        ...result,
+      },
+      ack,
+    );
+  }
+
+  private async handleConfigUpdate(
+    socket: Socket,
+    payload: unknown,
+    ack?: AckCallback<TimeStatus>,
+  ): Promise<void> {
+    const requestId = this.extractRequestId(payload);
+    const parsed = configUpdateSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const response = this.buildValidationResult(parsed.error, requestId);
+      this.emitCommandResponse(socket, 'config.update.result', response, ack);
+      return;
+    }
+
+    const { requestId: parsedRequestId, ...command } = parsed.data;
+    let result: CommandResult<TimeStatus>;
+
+    try {
+      result = await this.executeConfigUpdate(command);
+    } catch (error) {
+      result = this.buildInternalError('config.update', error);
+    }
+
+    this.emitCommandResponse(
+      socket,
+      'config.update.result',
+      {
+        requestId: parsedRequestId,
+        ...result,
+      },
+      ack,
+    );
+  }
+
+  private async executeSimulationControl(
+    command: SimulationControlCommand,
+  ): Promise<CommandResult<TimeStatus>> {
+    switch (command.action) {
+      case 'play': {
+        const intent: TimeStartIntent = {};
+        if (command.gameSpeed !== undefined) {
+          intent.gameSpeed = command.gameSpeed;
+        }
+        if (command.maxTicksPerFrame !== undefined) {
+          intent.maxTicksPerFrame = command.maxTicksPerFrame;
+        }
+        const status = this.facade.getTimeStatus();
+        if (!status.running) {
+          return this.facade.start(intent);
+        }
+        if (status.paused) {
+          return this.facade.resume();
+        }
+        return {
+          ok: true,
+          data: status,
+          warnings: ['Simulation is already running.'],
+        } satisfies CommandResult<TimeStatus>;
+      }
+      case 'pause':
+        return this.facade.pause();
+      case 'resume':
+        return this.facade.resume();
+      case 'step': {
+        const intent: TimeStepIntent | undefined =
+          command.ticks !== undefined ? { ticks: command.ticks } : undefined;
+        return this.facade.step(intent);
+      }
+      case 'fastForward': {
+        const intent: SetSpeedIntent = { multiplier: command.multiplier };
+        return this.facade.setSpeed(intent);
+      }
+      default:
+        return {
+          ok: false,
+          errors: [
+            {
+              code: 'ERR_INVALID_STATE',
+              message: `Unsupported simulation control action: ${(command as SimulationControlCommand).action}`,
+            },
+          ],
+        } satisfies CommandResult<TimeStatus>;
+    }
+  }
+
+  private async executeConfigUpdate(
+    command: ConfigUpdateCommand,
+  ): Promise<CommandResult<TimeStatus>> {
+    switch (command.type) {
+      case 'tickLength':
+        return this.facade.setTickLength(command.minutes);
+      case 'setpoint':
+        return {
+          ok: false,
+          errors: [
+            {
+              code: 'ERR_INVALID_STATE',
+              message: 'Setpoint updates are not supported in the current build.',
+              path: ['config.update', 'setpoint'],
+            },
+          ],
+        } satisfies CommandResult<TimeStatus>;
+      default:
+        return {
+          ok: false,
+          errors: [
+            {
+              code: 'ERR_INVALID_STATE',
+              message: `Unsupported config update type: ${(command as ConfigUpdateCommand).type}`,
+            },
+          ],
+        } satisfies CommandResult<TimeStatus>;
+    }
+  }
+
+  private buildValidationResult(error: ZodError, requestId?: string): CommandResponse<TimeStatus> {
+    const issues: CommandError[] = error.issues.map((issue) => ({
+      code: 'ERR_VALIDATION',
+      message: issue.message,
+      path: issue.path.map((segment) => String(segment)),
+    }));
+    return {
+      ok: false,
+      requestId,
+      errors: issues,
+    } satisfies CommandResponse<TimeStatus>;
+  }
+
+  private buildInternalError(command: string, error: unknown): CommandResult<TimeStatus> {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'ERR_INTERNAL',
+          message,
+          path: [command],
+        },
+      ],
+    } satisfies CommandResult<TimeStatus>;
+  }
+
+  private emitCommandResponse(
+    socket: Socket,
+    channel: string,
+    response: CommandResponse<TimeStatus>,
+    ack?: AckCallback<TimeStatus>,
+  ): void {
+    if (ack) {
+      ack(response);
+    }
+    socket.emit(channel, response);
+  }
+
+  private extractRequestId(payload: unknown): string | undefined {
+    if (typeof payload !== 'object' || payload === null) {
+      return undefined;
+    }
+    const candidate = (payload as { requestId?: unknown }).requestId;
+    return typeof candidate === 'string' ? candidate : undefined;
+  }
+}

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -12,6 +12,7 @@ export * from './stateFactory.js';
 export * from './sim/loop.js';
 export * from './sim/simScheduler.js';
 export * from '../facade/index.js';
+export * from '../server/socketGateway.js';
 
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
 

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -7,6 +7,6 @@
     "module": "NodeNext",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "data/**/*.ts", "facade/**/*.ts"],
+  "include": ["src/**/*.ts", "data/**/*.ts", "facade/**/*.ts", "server/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add a SocketGateway that mirrors SimulationFacade events via Socket.IO with batching, throttling, and validated command handling
- cover the gateway with socket.io-client integration tests and expose it through the backend package exports
- document the public socket protocol and wire dependencies/configuration updates needed for the new transport layer

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test


------
https://chatgpt.com/codex/tasks/task_e_68cef58890a4832591b507863a16568b