### PR TITLE
feat(frontend): bootstrap simulation dashboard shell

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,15 +77,30 @@ importers:
 
   src/frontend:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.66.7
+        version: 5.89.0(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.66.7
+        version: 5.89.0(@tanstack/react-query@5.89.0(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.10.7
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      i18next:
+        specifier: ^25.4.1
+        version: 25.5.2(typescript@5.9.2)
+      i18next-browser-languagedetector:
+        specifier: ^8.0.5
+        version: 8.2.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-i18next:
+        specifier: ^15.5.2
+        version: 15.7.3(i18next@25.5.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       recharts:
         specifier: ^2.8.0
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -605,6 +620,23 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@tanstack/query-core@5.89.0':
+    resolution: {integrity: sha512-joFV1MuPhSLsKfTzwjmPDrp8ENfZ9N23ymFu07nLfn3JCkSHy0CFgsyhHTJOmWaumC/WiNIKM0EJyduCF/Ih/Q==}
+
+  '@tanstack/query-devtools@5.87.3':
+    resolution: {integrity: sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==}
+
+  '@tanstack/react-query-devtools@5.89.0':
+    resolution: {integrity: sha512-Syc4UjZeIJCkXCRGyQcWwlnv89JNb98MMg/DAkFCV3rwOcknj98+nG3Nm6xLXM6ne9sK6RZeDJMPLKZUh6NUGA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.89.0
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.89.0':
+    resolution: {integrity: sha512-SXbtWSTSRXyBOe80mszPxpEbaN4XPRUp/i0EfQK1uyj3KCk/c8FuPJNIRwzOVe/OU3rzxrYtiNabsAmk1l714A==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -1622,6 +1654,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1638,6 +1673,17 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  i18next-browser-languagedetector@8.2.0:
+    resolution: {integrity: sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==}
+
+  i18next@25.5.2:
+    resolution: {integrity: sha512-lW8Zeh37i/o0zVr+NoCHfNnfvVw+M6FQbRp36ZZ/NyHDJ3NJVpp2HhAUyU9WafL5AssymNoOjMRB48mmx2P6Hw==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2159,6 +2205,22 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-i18next@15.7.3:
+    resolution: {integrity: sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==}
+    peerDependencies:
+      i18next: '>= 25.4.1'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2652,6 +2714,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -3201,6 +3267,21 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@tanstack/query-core@5.89.0': {}
+
+  '@tanstack/query-devtools@5.87.3': {}
+
+  '@tanstack/react-query-devtools@5.89.0(@tanstack/react-query@5.89.0(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.87.3
+      '@tanstack/react-query': 5.89.0(react@18.3.1)
+      react: 18.3.1
+
+  '@tanstack/react-query@5.89.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.89.0
+      react: 18.3.1
 
   '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -4387,6 +4468,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -4404,6 +4489,16 @@ snapshots:
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
+
+  i18next-browser-languagedetector@8.2.0:
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  i18next@25.5.2(typescript@5.9.2):
+    dependencies:
+      '@babel/runtime': 7.28.4
+    optionalDependencies:
+      typescript: 5.9.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -4917,6 +5012,16 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-i18next@15.7.3(i18next@25.5.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      html-parse-stringify: 3.0.1
+      i18next: 25.5.2(typescript@5.9.2)
+      react: 18.3.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+      typescript: 5.9.2
 
   react-is@16.13.1: {}
 
@@ -5549,6 +5654,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WeedBreed Simulation Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -11,8 +11,13 @@
   },
   "dependencies": {
     "@tanstack/react-table": "^8.10.7",
+    "@tanstack/react-query": "^5.66.7",
+    "@tanstack/react-query-devtools": "^5.66.7",
+    "i18next": "^25.4.1",
+    "i18next-browser-languagedetector": "^8.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.5.2",
     "recharts": "^2.8.0",
     "socket.io-client": "^4.7.5",
     "zustand": "^4.5.2"

--- a/src/frontend/src/App.module.css
+++ b/src/frontend/src/App.module.css
@@ -1,0 +1,110 @@
+.app {
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: var(--space-7) var(--space-6);
+  max-width: var(--layout-max-width);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-5);
+  padding: var(--space-6);
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.88));
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-strong);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.6vw, 2.4rem);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.subtitle {
+  margin: var(--space-2) 0 0;
+  max-width: 48ch;
+  color: var(--color-text-secondary);
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.statusLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-muted);
+}
+
+.statusValue {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.connected {
+  border-color: rgba(52, 211, 153, 0.25);
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--color-positive);
+}
+
+.connecting {
+  border-color: rgba(250, 204, 21, 0.25);
+  background: rgba(250, 204, 21, 0.12);
+  color: var(--color-warning);
+}
+
+.disconnected,
+.idle {
+  border-color: rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.error {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--color-danger);
+}
+
+.main {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.placeholder {
+  padding: var(--space-6);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.placeholder h2 {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.placeholder p {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,0 +1,77 @@
+import { Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './App.module.css';
+import { EventLog } from './components/EventLog';
+import { ModalRoot } from './components/ModalRoot';
+import { NavigationTabs } from './components/NavigationTabs';
+import { SimulationControls } from './components/SimulationControls';
+import { SimulationOverview } from './components/SimulationOverview';
+import { useSimulationBridge } from './hooks/useSimulationBridge';
+import { useAppStore } from './store';
+
+const PlaceholderView = ({ translationKey }: { translationKey: string }) => {
+  const { t } = useTranslation('simulation');
+
+  return (
+    <section className={styles.placeholder}>
+      <h2>{t('labels.inDevelopment')}</h2>
+      <p>{t(translationKey)}</p>
+    </section>
+  );
+};
+
+const App = () => {
+  const { t } = useTranslation(['common', 'simulation']);
+  const currentView = useAppStore((state) => state.currentView);
+  const bridge = useSimulationBridge({ autoConnect: true });
+
+  return (
+    <div className={styles.app}>
+      <header className={styles.header}>
+        <div>
+          <h1 className={styles.title}>{t('common:appTitle')}</h1>
+          <p className={styles.subtitle}>{t('common:tagline')}</p>
+        </div>
+        <div className={styles.status}>
+          <span className={styles.statusLabel}>{t('simulation:labels.connectionStatus')}</span>
+          <span className={`${styles.statusValue} ${styles[bridge.status] ?? ''}`}>
+            {t(`simulation:connection.${bridge.status}`)}
+            {bridge.socketId ? ` · ${bridge.socketId}` : ''}
+          </span>
+        </div>
+      </header>
+
+      <NavigationTabs />
+
+      <main className={styles.main}>
+        {currentView === 'overview' ? (
+          <Fragment>
+            <SimulationControls bridge={bridge} />
+            <SimulationOverview />
+            <EventLog />
+          </Fragment>
+        ) : null}
+
+        {currentView === 'zones' ? (
+          <PlaceholderView translationKey="views.zonesComingSoon" />
+        ) : null}
+
+        {currentView === 'plants' ? (
+          <PlaceholderView translationKey="views.plantsComingSoon" />
+        ) : null}
+
+        {currentView === 'devices' ? (
+          <PlaceholderView translationKey="views.devicesComingSoon" />
+        ) : null}
+
+        {currentView === 'settings' ? (
+          <PlaceholderView translationKey="views.settingsDescription" />
+        ) : null}
+      </main>
+
+      <ModalRoot bridge={bridge} />
+    </div>
+  );
+};
+
+export default App;

--- a/src/frontend/src/components/EventLog.module.css
+++ b/src/frontend/src/components/EventLog.module.css
@@ -1,0 +1,88 @@
+.card {
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h2 {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.count {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.empty {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.list li {
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.eventHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.eventType {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.eventMeta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.message {
+  margin: var(--space-2) 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.debug {
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.info {
+  border-color: rgba(139, 92, 246, 0.25);
+}
+
+.warning {
+  border-color: rgba(250, 204, 21, 0.35);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.error {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.1);
+}

--- a/src/frontend/src/components/EventLog.tsx
+++ b/src/frontend/src/components/EventLog.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import { useAppStore } from '../store';
+import styles from './EventLog.module.css';
+
+const severityToClass: Record<string, string> = {
+  debug: styles.debug,
+  info: styles.info,
+  warning: styles.warning,
+  error: styles.error,
+};
+
+export const EventLog = () => {
+  const { t } = useTranslation('simulation');
+  const events = useAppStore((state) => state.events);
+
+  return (
+    <section className={styles.card}>
+      <header className={styles.header}>
+        <h2>{t('labels.eventLog')}</h2>
+        <span className={styles.count}>{t('labels.totalEvents', { count: events.length })}</span>
+      </header>
+      {events.length === 0 ? (
+        <p className={styles.empty}>{t('events.empty')}</p>
+      ) : (
+        <ul className={styles.list}>
+          {events
+            .slice()
+            .reverse()
+            .map((event) => {
+              const severityClass = event.severity ? severityToClass[event.severity] : styles.info;
+              return (
+                <li
+                  key={`${event.type}-${event.tick ?? 'unknown'}-${event.ts ?? Math.random()}`}
+                  className={severityClass}
+                >
+                  <div className={styles.eventHeader}>
+                    <span className={styles.eventType}>{event.type}</span>
+                    {event.tick !== undefined ? (
+                      <span className={styles.eventMeta}>#{event.tick}</span>
+                    ) : null}
+                  </div>
+                  {event.message ? <p className={styles.message}>{event.message}</p> : null}
+                </li>
+              );
+            })}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/src/frontend/src/components/ModalRoot.module.css
+++ b/src/frontend/src/components/ModalRoot.module.css
@@ -1,0 +1,100 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+}
+
+.modal {
+  width: min(480px, 100%);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-strong);
+  padding: var(--space-5);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.header h2 {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.closeButton {
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.closeButton:hover {
+  color: var(--color-text-secondary);
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.form {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.select,
+input[type='number'] {
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.cancel,
+.confirm {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.cancel {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--color-text-muted);
+}
+
+.cancel:hover {
+  color: var(--color-text-secondary);
+}
+
+.confirm {
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.85), rgba(139, 92, 246, 0.8));
+  border: 1px solid rgba(124, 58, 237, 0.45);
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 32px -20px rgba(124, 58, 237, 0.85);
+}
+
+.confirm:hover {
+  transform: translateY(-1px);
+}

--- a/src/frontend/src/components/ModalRoot.tsx
+++ b/src/frontend/src/components/ModalRoot.tsx
@@ -1,0 +1,89 @@
+import { FormEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SimulationBridgeHandle } from '../hooks/useSimulationBridge';
+import { useAppStore } from '../store';
+import styles from './ModalRoot.module.css';
+
+interface ModalRootProps {
+  bridge: SimulationBridgeHandle;
+}
+
+export const ModalRoot = ({ bridge }: ModalRootProps) => {
+  const { t } = useTranslation('simulation');
+  const activeModal = useAppStore((state) => state.activeModal);
+  const closeModal = useAppStore((state) => state.closeModal);
+  const [target, setTarget] = useState('temperature');
+  const [value, setValue] = useState(24);
+
+  if (!activeModal) {
+    return null;
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    bridge.sendControlCommand({ action: 'setSetpoint', target, value });
+    closeModal();
+  };
+
+  return (
+    <div className={styles.backdrop} role="presentation" onClick={closeModal}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className={styles.header}>
+          <h2>{activeModal.title ?? t('modals.settingsTitle')}</h2>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={closeModal}
+            aria-label={t('modals.close')}
+          >
+            ×
+          </button>
+        </header>
+        <p className={styles.description}>
+          {activeModal.description ?? t('modals.settingsDescription')}
+        </p>
+        <form className={styles.form} onSubmit={handleSubmit}>
+          <label className={styles.label} htmlFor="setpoint-target">
+            {t('modals.setpointTarget')}
+          </label>
+          <select
+            id="setpoint-target"
+            value={target}
+            onChange={(event) => setTarget(event.target.value)}
+            className={styles.select}
+          >
+            <option value="temperature">{t('labels.temperature')}</option>
+            <option value="humidity">{t('labels.humidity')}</option>
+            <option value="co2">{t('labels.co2')}</option>
+            <option value="ppfd">{t('labels.ppfd')}</option>
+          </select>
+
+          <label className={styles.label} htmlFor="setpoint-value">
+            {t('modals.setpointValue')}
+          </label>
+          <input
+            id="setpoint-value"
+            type="number"
+            step={0.5}
+            value={value}
+            onChange={(event) => setValue(Number(event.target.value))}
+          />
+
+          <div className={styles.actions}>
+            <button type="button" onClick={closeModal} className={styles.cancel}>
+              {t('modals.cancel')}
+            </button>
+            <button type="submit" className={styles.confirm}>
+              {t('modals.apply')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/components/NavigationTabs.module.css
+++ b/src/frontend/src/components/NavigationTabs.module.css
@@ -1,0 +1,54 @@
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.tab {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.tab:hover {
+  color: var(--color-text-secondary);
+  border-color: rgba(139, 92, 246, 0.25);
+}
+
+.active {
+  color: var(--color-text-primary);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.85), rgba(139, 92, 246, 0.8));
+  border-color: rgba(124, 58, 237, 0.45);
+  box-shadow: 0 12px 30px -18px rgba(124, 58, 237, 0.75);
+}
+
+.historyButton {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--color-text-secondary);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.historyButton:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: rgba(139, 92, 246, 0.35);
+}

--- a/src/frontend/src/components/NavigationTabs.tsx
+++ b/src/frontend/src/components/NavigationTabs.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { useAppStore } from '../store';
+import type { NavigationView } from '../store';
+import styles from './NavigationTabs.module.css';
+
+const tabs: NavigationView[] = ['overview', 'zones', 'plants', 'devices', 'settings'];
+
+export const NavigationTabs = () => {
+  const { t } = useTranslation('navigation');
+  const currentView = useAppStore((state) => state.currentView);
+  const setCurrentView = useAppStore((state) => state.setCurrentView);
+  const goBack = useAppStore((state) => state.goBack);
+  const history = useAppStore((state) => state.history);
+
+  return (
+    <nav className={styles.nav}>
+      <div className={styles.tabs}>
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setCurrentView(tab)}
+            className={`${styles.tab} ${tab === currentView ? styles.active : ''}`}
+          >
+            {t(tab)}
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        className={styles.historyButton}
+        onClick={goBack}
+        disabled={history.length === 0}
+      >
+        {t('goBack')}
+      </button>
+    </nav>
+  );
+};

--- a/src/frontend/src/components/SimulationControls.module.css
+++ b/src/frontend/src/components/SimulationControls.module.css
@@ -1,0 +1,111 @@
+.controls {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--color-text-secondary);
+}
+
+.connectionActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.actions button,
+.ghostButton,
+.secondary,
+.primary {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition:
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.actions button {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(37, 99, 235, 0.82));
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 28px -18px rgba(59, 130, 246, 0.85);
+}
+
+.actions button:hover {
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(139, 92, 246, 0.18);
+  color: var(--color-text-secondary);
+  border-color: rgba(139, 92, 246, 0.35);
+}
+
+.secondary:hover {
+  color: var(--color-text-primary);
+}
+
+.ghostButton {
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--color-text-muted);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.ghostButton:hover {
+  color: var(--color-text-secondary);
+  border-color: rgba(139, 92, 246, 0.3);
+}
+
+.tickLength {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.tickLength label {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tickLengthInputRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.tickLength input {
+  max-width: 6rem;
+}
+
+.primary {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.85), rgba(52, 211, 153, 0.75));
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 32px -20px rgba(16, 185, 129, 0.85);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+}

--- a/src/frontend/src/components/SimulationControls.tsx
+++ b/src/frontend/src/components/SimulationControls.tsx
@@ -1,0 +1,78 @@
+import { FormEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SimulationBridgeHandle } from '../hooks/useSimulationBridge';
+import { useAppStore } from '../store';
+import styles from './SimulationControls.module.css';
+
+interface SimulationControlsProps {
+  bridge: SimulationBridgeHandle;
+}
+
+export const SimulationControls = ({ bridge }: SimulationControlsProps) => {
+  const { t } = useTranslation('simulation');
+  const [tickLength, setTickLength] = useState(3);
+  const openModal = useAppStore((state) => state.openModal);
+
+  const handleTickLengthSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (tickLength <= 0) {
+      return;
+    }
+
+    bridge.sendControlCommand({ action: 'setTickLength', minutes: tickLength });
+  };
+
+  return (
+    <section className={styles.controls}>
+      <header className={styles.header}>
+        <h2>{t('labels.controls')}</h2>
+        <div className={styles.connectionActions}>
+          <button type="button" onClick={bridge.connect} className={styles.ghostButton}>
+            {t('controls.connect')}
+          </button>
+          <button type="button" onClick={bridge.disconnect} className={styles.ghostButton}>
+            {t('controls.disconnect')}
+          </button>
+        </div>
+      </header>
+      <div className={styles.actions}>
+        <button type="button" onClick={() => bridge.sendControlCommand({ action: 'play' })}>
+          {t('controls.play')}
+        </button>
+        <button type="button" onClick={() => bridge.sendControlCommand({ action: 'pause' })}>
+          {t('controls.pause')}
+        </button>
+        <button type="button" onClick={() => bridge.sendControlCommand({ action: 'step' })}>
+          {t('controls.step')}
+        </button>
+        <button type="button" onClick={() => bridge.sendControlCommand({ action: 'fastForward' })}>
+          {t('controls.fastForward')}
+        </button>
+        <button
+          type="button"
+          onClick={() => openModal({ kind: 'settings' })}
+          className={styles.secondary}
+        >
+          {t('controls.openSettings')}
+        </button>
+      </div>
+      <form className={styles.tickLength} onSubmit={handleTickLengthSubmit}>
+        <label htmlFor="tick-length">{t('controls.tickLength')}</label>
+        <div className={styles.tickLengthInputRow}>
+          <input
+            id="tick-length"
+            name="tickLength"
+            type="number"
+            min={0.5}
+            step={0.5}
+            value={tickLength}
+            onChange={(event) => setTickLength(Number(event.target.value))}
+          />
+          <button type="submit" className={styles.primary}>
+            {t('controls.apply')}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/frontend/src/components/SimulationOverview.module.css
+++ b/src/frontend/src/components/SimulationOverview.module.css
@@ -1,0 +1,94 @@
+.card {
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-4);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-4);
+  align-items: center;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--color-text-secondary);
+}
+
+.meta {
+  margin: var(--space-1) 0 0;
+  color: var(--color-text-muted);
+}
+
+.metrics {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.metricLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.metricValue {
+  display: block;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.environments {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.environmentCard {
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.environmentHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+}
+
+.environmentMetrics {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.environmentMetrics div {
+  display: flex;
+  justify-content: space-between;
+  font-feature-settings: 'tnum';
+}
+
+.environmentMetrics dt {
+  color: var(--color-text-muted);
+}
+
+.environmentMetrics dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/frontend/src/components/SimulationOverview.tsx
+++ b/src/frontend/src/components/SimulationOverview.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppStore } from '../store';
+import type { SimulationEnvironmentSnapshot } from '../types/simulation';
+import styles from './SimulationOverview.module.css';
+
+const formatTimestamp = (timestamp: number) => {
+  try {
+    return new Date(timestamp).toLocaleString();
+  } catch (error) {
+    return String(timestamp);
+  }
+};
+
+const normalizeEnv = (
+  env?: SimulationEnvironmentSnapshot | SimulationEnvironmentSnapshot[],
+): SimulationEnvironmentSnapshot[] => {
+  if (!env) {
+    return [];
+  }
+
+  return Array.isArray(env) ? env : [env];
+};
+
+export const SimulationOverview = () => {
+  const { t } = useTranslation('simulation');
+  const snapshot = useAppStore((state) => state.lastSnapshot);
+  const lastTick = useAppStore((state) => state.lastTickCompleted);
+  const plantCount = useAppStore((state) => Object.keys(state.plants).length);
+
+  const environments = useMemo(() => normalizeEnv(snapshot?.env), [snapshot]);
+
+  if (!snapshot) {
+    return (
+      <section className={styles.card}>
+        <header className={styles.header}>
+          <h2>{t('labels.overview')}</h2>
+        </header>
+        <p className={styles.placeholder}>{t('labels.noData')}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.card}>
+      <header className={styles.header}>
+        <div>
+          <h2>{t('labels.overview')}</h2>
+          <p className={styles.meta}>{t('labels.latestTick', { tick: snapshot.tick })}</p>
+        </div>
+        <div className={styles.metrics}>
+          <div>
+            <span className={styles.metricLabel}>{t('labels.tickTimestamp')}</span>
+            <span className={styles.metricValue}>{formatTimestamp(snapshot.ts)}</span>
+          </div>
+          <div>
+            <span className={styles.metricLabel}>{t('labels.plantCount')}</span>
+            <span className={styles.metricValue}>{plantCount}</span>
+          </div>
+          {lastTick?.durationMs ? (
+            <div>
+              <span className={styles.metricLabel}>{t('labels.tickDuration')}</span>
+              <span className={styles.metricValue}>{lastTick.durationMs.toFixed(1)} ms</span>
+            </div>
+          ) : null}
+        </div>
+      </header>
+
+      <div className={styles.environments}>
+        {environments.map((env) => (
+          <article key={env.zoneId} className={styles.environmentCard}>
+            <header className={styles.environmentHeader}>
+              <h3>{t('labels.zoneTitle', { zoneId: env.zoneId })}</h3>
+            </header>
+            <dl className={styles.environmentMetrics}>
+              <div>
+                <dt>{t('labels.temperature')}</dt>
+                <dd>{env.temperature.toFixed(1)} °C</dd>
+              </div>
+              <div>
+                <dt>{t('labels.humidity')}</dt>
+                <dd>{(env.humidity * 100).toFixed(0)}%</dd>
+              </div>
+              <div>
+                <dt>{t('labels.co2')}</dt>
+                <dd>{env.co2.toLocaleString()} ppm</dd>
+              </div>
+              <div>
+                <dt>{t('labels.ppfd')}</dt>
+                <dd>{env.ppfd.toFixed(0)} µmol·m⁻²·s⁻¹</dd>
+              </div>
+              <div>
+                <dt>{t('labels.vpd')}</dt>
+                <dd>{env.vpd?.toFixed(2) ?? '—'} kPa</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/frontend/src/hooks/useSimulationBridge.ts
+++ b/src/frontend/src/hooks/useSimulationBridge.ts
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { io, type Socket } from 'socket.io-client';
+import type {
+  SimulationConfigUpdate,
+  SimulationControlCommand,
+  SimulationEvent,
+  SimulationSnapshot,
+  SimulationTickEvent,
+} from '../types/simulation';
+import { useAppStore } from '../store';
+import type { ConnectionStatus } from '../store';
+
+type AnyHandler = (...args: unknown[]) => void;
+
+interface PendingSubscription {
+  event: string;
+  handler: AnyHandler;
+}
+
+export interface UseSimulationBridgeOptions {
+  url?: string;
+  autoConnect?: boolean;
+  debug?: boolean;
+}
+
+export interface SimulationBridgeHandle {
+  status: ConnectionStatus;
+  socketId: string | null;
+  connect: () => void;
+  disconnect: () => void;
+  sendControlCommand: (command: SimulationControlCommand) => void;
+  sendConfigUpdate: (update: SimulationConfigUpdate) => void;
+  subscribe: <TPayload = unknown>(
+    event: string,
+    handler: (payload: TPayload) => void,
+  ) => () => void;
+}
+
+const toSimulationEvent = (payload: unknown): SimulationEvent => {
+  if (payload && typeof payload === 'object' && 'type' in (payload as Record<string, unknown>)) {
+    return payload as SimulationEvent;
+  }
+
+  return {
+    type: 'domain.untyped',
+    severity: 'debug',
+    message: typeof payload === 'string' ? payload : JSON.stringify(payload),
+  };
+};
+
+export const useSimulationBridge = (
+  options: UseSimulationBridgeOptions = {},
+): SimulationBridgeHandle => {
+  const { url = '/socket.io', autoConnect = true, debug = false } = options;
+  const setConnectionStatus = useAppStore((state) => state.setConnectionStatus);
+  const ingestSnapshot = useAppStore((state) => state.ingestSnapshot);
+  const appendEvents = useAppStore((state) => state.appendEvents);
+  const registerTickCompleted = useAppStore((state) => state.registerTickCompleted);
+  const setCommandHandlers = useAppStore((state) => state.setCommandHandlers);
+  const status = useAppStore((state) => state.connectionStatus);
+
+  const socketRef = useRef<Socket | null>(null);
+  const pendingSubscriptionsRef = useRef<PendingSubscription[]>([]);
+  const [socketId, setSocketId] = useState<string | null>(null);
+
+  const sendControlCommand = useCallback((command: SimulationControlCommand) => {
+    const socket = socketRef.current;
+    if (!socket || !socket.connected) {
+      console.warn('[useSimulationBridge] No active socket to send control command', command);
+      return;
+    }
+
+    socket.emit('simulationControl', { type: 'simulationControl', ...command });
+  }, []);
+
+  const sendConfigUpdate = useCallback((update: SimulationConfigUpdate) => {
+    const socket = socketRef.current;
+    if (!socket || !socket.connected) {
+      console.warn('[useSimulationBridge] No active socket to send config update', update);
+      return;
+    }
+
+    socket.emit('config.update', update);
+  }, []);
+
+  useEffect(() => {
+    setCommandHandlers(sendControlCommand, sendConfigUpdate);
+  }, [sendConfigUpdate, sendControlCommand, setCommandHandlers]);
+
+  const subscribe = useCallback(<TPayload>(event: string, handler: (payload: TPayload) => void) => {
+    const wrapped: AnyHandler = (payload: unknown) => handler(payload as TPayload);
+    const socket = socketRef.current;
+
+    if (socket) {
+      socket.on(event, wrapped);
+      return () => socket.off(event, wrapped);
+    }
+
+    const subscription: PendingSubscription = { event, handler: wrapped };
+    pendingSubscriptionsRef.current = [...pendingSubscriptionsRef.current, subscription];
+
+    return () => {
+      pendingSubscriptionsRef.current = pendingSubscriptionsRef.current.filter(
+        (candidate) => candidate !== subscription,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    const socket = io(url, {
+      autoConnect: false,
+      transports: ['websocket'],
+    });
+
+    socketRef.current = socket;
+
+    const flushSubscriptions = () => {
+      if (pendingSubscriptionsRef.current.length === 0) {
+        return;
+      }
+
+      for (const subscription of pendingSubscriptionsRef.current) {
+        socket.on(subscription.event, subscription.handler);
+      }
+
+      pendingSubscriptionsRef.current = [];
+    };
+
+    const handleConnect = () => {
+      setSocketId(socket.id ?? null);
+      setConnectionStatus('connected');
+      flushSubscriptions();
+    };
+
+    const handleDisconnect = () => {
+      setSocketId(null);
+      setConnectionStatus('disconnected');
+    };
+
+    const handleConnectError = (error: Error) => {
+      setConnectionStatus('error', error.message);
+    };
+
+    const handleSimulationUpdate = (payload: SimulationSnapshot) => {
+      ingestSnapshot(payload);
+    };
+
+    const handleTickCompleted = (payload: SimulationTickEvent) => {
+      registerTickCompleted(payload);
+    };
+
+    const handleDomainEvent = (payload: unknown) => {
+      appendEvents([toSimulationEvent(payload)]);
+    };
+
+    socket.on('connect', handleConnect);
+    socket.on('disconnect', handleDisconnect);
+    socket.on('connect_error', handleConnectError);
+    socket.on('error', handleConnectError);
+    socket.on('simulationUpdate', handleSimulationUpdate);
+    socket.on('sim.tickCompleted', handleTickCompleted);
+    socket.on('domain.event', handleDomainEvent);
+    socket.on('simulation.event', handleDomainEvent);
+
+    if (debug) {
+      socket.onAny((event, payload) => {
+        if (
+          event === 'simulationUpdate' ||
+          event === 'sim.tickCompleted' ||
+          event === 'domain.event' ||
+          event === 'simulation.event'
+        ) {
+          return;
+        }
+
+        console.debug('[useSimulationBridge] event', event, payload);
+      });
+    }
+
+    if (autoConnect) {
+      setConnectionStatus('connecting');
+      socket.connect();
+    }
+
+    return () => {
+      socket.removeAllListeners();
+      socket.disconnect();
+      socketRef.current = null;
+      setSocketId(null);
+      setConnectionStatus('disconnected');
+    };
+  }, [
+    appendEvents,
+    autoConnect,
+    debug,
+    ingestSnapshot,
+    registerTickCompleted,
+    setConnectionStatus,
+    url,
+  ]);
+
+  const connect = useCallback(() => {
+    const socket = socketRef.current;
+    if (!socket) {
+      return;
+    }
+
+    if (socket.connected) {
+      return;
+    }
+
+    setConnectionStatus('connecting');
+    socket.connect();
+  }, [setConnectionStatus]);
+
+  const disconnect = useCallback(() => {
+    socketRef.current?.disconnect();
+  }, []);
+
+  return useMemo(
+    () => ({
+      status,
+      socketId,
+      connect,
+      disconnect,
+      sendControlCommand,
+      sendConfigUpdate,
+      subscribe,
+    }),
+    [connect, disconnect, sendConfigUpdate, sendControlCommand, socketId, status, subscribe],
+  );
+};

--- a/src/frontend/src/i18n/index.ts
+++ b/src/frontend/src/i18n/index.ts
@@ -1,0 +1,43 @@
+import { createInstance, type i18n as I18nInstance } from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import common from './locales/en/common.json';
+import navigation from './locales/en/navigation.json';
+import simulation from './locales/en/simulation.json';
+
+const resources = {
+  en: {
+    common,
+    navigation,
+    simulation,
+  },
+};
+
+export const initI18n = (): I18nInstance => {
+  const instance = createInstance();
+
+  instance
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      resources,
+      lng: 'en',
+      fallbackLng: 'en',
+      supportedLngs: ['en'],
+      defaultNS: 'common',
+      ns: ['common', 'navigation', 'simulation'],
+      interpolation: {
+        escapeValue: false,
+      },
+      detection: {
+        order: ['querystring', 'localStorage', 'navigator'],
+        caches: ['localStorage'],
+      },
+      returnNull: false,
+    });
+
+  return instance;
+};
+
+export type AppLocales = keyof typeof resources;
+export type AppNamespaces = keyof (typeof resources)['en'];

--- a/src/frontend/src/i18n/locales/en/common.json
+++ b/src/frontend/src/i18n/locales/en/common.json
@@ -1,0 +1,4 @@
+{
+  "appTitle": "WeedBreed Simulation",
+  "tagline": "Monitor telemetry and orchestrate deterministic grow runs in real time."
+}

--- a/src/frontend/src/i18n/locales/en/navigation.json
+++ b/src/frontend/src/i18n/locales/en/navigation.json
@@ -1,0 +1,8 @@
+{
+  "overview": "Overview",
+  "zones": "Zones",
+  "plants": "Plants",
+  "devices": "Devices",
+  "settings": "Settings",
+  "goBack": "Back"
+}

--- a/src/frontend/src/i18n/locales/en/simulation.json
+++ b/src/frontend/src/i18n/locales/en/simulation.json
@@ -1,0 +1,58 @@
+{
+  "labels": {
+    "controls": "Simulation controls",
+    "connectionStatus": "Connection",
+    "overview": "Latest snapshot",
+    "latestTick": "Tick {{tick}}",
+    "tickTimestamp": "Timestamp",
+    "plantCount": "Tracked plants",
+    "tickDuration": "Tick duration",
+    "zoneTitle": "Zone {{zoneId}}",
+    "temperature": "Temperature",
+    "humidity": "Humidity",
+    "co2": "CO₂",
+    "ppfd": "PPFD",
+    "vpd": "VPD",
+    "eventLog": "Event log",
+    "totalEvents": "{{count}} events",
+    "noData": "No telemetry received yet.",
+    "inDevelopment": "Work in progress",
+    "tickTimestampShort": "Tick timestamp"
+  },
+  "connection": {
+    "idle": "Idle",
+    "connecting": "Connecting",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "error": "Error"
+  },
+  "controls": {
+    "play": "Play",
+    "pause": "Pause",
+    "step": "Step",
+    "fastForward": "Fast forward",
+    "openSettings": "Set setpoints",
+    "tickLength": "Tick length (min)",
+    "apply": "Apply",
+    "connect": "Connect",
+    "disconnect": "Disconnect"
+  },
+  "events": {
+    "empty": "No events yet."
+  },
+  "views": {
+    "zonesComingSoon": "Detailed zone analytics dashboards are coming soon.",
+    "plantsComingSoon": "Plant inventory and lifecycle tooling are under construction.",
+    "devicesComingSoon": "Device diagnostics and maintenance controls are coming soon.",
+    "settingsDescription": "Tune run-time parameters and advanced controls from this panel."
+  },
+  "modals": {
+    "settingsTitle": "Adjust setpoints",
+    "settingsDescription": "Send a command to the simulation bridge to update the active zone setpoints.",
+    "setpointTarget": "Target",
+    "setpointValue": "Value",
+    "cancel": "Cancel",
+    "apply": "Apply",
+    "close": "Close"
+  }
+}

--- a/src/frontend/src/i18n/types.d.ts
+++ b/src/frontend/src/i18n/types.d.ts
@@ -1,0 +1,15 @@
+import 'i18next';
+import common from './locales/en/common.json';
+import navigation from './locales/en/navigation.json';
+import simulation from './locales/en/simulation.json';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'common';
+    resources: {
+      common: typeof common;
+      navigation: typeof navigation;
+      simulation: typeof simulation;
+    };
+  }
+}

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,9 +1,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-
-const Root = () => {
-  return <div>WeedBreed dashboard placeholder</div>;
-};
+import App from './App.tsx';
+import { AppProviders } from './providers/AppProviders.tsx';
+import './styles/global.css';
 
 const mount = document.getElementById('root');
 
@@ -11,7 +10,9 @@ if (mount) {
   const root = createRoot(mount);
   root.render(
     <StrictMode>
-      <Root />
+      <AppProviders>
+        <App />
+      </AppProviders>
     </StrictMode>,
   );
 }

--- a/src/frontend/src/providers/AppProviders.tsx
+++ b/src/frontend/src/providers/AppProviders.tsx
@@ -1,0 +1,32 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { initI18n } from '../i18n';
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: 1,
+      },
+    },
+  });
+
+export const AppProviders = ({ children }: { children: ReactNode }) => {
+  const [i18n] = useState(() => initI18n());
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        {import.meta.env.DEV ? (
+          <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
+        ) : null}
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+};

--- a/src/frontend/src/store/index.ts
+++ b/src/frontend/src/store/index.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+import { createModalSlice } from './slices/modalSlice';
+import { createNavigationSlice } from './slices/navigationSlice';
+import { createSimulationSlice } from './slices/simulationSlice';
+import type { AppStoreState } from './types';
+
+export const useAppStore = create<AppStoreState>()((...args) => ({
+  ...createSimulationSlice(...args),
+  ...createNavigationSlice(...args),
+  ...createModalSlice(...args),
+}));
+
+export * from './types';

--- a/src/frontend/src/store/slices/modalSlice.ts
+++ b/src/frontend/src/store/slices/modalSlice.ts
@@ -1,0 +1,8 @@
+import type { StateCreator } from 'zustand';
+import type { AppStoreState, ModalDescriptor, ModalSlice } from '../types';
+
+export const createModalSlice: StateCreator<AppStoreState, [], [], ModalSlice> = (set) => ({
+  activeModal: null,
+  openModal: (modal: ModalDescriptor) => set(() => ({ activeModal: modal })),
+  closeModal: () => set(() => ({ activeModal: null })),
+});

--- a/src/frontend/src/store/slices/navigationSlice.ts
+++ b/src/frontend/src/store/slices/navigationSlice.ts
@@ -1,0 +1,42 @@
+import type { StateCreator } from 'zustand';
+import type { AppStoreState, NavigationSlice, NavigationView } from '../types';
+
+const HISTORY_LIMIT = 10;
+
+export const createNavigationSlice: StateCreator<AppStoreState, [], [], NavigationSlice> = (
+  set,
+) => ({
+  currentView: 'overview',
+  history: [],
+  setCurrentView: (view: NavigationView) =>
+    set((state) => {
+      if (state.currentView === view) {
+        return {};
+      }
+
+      const nextHistory = [...state.history, state.currentView];
+      if (nextHistory.length > HISTORY_LIMIT) {
+        nextHistory.shift();
+      }
+
+      return {
+        currentView: view,
+        history: nextHistory,
+      };
+    }),
+  goBack: () =>
+    set((state) => {
+      if (state.history.length === 0) {
+        return {};
+      }
+
+      const nextHistory = [...state.history];
+      const previous = nextHistory.pop() ?? 'overview';
+
+      return {
+        currentView: previous,
+        history: nextHistory,
+      };
+    }),
+  clearHistory: () => set(() => ({ history: [] })),
+});

--- a/src/frontend/src/store/slices/simulationSlice.ts
+++ b/src/frontend/src/store/slices/simulationSlice.ts
@@ -1,0 +1,101 @@
+import type { StateCreator } from 'zustand';
+import type { SimulationSnapshot } from '../../types/simulation';
+import type { AppStoreState, SimulationSlice, SimulationTimelineEntry } from '../types';
+
+const MAX_EVENTS = 250;
+const MAX_TIMELINE_ENTRIES = 180;
+
+const toArray = <T>(input: T | T[] | undefined): T[] => {
+  if (!input) {
+    return [];
+  }
+
+  return Array.isArray(input) ? input : [input];
+};
+
+const truncate = <T>(items: T[], limit: number): T[] => {
+  if (items.length <= limit) {
+    return items;
+  }
+
+  return items.slice(items.length - limit);
+};
+
+const mapTimelineEntries = (snapshot: SimulationSnapshot): SimulationTimelineEntry[] => {
+  return toArray(snapshot.env).map((env) => ({
+    tick: snapshot.tick,
+    ts: snapshot.ts,
+    zoneId: env.zoneId,
+    temperature: env.temperature,
+    humidity: env.humidity,
+    vpd: env.vpd,
+  }));
+};
+
+export const createSimulationSlice: StateCreator<AppStoreState, [], [], SimulationSlice> = (
+  set,
+) => ({
+  connectionStatus: 'idle',
+  zones: {},
+  plants: {},
+  events: [],
+  timeline: [],
+  setConnectionStatus: (status, errorMessage) =>
+    set((state) => ({
+      connectionStatus: status,
+      lastError: status === 'error' ? (errorMessage ?? state.lastError) : undefined,
+    })),
+  ingestSnapshot: (snapshot) =>
+    set((state) => {
+      const zones = { ...state.zones };
+      for (const env of toArray(snapshot.env)) {
+        zones[env.zoneId] = env;
+      }
+
+      const plants = { ...state.plants };
+      for (const plant of snapshot.plants ?? []) {
+        plants[plant.id] = plant;
+      }
+
+      const appendedTimeline = [...state.timeline, ...mapTimelineEntries(snapshot)];
+      const nextEvents = snapshot.events?.length
+        ? truncate([...state.events, ...snapshot.events], MAX_EVENTS)
+        : state.events;
+
+      return {
+        lastSnapshot: snapshot,
+        zones,
+        plants,
+        timeline: truncate(appendedTimeline, MAX_TIMELINE_ENTRIES),
+        events: nextEvents,
+      };
+    }),
+  appendEvents: (events) =>
+    set((state) => {
+      if (!events.length) {
+        return {};
+      }
+
+      return {
+        events: truncate([...state.events, ...events], MAX_EVENTS),
+      };
+    }),
+  registerTickCompleted: (event) =>
+    set(() => ({
+      lastTickCompleted: event,
+    })),
+  resetSimulation: () =>
+    set(() => ({
+      lastSnapshot: undefined,
+      zones: {},
+      plants: {},
+      events: [],
+      timeline: [],
+      lastTickCompleted: undefined,
+    })),
+  setCommandHandlers: (control, config) =>
+    set(() => ({
+      sendControlCommand: control,
+      sendConfigUpdate: config,
+    })),
+});

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -1,0 +1,69 @@
+import type {
+  SimulationConfigUpdate,
+  SimulationControlCommand,
+  SimulationEvent,
+  SimulationSnapshot,
+  SimulationTickEvent,
+  SimulationEnvironmentSnapshot,
+  SimulationPlantSnapshot,
+} from '../types/simulation';
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
+
+export type NavigationView = 'overview' | 'zones' | 'plants' | 'devices' | 'settings';
+
+export interface SimulationTimelineEntry {
+  tick: number;
+  ts: number;
+  zoneId?: string;
+  temperature?: number;
+  humidity?: number;
+  vpd?: number;
+}
+
+export interface SimulationSlice {
+  connectionStatus: ConnectionStatus;
+  lastError?: string;
+  lastSnapshot?: SimulationSnapshot;
+  zones: Record<string, SimulationEnvironmentSnapshot>;
+  plants: Record<string, SimulationPlantSnapshot>;
+  events: SimulationEvent[];
+  timeline: SimulationTimelineEntry[];
+  lastTickCompleted?: SimulationTickEvent;
+  setConnectionStatus: (status: ConnectionStatus, errorMessage?: string) => void;
+  ingestSnapshot: (snapshot: SimulationSnapshot) => void;
+  appendEvents: (events: SimulationEvent[]) => void;
+  registerTickCompleted: (event: SimulationTickEvent) => void;
+  resetSimulation: () => void;
+  sendControlCommand?: (command: SimulationControlCommand) => void;
+  sendConfigUpdate?: (update: SimulationConfigUpdate) => void;
+  setCommandHandlers: (
+    control: (command: SimulationControlCommand) => void,
+    config: (update: SimulationConfigUpdate) => void,
+  ) => void;
+}
+
+export interface NavigationSlice {
+  currentView: NavigationView;
+  history: NavigationView[];
+  setCurrentView: (view: NavigationView) => void;
+  goBack: () => void;
+  clearHistory: () => void;
+}
+
+export type ModalKind = 'settings' | 'snapshot' | 'custom';
+
+export interface ModalDescriptor {
+  kind: ModalKind;
+  title?: string;
+  description?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface ModalSlice {
+  activeModal: ModalDescriptor | null;
+  openModal: (modal: ModalDescriptor) => void;
+  closeModal: () => void;
+}
+
+export type AppStoreState = SimulationSlice & NavigationSlice & ModalSlice;

--- a/src/frontend/src/styles/designTokens.css
+++ b/src/frontend/src/styles/designTokens.css
@@ -1,0 +1,37 @@
+:root {
+  --color-surface: #0b1120;
+  --color-surface-alt: #111c34;
+  --color-surface-elevated: rgba(30, 41, 59, 0.9);
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-border-strong: rgba(148, 163, 184, 0.35);
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5f5;
+  --color-text-muted: #94a3b8;
+  --color-accent: #8b5cf6;
+  --color-accent-strong: #7c3aed;
+  --color-positive: #34d399;
+  --color-warning: #facc15;
+  --color-danger: #f87171;
+  --color-overlay: rgba(15, 23, 42, 0.75);
+
+  --font-family-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 2rem;
+  --space-8: 2.5rem;
+
+  --shadow-soft: 0 20px 45px -35px rgba(148, 163, 184, 0.55);
+  --shadow-strong: 0 25px 50px -25px rgba(30, 41, 59, 0.8);
+
+  --layout-max-width: 1200px;
+  --transition-fast: 150ms ease;
+}

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1,0 +1,58 @@
+@import './designTokens.css';
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-sans);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(16, 185, 129, 0.2), transparent 45%),
+    var(--color-surface);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  font: inherit;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+input,
+select {
+  font: inherit;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-text-primary);
+}
+
+::selection {
+  background: rgba(139, 92, 246, 0.35);
+}

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -1,0 +1,58 @@
+export interface SimulationEnvironmentSnapshot {
+  zoneId: string;
+  temperature: number;
+  humidity: number;
+  co2: number;
+  ppfd: number;
+  vpd?: number;
+}
+
+export interface SimulationPlantSnapshot {
+  id: string;
+  stage: string;
+  biomass?: number;
+  health?: number;
+  zoneId?: string;
+  strainId?: string;
+}
+
+export interface SimulationEvent {
+  type: string;
+  severity?: 'debug' | 'info' | 'warning' | 'error';
+  message?: string;
+  tick?: number;
+  ts?: number;
+  plantId?: string;
+  deviceId?: string;
+  zoneId?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface SimulationSnapshot {
+  type?: 'simulationUpdate';
+  tick: number;
+  ts: number;
+  env?: SimulationEnvironmentSnapshot | SimulationEnvironmentSnapshot[];
+  plants?: SimulationPlantSnapshot[];
+  events?: SimulationEvent[];
+}
+
+export interface SimulationTickEvent {
+  type?: 'sim.tickCompleted';
+  tick: number;
+  ts: number;
+  durationMs?: number;
+  queuedTicks?: number;
+}
+
+export type SimulationControlCommand =
+  | { action: 'play' | 'pause' | 'step' | 'fastForward' }
+  | { action: 'setTickLength'; minutes: number }
+  | { action: 'setSetpoint'; target: string; value: number };
+
+export interface SimulationConfigUpdate {
+  scope: string;
+  payload: Record<string, unknown>;
+}
+
+export type DomainEventPayload = SimulationEvent | Record<string, unknown>;

--- a/src/frontend/src/types/style.d.ts
+++ b/src/frontend/src/types/style.d.ts
@@ -1,0 +1,9 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
- bootstrap a Vite/React TypeScript shell with global providers, design tokens, navigation, and placeholder panels for the dashboard
- add a simulation bridge hook plus Zustand slices for simulation data, navigation history, and modal orchestration
- wire up internationalisation resources and namespace JSON, and expose Query/i18n providers with devtools support

## Testing
- pnpm --filter @weebbreed/frontend lint
- pnpm --filter @weebbreed/frontend test
- pnpm --filter @weebbreed/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68cf024c5f9483258702505065c94c0f