### PR TITLE
Add backend fixtures, tests, and bench fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "build": "pnpm -r build",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
+    "bench": "pnpm --filter @weebbreed/backend bench",
     "prepare": "husky"
   },
   "devDependencies": {
     "@types/node": "^20.19.17",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-import-resolver-typescript": "^3.10.1",
@@ -22,6 +24,7 @@
     "lint-staged": "^15.5.2",
     "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
+    "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vite": "^7.1.6",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -41,15 +44,18 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.17)(typescript@5.9.2)
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       vite:
         specifier: ^7.1.6
-        version: 7.1.6(@types/node@20.19.17)(yaml@2.8.1)
+        version: 7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(yaml@2.8.1)
+        version: 3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1)
 
   src/backend:
     dependencies:
@@ -98,12 +104,16 @@ importers:
         version: 18.3.7(@types/react@18.3.24)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.7.0(vite@7.1.6(@types/node@20.19.17)(yaml@2.8.1))
+        version: 4.7.0(vite@7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1))
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -194,6 +204,10 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -423,6 +437,14 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -460,6 +482,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -836,6 +862,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -951,6 +986,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.5:
+    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1228,11 +1266,20 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.222:
     resolution: {integrity: sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==}
 
   emoji-regex@10.5.0:
     resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   engine.io-client@6.6.3:
     resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
@@ -1453,6 +1500,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
@@ -1510,6 +1561,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1563,6 +1618,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1659,6 +1717,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
@@ -1743,6 +1805,25 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1836,6 +1917,13 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -1879,6 +1967,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1969,6 +2061,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1994,6 +2089,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2278,6 +2377,14 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -2327,6 +2434,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2393,6 +2504,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2587,6 +2703,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -2664,6 +2788,11 @@ packages:
         optional: true
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -2786,6 +2915,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2940,6 +3071,17 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2984,6 +3126,9 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3294,7 +3439,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.6(@types/node@20.19.17)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -3302,7 +3447,26 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.6(@types/node@20.19.17)(yaml@2.8.1)
+      vite: 7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.5
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3314,13 +3478,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.6(@types/node@20.19.17)(yaml@2.8.1)
+      vite: 7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3448,6 +3612,12 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   async-function@1.0.0: {}
 
@@ -3709,9 +3879,15 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.222: {}
 
   emoji-regex@10.5.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   engine.io-client@6.6.3:
     dependencies:
@@ -4070,6 +4246,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -4138,6 +4319,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4194,6 +4384,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -4295,6 +4487,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-fullwidth-code-point@4.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
@@ -4371,6 +4565,33 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   js-tokens@4.0.0: {}
 
@@ -4489,6 +4710,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
   make-error@1.3.6: {}
 
   math-intrinsics@1.1.0: {}
@@ -4521,6 +4752,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
 
   ms@2.1.3: {}
 
@@ -4612,6 +4845,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4629,6 +4864,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 
@@ -4972,6 +5212,18 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.5.0
@@ -5026,6 +5278,12 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   text-table@0.2.0: {}
 
@@ -5091,6 +5349,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -5208,13 +5473,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@20.19.17)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.6(@types/node@20.19.17)(yaml@2.8.1)
+      vite: 7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5229,7 +5494,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.6(@types/node@20.19.17)(yaml@2.8.1):
+  vite@7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5240,13 +5505,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.17
       fsevents: 2.3.3
+      tsx: 4.20.5
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5264,8 +5530,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.6(@types/node@20.19.17)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.17)(yaml@2.8.1)
+      vite: 7.1.6(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.17)(tsx@4.20.5)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17
@@ -5352,6 +5618,18 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -9,7 +9,9 @@
     "dev": "ts-node --esm src/index.ts",
     "build": "tsc --project tsconfig.json",
     "lint": "eslint --ext .ts src data",
-    "test": "vitest --run --passWithNoTests"
+    "test": "vitest --run --passWithNoTests",
+    "test:coverage": "vitest --run --coverage",
+    "bench": "tsx src/bench.ts"
   },
   "dependencies": {
     "chokidar": "^3.5.3",

--- a/src/backend/src/bench.ts
+++ b/src/backend/src/bench.ts
@@ -1,0 +1,261 @@
+import { stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { DataIssue } from '../data/index.js';
+import { BlueprintRepository, DataLoaderError } from '../data/index.js';
+import type { BlueprintRepository as BlueprintRepositoryType } from '../data/blueprintRepository.js';
+import type { StructureBlueprint } from './state/models.js';
+import { createInitialState, loadStructureBlueprints } from './stateFactory.js';
+import { EventBus } from './lib/eventBus.js';
+import { SimulationLoop } from './sim/loop.js';
+import type { SimulationPhaseContext } from './sim/loop.js';
+import { createPhenologyConfig } from './engine/plants/phenology.js';
+import type { PhenologyState } from './engine/plants/phenology.js';
+import { updatePlantGrowth } from './engine/plants/growthModel.js';
+import { createBlueprintRepositoryStub, createStateFactoryContext } from './testing/fixtures.js';
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+process.on('uncaughtException', (error) => {
+  console.error('Benchmark run failed with an uncaught error:', error);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Benchmark run failed with an unhandled rejection:', reason);
+  process.exit(1);
+});
+
+const isDirectory = async (candidate: string): Promise<boolean> => {
+  try {
+    const stats = await stat(candidate);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const resolveDataDirectory = async (): Promise<string> => {
+  const candidates = [
+    process.env.WEEBBREED_DATA_DIR,
+    path.resolve(moduleDirectory, '../../..', 'data'),
+    path.resolve(process.cwd(), 'data'),
+    path.resolve(process.cwd(), '..', 'data'),
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    if (!(await isDirectory(candidate))) {
+      continue;
+    }
+    const blueprintsDir = path.join(candidate, 'blueprints');
+    if (await isDirectory(blueprintsDir)) {
+      return candidate;
+    }
+  }
+
+  throw new Error('Unable to locate data directory. Set WEEBBREED_DATA_DIR to override.');
+};
+
+const safeStringify = (value: unknown): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '<unserializable>';
+  }
+};
+
+const reportDataIssues = (heading: string, issues: DataIssue[]): void => {
+  if (issues.length === 0) {
+    return;
+  }
+
+  console.warn(heading);
+  for (const issue of issues) {
+    const location = issue.file ? ` (${issue.file})` : '';
+    const details = safeStringify(issue.details);
+    const suffix = details ? ` details=${details}` : '';
+    const logger = issue.level === 'error' ? console.error : console.warn;
+    logger(`  - [${issue.level.toUpperCase()}] ${issue.message}${location}${suffix}`);
+  }
+};
+
+const loadStructureBlueprintsSafe = async (
+  dataDirectory?: string,
+): Promise<StructureBlueprint[] | undefined> => {
+  if (!dataDirectory) {
+    return undefined;
+  }
+  try {
+    const blueprints = await loadStructureBlueprints(dataDirectory);
+    if (blueprints.length === 0) {
+      console.warn(
+        `No structure blueprints found in ${dataDirectory}; using fixture structure blueprints instead.`,
+      );
+      return undefined;
+    }
+    return blueprints;
+  } catch (error) {
+    console.warn(`Failed to load structure blueprints from ${dataDirectory}:`, error);
+    return undefined;
+  }
+};
+
+const createPlantPhase = (
+  repository: BlueprintRepositoryType,
+  phenologies: Map<string, PhenologyState>,
+  metrics: Map<number, { biomassDelta: number; avgVpd: number; avgHealth: number }>,
+) => {
+  return (context: SimulationPhaseContext) => {
+    const tickHours = context.tickLengthMinutes / 60;
+    let biomassDelta = 0;
+    let vpdSum = 0;
+    let healthSum = 0;
+    let plantCount = 0;
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          const strain = zone.strainId ? repository.getStrain(zone.strainId) : undefined;
+          if (!strain) {
+            continue;
+          }
+          const phenologyConfig = createPhenologyConfig(strain);
+          zone.plants = zone.plants.map((plant) => {
+            const result = updatePlantGrowth({
+              plant,
+              strain,
+              environment: zone.environment,
+              tickHours,
+              tick: context.tick,
+              phenology: phenologies.get(plant.id),
+              phenologyConfig,
+              resourceSupply: {
+                waterSupplyFraction: zone.resources.reservoirLevel,
+                nutrientSupplyFraction: zone.resources.nutrientStrength,
+              },
+            });
+            phenologies.set(plant.id, result.phenology);
+            context.events.queueMany(result.events);
+            biomassDelta += result.biomassDelta;
+            vpdSum += result.metrics.vpd.value;
+            healthSum += result.plant.health;
+            plantCount += 1;
+            return result.plant;
+          });
+          if (plantCount > 0) {
+            zone.environment.vpd = vpdSum / plantCount;
+          }
+        }
+      }
+    }
+
+    const divisor = plantCount > 0 ? plantCount : 1;
+    metrics.set(context.tick, {
+      biomassDelta,
+      avgVpd: vpdSum / divisor,
+      avgHealth: healthSum / divisor,
+    });
+  };
+};
+
+export const runBenchmark = async (ticks = Number(process.env.WEEBBREED_BENCH_TICKS ?? '24')) => {
+  console.log('Preparing benchmark run...');
+  const seed = process.env.WEEBBREED_BENCH_SEED ?? 'bench-reference';
+
+  let dataDirectory: string | undefined;
+  try {
+    dataDirectory = await resolveDataDirectory();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Data directory resolution failed: ${message}`);
+  }
+
+  let repository: BlueprintRepositoryType | undefined;
+  if (dataDirectory) {
+    try {
+      repository = await BlueprintRepository.loadFrom(dataDirectory);
+      const summary = repository.getSummary();
+      reportDataIssues('Blueprint data reported issues:', summary.issues);
+    } catch (error) {
+      if (error instanceof DataLoaderError) {
+        reportDataIssues(
+          'Blocking blueprint data issues encountered while loading repository. Falling back to fixture data.',
+          error.issues,
+        );
+      } else {
+        console.warn(`Failed to load blueprint repository from ${dataDirectory}:`, error);
+      }
+    }
+  }
+
+  const structureBlueprints = await loadStructureBlueprintsSafe(dataDirectory);
+
+  let usingFixtureRepository = false;
+  if (!repository) {
+    usingFixtureRepository = true;
+    console.warn('Using fixture repository data for benchmark run.');
+    repository = createBlueprintRepositoryStub();
+  }
+
+  const context = createStateFactoryContext(seed, {
+    repository,
+    dataDirectory,
+    structureBlueprints:
+      structureBlueprints && structureBlueprints.length > 0 ? structureBlueprints : undefined,
+  });
+
+  const state = await createInitialState(context);
+
+  const phenologies = new Map<string, PhenologyState>();
+  const metrics = new Map<number, { biomassDelta: number; avgVpd: number; avgHealth: number }>();
+  const eventBus = new EventBus();
+  const loop = new SimulationLoop({
+    state,
+    eventBus,
+    phases: {
+      updatePlants: createPlantPhase(context.repository, phenologies, metrics),
+    },
+  });
+
+  const dataDescription = dataDirectory
+    ? usingFixtureRepository
+      ? `fixture data (failed to load ${dataDirectory})`
+      : `data at ${dataDirectory}`
+    : 'fixture data (no data directory found)';
+
+  console.log(`Running benchmark with seed "${seed}" for ${ticks} ticks using ${dataDescription}.`);
+  let totalDuration = 0;
+  let totalEvents = 0;
+
+  for (let index = 0; index < ticks; index += 1) {
+    const result = await loop.processTick();
+    const tickTiming = result.phaseTimings.commit.completedAt;
+    totalDuration += tickTiming;
+    totalEvents += result.events.length;
+
+    const tickMetrics = metrics.get(result.tick) ?? { biomassDelta: 0, avgVpd: 0, avgHealth: 0 };
+    const biomassDelta = tickMetrics.biomassDelta.toFixed(3);
+    const avgVpd = tickMetrics.avgVpd.toFixed(3);
+    const avgHealth = tickMetrics.avgHealth.toFixed(3);
+
+    console.log(
+      `tick ${result.tick.toString().padStart(3, ' ')} | duration ${tickTiming.toFixed(
+        2,
+      )} ms | events ${result.events.length} | Δbiomass ${biomassDelta} g | avgVPD ${avgVpd} kPa | avgHealth ${avgHealth}`,
+    );
+  }
+
+  const averageDuration = totalDuration / Math.max(ticks, 1);
+  console.log(`Average tick duration: ${averageDuration.toFixed(2)} ms`);
+  console.log(`Total events emitted: ${totalEvents}`);
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runBenchmark().catch((error) => {
+    console.error('Benchmark run failed:', error);
+    process.exitCode = 1;
+  });
+}

--- a/src/backend/src/persistence/schemas.test.ts
+++ b/src/backend/src/persistence/schemas.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { SAVEGAME_KIND, saveGameEnvelopeSchema } from './schemas.js';
+import { createInitialState } from '../stateFactory.js';
+import { createStateFactoryContext } from '../testing/fixtures.js';
+
+describe('saveGameEnvelopeSchema', () => {
+  it('accepts a well-formed save game envelope', async () => {
+    const context = createStateFactoryContext('schema-seed');
+    const state = await createInitialState(context);
+
+    const createdAt = '2025-01-01T00:00:00.000Z';
+    const envelope = {
+      header: { kind: SAVEGAME_KIND, version: '1.0.0', createdAt },
+      metadata: {
+        tickLengthMinutes: state.metadata.tickLengthMinutes,
+        rngSeed: context.rng.getSeed(),
+      },
+      rng: context.rng.serialize(),
+      state,
+    } as const;
+
+    const parsed = saveGameEnvelopeSchema.parse(envelope);
+    expect(parsed.header.kind).toBe(SAVEGAME_KIND);
+    expect(parsed.state.metadata.gameId).toBe(state.metadata.gameId);
+    expect(parsed.state.structures).toHaveLength(state.structures.length);
+  });
+
+  it('rejects envelopes with invalid metadata', async () => {
+    const context = createStateFactoryContext('schema-seed');
+    const state = await createInitialState(context);
+    const base = {
+      header: { kind: SAVEGAME_KIND, version: '1.0.0', createdAt: '2025-01-01T00:00:00.000Z' },
+      metadata: {
+        tickLengthMinutes: state.metadata.tickLengthMinutes,
+        rngSeed: context.rng.getSeed(),
+      },
+      rng: context.rng.serialize(),
+      state,
+    } as const;
+
+    const invalid = JSON.parse(JSON.stringify(base)) as typeof base;
+    invalid.metadata.tickLengthMinutes = -5;
+    invalid.metadata.rngSeed = '';
+
+    const result = saveGameEnvelopeSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/backend/src/sim/integrationScenarios.test.ts
+++ b/src/backend/src/sim/integrationScenarios.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '../lib/eventBus.js';
+import { SimulationLoop } from './loop.js';
+import { createInitialState } from '../stateFactory.js';
+import {
+  createBlueprintRepositoryStub,
+  createCultivationMethodBlueprint,
+  createDeviceBlueprint,
+  createDevicePriceMap,
+  createStateFactoryContext,
+  createStrainBlueprint,
+  createStrainPriceMap,
+  createStructureBlueprint,
+} from '../testing/fixtures.js';
+import { createPhenologyConfig } from '../engine/plants/phenology.js';
+import type { PhenologyState } from '../engine/plants/phenology.js';
+import { updatePlantGrowth } from '../engine/plants/growthModel.js';
+import type { BlueprintRepository } from '../../data/blueprintRepository.js';
+import type { SimulationPhaseContext } from './loop.js';
+
+interface TickMetrics {
+  biomassDelta: number;
+  avgVpd: number;
+  avgStress: number;
+  avgHealth: number;
+}
+
+const buildRepository = () => {
+  const strain = createStrainBlueprint();
+  const method = createCultivationMethodBlueprint();
+  const lamp = createDeviceBlueprint({
+    kind: 'Lamp',
+    settings: { coverageArea: 12, ppfd: 900, power: 0.8 },
+  });
+  const hvac = createDeviceBlueprint({
+    kind: 'ClimateUnit',
+    settings: {
+      airflow: 400,
+      coverageArea: 12,
+      targetTemperature: 24,
+      targetTemperatureRange: [23, 25],
+    },
+  });
+  const dehumidifier = createDeviceBlueprint({ kind: 'Dehumidifier', settings: { airflow: 180 } });
+
+  return createBlueprintRepositoryStub({
+    strains: [strain],
+    cultivationMethods: [method],
+    devices: [lamp, hvac, dehumidifier],
+    devicePrices: createDevicePriceMap([
+      [
+        lamp.id,
+        {
+          capitalExpenditure: 720,
+          baseMaintenanceCostPerTick: 0.002,
+          costIncreasePer1000Ticks: 0.0004,
+        },
+      ],
+      [
+        hvac.id,
+        {
+          capitalExpenditure: 1450,
+          baseMaintenanceCostPerTick: 0.0028,
+          costIncreasePer1000Ticks: 0.0006,
+        },
+      ],
+      [
+        dehumidifier.id,
+        {
+          capitalExpenditure: 680,
+          baseMaintenanceCostPerTick: 0.0018,
+          costIncreasePer1000Ticks: 0.0005,
+        },
+      ],
+    ]),
+    strainPrices: createStrainPriceMap([[strain.id, { seedPrice: 0.6, harvestPricePerGram: 4.2 }]]),
+  });
+};
+
+const createPlantPhaseHandler = (
+  repository: BlueprintRepository,
+  phenologies: Map<string, PhenologyState>,
+  metrics: Map<number, TickMetrics>,
+) => {
+  return (context: SimulationPhaseContext) => {
+    const tickHours = context.tickLengthMinutes / 60;
+    let biomassDelta = 0;
+    let vpdSum = 0;
+    let stressSum = 0;
+    let healthSum = 0;
+    let plantCount = 0;
+
+    for (const structure of context.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          const strain = zone.strainId ? repository.getStrain(zone.strainId) : undefined;
+          if (!strain) {
+            continue;
+          }
+          const phenologyConfig = createPhenologyConfig(strain);
+          const updatedPlants = zone.plants.map((plant) => {
+            const result = updatePlantGrowth({
+              plant,
+              strain,
+              environment: zone.environment,
+              tickHours,
+              tick: context.tick,
+              phenology: phenologies.get(plant.id),
+              phenologyConfig,
+              resourceSupply: {
+                waterSupplyFraction: zone.resources.reservoirLevel,
+                nutrientSupplyFraction: zone.resources.nutrientStrength,
+              },
+            });
+            phenologies.set(plant.id, result.phenology);
+            context.events.queueMany(result.events);
+            biomassDelta += result.biomassDelta;
+            vpdSum += result.metrics.vpd.value;
+            stressSum += result.metrics.overallStress;
+            healthSum += result.plant.health;
+            plantCount += 1;
+            return result.plant;
+          });
+          zone.plants = updatedPlants;
+        }
+      }
+    }
+
+    const normaliser = plantCount > 0 ? plantCount : 1;
+    metrics.set(context.tick, {
+      biomassDelta,
+      avgVpd: vpdSum / normaliser,
+      avgStress: stressSum / normaliser,
+      avgHealth: healthSum / normaliser,
+    });
+
+    if (plantCount > 0) {
+      const averageVpd = vpdSum / plantCount;
+      for (const structure of context.state.structures) {
+        for (const room of structure.rooms) {
+          for (const zone of room.zones) {
+            zone.environment.vpd = averageVpd;
+          }
+        }
+      }
+    }
+  };
+};
+
+describe('integration scenarios', () => {
+  it('dark run keeps biomass near zero growth', async () => {
+    const repository = buildRepository();
+    const context = createStateFactoryContext('dark-run', {
+      repository,
+      structureBlueprints: [
+        createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
+      ],
+    });
+    const state = await createInitialState(context);
+    const zone = state.structures[0].rooms[0].zones[0];
+
+    zone.environment.ppfd = 0;
+    for (const device of zone.devices) {
+      if (device.kind === 'Lamp') {
+        device.settings.ppfd = 0;
+        device.settings.power = 0;
+      }
+    }
+
+    const phenologies = new Map<string, PhenologyState>();
+    const metrics = new Map<number, TickMetrics>();
+    const loop = new SimulationLoop({
+      state,
+      eventBus: new EventBus(),
+      phases: {
+        applyDevices: () => undefined,
+        deriveEnvironment: () => undefined,
+        updatePlants: createPlantPhaseHandler(repository, phenologies, metrics),
+      },
+    });
+
+    const ticks = 24;
+    const deltas: number[] = [];
+    for (let index = 0; index < ticks; index += 1) {
+      const result = await loop.processTick();
+      const tickDelta = metrics.get(result.tick)?.biomassDelta ?? 0;
+      deltas.push(tickDelta);
+      expect(result.events.every((event) => event.type === 'plant.healthAlert')).toBe(true);
+    }
+
+    for (const delta of deltas) {
+      expect(Math.abs(delta)).toBeLessThan(0.1);
+    }
+
+    const finalBiomass = state.structures
+      .flatMap((structure) => structure.rooms)
+      .flatMap((room) => room.zones)
+      .flatMap((zone) => zone.plants)
+      .reduce((sum, plant) => sum + plant.biomassDryGrams, 0);
+
+    expect(finalBiomass).toBeLessThan(0.01);
+  });
+
+  it('dry air increases VPD and stress compared to baseline', async () => {
+    const repository = buildRepository();
+    const context = createStateFactoryContext('dry-air', {
+      repository,
+      structureBlueprints: [
+        createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
+      ],
+    });
+    const state = await createInitialState(context);
+    const zone = state.structures[0].rooms[0].zones[0];
+
+    zone.environment.temperature = 26;
+    zone.environment.relativeHumidity = 0.62;
+
+    const phenologies = new Map<string, PhenologyState>();
+    const metrics = new Map<number, TickMetrics>();
+    const loop = new SimulationLoop({
+      state,
+      eventBus: new EventBus(),
+      phases: {
+        applyDevices: () => undefined,
+        deriveEnvironment: () => undefined,
+        updatePlants: createPlantPhaseHandler(repository, phenologies, metrics),
+      },
+    });
+
+    const baseline = await loop.processTick();
+    const baselineMetrics = metrics.get(baseline.tick);
+    expect(baselineMetrics).toBeDefined();
+
+    zone.environment.relativeHumidity = 0.52;
+    const dry = await loop.processTick();
+    const dryMetrics = metrics.get(dry.tick);
+
+    expect(dryMetrics).toBeDefined();
+    expect(dryMetrics!.avgVpd).toBeGreaterThan(baselineMetrics!.avgVpd);
+    expect(dryMetrics!.avgStress).toBeGreaterThan(baselineMetrics!.avgStress);
+    expect(dryMetrics!.avgHealth).toBeLessThan(baselineMetrics!.avgHealth);
+  });
+
+  it('additional lighting overcomes coverage limits for PPFD', async () => {
+    const repositorySingle = buildRepository();
+    const contextSingle = createStateFactoryContext('coverage', {
+      repository: repositorySingle,
+      structureBlueprints: [
+        createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
+      ],
+    });
+    const stateSingle = await createInitialState(contextSingle);
+    const zoneSingle = stateSingle.structures[0].rooms[0].zones[0];
+    zoneSingle.environment.ppfd = 0;
+
+    const loopSingle = new SimulationLoop({
+      state: stateSingle,
+      eventBus: new EventBus(),
+    });
+    await loopSingle.processTick();
+    const ppfdSingle = zoneSingle.environment.ppfd;
+    expect(ppfdSingle).toBeGreaterThan(0);
+
+    const repositoryDouble = buildRepository();
+    const contextDouble = createStateFactoryContext('coverage', {
+      repository: repositoryDouble,
+      structureBlueprints: [
+        createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
+      ],
+    });
+    const stateDouble = await createInitialState(contextDouble);
+    const zoneDouble = stateDouble.structures[0].rooms[0].zones[0];
+    zoneDouble.environment.ppfd = 0;
+    const lamp = zoneDouble.devices.find((device) => device.kind === 'Lamp');
+    if (lamp) {
+      zoneDouble.devices.push({ ...lamp, id: `${lamp.id}-extra` });
+    }
+
+    const loopDouble = new SimulationLoop({
+      state: stateDouble,
+      eventBus: new EventBus(),
+    });
+    await loopDouble.processTick();
+    const ppfdDouble = zoneDouble.environment.ppfd;
+
+    expect(ppfdDouble).toBeGreaterThan(ppfdSingle * 1.8);
+    if (lamp?.settings?.ppfd) {
+      expect(ppfdDouble).toBeLessThanOrEqual(lamp.settings.ppfd * 2);
+    }
+  });
+});

--- a/src/backend/src/stateFactory.test.ts
+++ b/src/backend/src/stateFactory.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskDefinitionMap } from './state/models.js';
+import { createInitialState } from './stateFactory.js';
+import {
+  createBlueprintRepositoryStub,
+  createCultivationMethodBlueprint,
+  createDeviceBlueprint,
+  createDevicePriceMap,
+  createStateFactoryContext,
+  createStrainBlueprint,
+  createStrainPriceMap,
+  createStructureBlueprint,
+} from './testing/fixtures.js';
+
+describe('createInitialState', () => {
+  it('initialises backlog tasks using provided definitions', async () => {
+    const strain = createStrainBlueprint();
+    const method = createCultivationMethodBlueprint({ areaPerPlant: 1.2 });
+    const lamp = createDeviceBlueprint({ kind: 'Lamp', settings: { coverageArea: 10, ppfd: 750 } });
+    const hvac = createDeviceBlueprint({
+      kind: 'ClimateUnit',
+      settings: {
+        airflow: 360,
+        coverageArea: 12,
+        targetTemperature: 24,
+        targetTemperatureRange: [23, 25],
+      },
+    });
+
+    const repository = createBlueprintRepositoryStub({
+      strains: [strain],
+      cultivationMethods: [method],
+      devices: [lamp, hvac],
+      devicePrices: createDevicePriceMap([
+        [
+          lamp.id,
+          {
+            capitalExpenditure: 650,
+            baseMaintenanceCostPerTick: 0.002,
+            costIncreasePer1000Ticks: 0.0005,
+          },
+        ],
+        [
+          hvac.id,
+          {
+            capitalExpenditure: 1200,
+            baseMaintenanceCostPerTick: 0.0025,
+            costIncreasePer1000Ticks: 0.0007,
+          },
+        ],
+      ]),
+      strainPrices: createStrainPriceMap([
+        [strain.id, { seedPrice: 0.6, harvestPricePerGram: 4.1 }],
+      ]),
+    });
+
+    const taskDefinitions: TaskDefinitionMap = {
+      execute_planting_plan: {
+        id: 'execute_planting_plan',
+        costModel: { basis: 'perAction', laborMinutes: 120 },
+        priority: 8,
+        requiredRole: 'Gardener',
+        requiredSkill: 'Gardening',
+        minSkillLevel: 2,
+        description: 'Execute planting plan',
+      },
+      refill_supplies_water: {
+        id: 'refill_supplies_water',
+        costModel: { basis: 'perAction', laborMinutes: 45 },
+        priority: 6,
+        requiredRole: 'Operator',
+        requiredSkill: 'Logistics',
+        minSkillLevel: 1,
+        description: 'Refill the water reservoir',
+      },
+      maintain_device: {
+        id: 'maintain_device',
+        costModel: { basis: 'perAction', laborMinutes: 180 },
+        priority: 5,
+        requiredRole: 'Technician',
+        requiredSkill: 'Maintenance',
+        minSkillLevel: 3,
+        description: 'Maintain installed devices',
+      },
+    };
+
+    const context = createStateFactoryContext('task-seed', {
+      repository,
+      structureBlueprints: [
+        createStructureBlueprint({ footprint: { length: 10, width: 6, height: 4 } }),
+      ],
+      taskDefinitions,
+    });
+
+    const state = await createInitialState(context);
+
+    expect(state.tasks.backlog).toHaveLength(3);
+    const byDefinition = Object.fromEntries(
+      state.tasks.backlog.map((task) => [task.definitionId, task]),
+    ) as Record<string, (typeof state.tasks.backlog)[number]>;
+
+    const planting = byDefinition.execute_planting_plan;
+    expect(planting.priority).toBe(taskDefinitions.execute_planting_plan.priority);
+    expect(planting.dueTick).toBe(Math.round(taskDefinitions.execute_planting_plan.priority * 4));
+    expect(planting.metadata).toMatchObject({ description: 'Execute planting plan' });
+
+    const refill = byDefinition.refill_supplies_water;
+    expect(refill.priority).toBe(taskDefinitions.refill_supplies_water.priority);
+    expect(refill.metadata).toMatchObject({
+      zoneName: 'Zone A',
+      structureName: 'Reference Warehouse',
+    });
+
+    const maintenance = byDefinition.maintain_device;
+    expect(maintenance.priority).toBe(taskDefinitions.maintain_device.priority);
+    expect(maintenance.metadata).toMatchObject({ deviceCount: expect.any(Number) });
+  });
+
+  it('produces deterministic ids and ordering for identical seeds', async () => {
+    const contextFactory = () =>
+      createStateFactoryContext('deterministic-seed', {
+        repository: createBlueprintRepositoryStub(),
+        structureBlueprints: [createStructureBlueprint()],
+      });
+
+    const firstState = await createInitialState(contextFactory());
+    const secondState = await createInitialState(contextFactory());
+
+    expect(firstState.tasks.backlog).toEqual(secondState.tasks.backlog);
+
+    const firstZone = firstState.structures[0]?.rooms[0]?.zones[0];
+    const secondZone = secondState.structures[0]?.rooms[0]?.zones[0];
+    expect(firstZone).toBeDefined();
+    expect(secondZone).toBeDefined();
+
+    const firstPlantIds = firstZone?.plants.map((plant) => plant.id);
+    const secondPlantIds = secondZone?.plants.map((plant) => plant.id);
+    expect(firstPlantIds).toEqual(secondPlantIds);
+
+    const firstDeviceIds = firstZone?.devices.map((device) => device.id);
+    const secondDeviceIds = secondZone?.devices.map((device) => device.id);
+    expect(firstDeviceIds).toEqual(secondDeviceIds);
+  });
+});

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -4,6 +4,13 @@ import path from 'node:path';
 export default defineConfig({
   test: {
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/testing/**'],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure backend Vitest coverage reporting and expose coverage/bench commands
- add shared fixture helpers and new unit/integration tests for plants, tasks, schemas, and cost accounting
- refactor the benchmark runner to resolve data directories safely, fall back to fixture data, and log deterministic metrics

## Testing
- npm run bench
- pnpm --filter @weebbreed/backend test
- pnpm --filter @weebbreed/backend test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68cefb0cd4b88325a7b4984393c9d971