### PR TITLE
Align workforce priorities and scheduling

### DIFF
--- a/data/configs/task_definitions.json
+++ b/data/configs/task_definitions.json
@@ -1,7 +1,7 @@
 {
   "repair_device": {
     "costModel": { "basis": "perAction", "laborMinutes": 90 },
-    "priority": 10,
+    "priority": 100,
     "requiredRole": "Technician",
     "requiredSkill": "Maintenance",
     "minSkillLevel": 2,
@@ -9,7 +9,7 @@
   },
   "maintain_device": {
     "costModel": { "basis": "perAction", "laborMinutes": 30 },
-    "priority": 3,
+    "priority": 30,
     "requiredRole": "Technician",
     "requiredSkill": "Maintenance",
     "minSkillLevel": 4,
@@ -17,7 +17,7 @@
   },
   "harvest_plants": {
     "costModel": { "basis": "perPlant", "laborMinutes": 5 },
-    "priority": 9,
+    "priority": 90,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 0,
@@ -25,7 +25,7 @@
   },
   "refill_supplies_water": {
     "costModel": { "basis": "perAction", "laborMinutes": 15 },
-    "priority": 8,
+    "priority": 80,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 0,
@@ -33,7 +33,7 @@
   },
   "refill_supplies_nutrients": {
     "costModel": { "basis": "perAction", "laborMinutes": 15 },
-    "priority": 8,
+    "priority": 80,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 0,
@@ -41,7 +41,7 @@
   },
   "clean_zone": {
     "costModel": { "basis": "perSquareMeter", "laborMinutes": 1 },
-    "priority": 6,
+    "priority": 60,
     "requiredRole": "Janitor",
     "requiredSkill": "Cleanliness",
     "minSkillLevel": 0,
@@ -49,7 +49,7 @@
   },
   "overhaul_zone_substrate": {
     "costModel": { "basis": "perSquareMeter", "laborMinutes": 5 },
-    "priority": 7,
+    "priority": 70,
     "requiredRole": "Janitor",
     "requiredSkill": "Cleanliness",
     "minSkillLevel": 2,
@@ -57,7 +57,7 @@
   },
   "reset_light_cycle": {
     "costModel": { "basis": "perAction", "laborMinutes": 5 },
-    "priority": 5,
+    "priority": 50,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 0,
@@ -65,7 +65,7 @@
   },
   "execute_planting_plan": {
     "costModel": { "basis": "perPlant", "laborMinutes": 2 },
-    "priority": 4,
+    "priority": 40,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 0,
@@ -73,7 +73,7 @@
   },
   "adjust_light_cycle": {
     "costModel": { "basis": "perAction", "laborMinutes": 5 },
-    "priority": 8,
+    "priority": 80,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 3,
@@ -81,7 +81,7 @@
   },
   "apply_treatment": {
     "costModel": { "basis": "perPlant", "laborMinutes": 4 },
-    "priority": 9,
+    "priority": 90,
     "requiredRole": "Gardener",
     "requiredSkill": "Gardening",
     "minSkillLevel": 2,


### PR DESCRIPTION
## Summary
- remap task definition priorities onto the new 30–100 buckets
- normalize workforce priority handling, convert dynamic boosts into ±10 deltas, and add round-robin ordering for equal-priority work
- extend workforce engine tests to cover the revised priority scale and fairness rotation

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf150e271083258903cd49f94dd886