### PR TITLE
feat(environment): add climate controller with PI power management

### DIFF
--- a/src/backend/src/engine/environment/climateController.test.ts
+++ b/src/backend/src/engine/environment/climateController.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { ClimateController } from './climateController.js';
+
+describe('ClimateController', () => {
+  const baseSetpoints = {
+    temperature: 24,
+    humidity: 0.6,
+    co2: 1000,
+  };
+
+  it('increases heating power when below the temperature setpoint', () => {
+    const controller = new ClimateController();
+    const output = controller.update(
+      baseSetpoints,
+      {
+        temperature: 22,
+        humidity: 0.6,
+        co2: 1000,
+      },
+      1,
+    );
+
+    expect(output.temperatureHeating).toBe(42);
+    expect(output.temperatureCooling).toBe(0);
+    expect(Number.isInteger(output.temperatureHeating)).toBe(true);
+  });
+
+  it('requests cooling when above the temperature setpoint', () => {
+    const controller = new ClimateController();
+    const output = controller.update(
+      baseSetpoints,
+      {
+        temperature: 28,
+        humidity: 0.6,
+        co2: 1000,
+      },
+      1,
+    );
+
+    expect(output.temperatureHeating).toBe(0);
+    expect(output.temperatureCooling).toBe(84);
+  });
+
+  it('handles humidification and dehumidification', () => {
+    const humidifyController = new ClimateController();
+
+    const humidify = humidifyController.update(
+      baseSetpoints,
+      {
+        temperature: 24,
+        humidity: 0.5,
+        co2: 1000,
+      },
+      1,
+    );
+    expect(humidify.humidityHumidify).toBe(44);
+    expect(humidify.humidityDehumidify).toBe(0);
+
+    const dehumidifyController = new ClimateController();
+    const dehumidify = dehumidifyController.update(
+      baseSetpoints,
+      {
+        temperature: 24,
+        humidity: 0.7,
+        co2: 1000,
+      },
+      1,
+    );
+    expect(dehumidify.humidityHumidify).toBe(0);
+    expect(dehumidify.humidityDehumidify).toBe(44);
+  });
+
+  it('modulates CO₂ injection when below the target', () => {
+    const controller = new ClimateController();
+    const output = controller.update(
+      baseSetpoints,
+      {
+        temperature: 24,
+        humidity: 0.6,
+        co2: 700,
+      },
+      1,
+    );
+
+    expect(output.co2Injection).toBe(36);
+    expect(Number.isInteger(output.co2Injection)).toBe(true);
+  });
+
+  it('prevents integrator windup under saturation', () => {
+    const controller = new ClimateController();
+
+    for (let i = 0; i < 5; i += 1) {
+      const saturated = controller.update(
+        { ...baseSetpoints, temperature: 40 },
+        {
+          temperature: 10,
+          humidity: 0.4,
+          co2: 300,
+        },
+        1,
+      );
+      expect(saturated.temperatureHeating).toBe(100);
+    }
+
+    const recovery = controller.update(
+      baseSetpoints,
+      {
+        temperature: 26,
+        humidity: 0.6,
+        co2: 1100,
+      },
+      1,
+    );
+
+    expect(recovery.temperatureHeating).toBe(0);
+    expect(recovery.temperatureCooling).toBeGreaterThan(0);
+    expect(recovery.temperatureCooling).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/backend/src/engine/environment/climateController.ts
+++ b/src/backend/src/engine/environment/climateController.ts
@@ -1,0 +1,183 @@
+export interface SinglePIControllerConfig {
+  kp: number;
+  ki: number;
+  min?: number;
+  max?: number;
+}
+
+export interface ClimateControllerOptions {
+  temperature?: SinglePIControllerConfig;
+  humidity?: SinglePIControllerConfig;
+  co2?: SinglePIControllerConfig;
+  outputStep?: number;
+}
+
+export interface ClimateControlSetpoints {
+  temperature: number;
+  humidity: number;
+  co2: number;
+}
+
+export interface ClimateControlFeedback {
+  temperature: number;
+  humidity: number;
+  co2: number;
+}
+
+export interface ClimateControlOutput {
+  temperatureHeating: number;
+  temperatureCooling: number;
+  humidityHumidify: number;
+  humidityDehumidify: number;
+  co2Injection: number;
+}
+
+const DEFAULT_TEMPERATURE_CONFIG: Required<SinglePIControllerConfig> = {
+  kp: 20,
+  ki: 1,
+  min: -100,
+  max: 100,
+};
+
+const DEFAULT_HUMIDITY_CONFIG: Required<SinglePIControllerConfig> = {
+  kp: 400,
+  ki: 40,
+  min: -100,
+  max: 100,
+};
+
+const DEFAULT_CO2_CONFIG: Required<SinglePIControllerConfig> = {
+  kp: 0.1,
+  ki: 0.02,
+  min: 0,
+  max: 100,
+};
+
+const DEFAULT_OUTPUT_STEP = 1;
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
+
+class SinglePIController {
+  private integral = 0;
+
+  constructor(private readonly config: Required<SinglePIControllerConfig>) {}
+
+  update(error: number, dtMinutes: number): number {
+    const { kp, ki, min, max } = this.config;
+    const dt = Math.max(dtMinutes, 0);
+
+    if (dt === 0 || ki === 0) {
+      const proportional = kp * error;
+      return clamp(proportional, min, max);
+    }
+
+    const deltaIntegral = error * dt;
+    const candidateIntegral = this.integral + deltaIntegral;
+    const candidateOutput = kp * error + ki * candidateIntegral;
+
+    let integral = this.integral;
+    let output: number;
+
+    if (candidateOutput > max && error > 0) {
+      output = max;
+    } else if (candidateOutput < min && error < 0) {
+      output = min;
+    } else {
+      integral = candidateIntegral;
+      output = clamp(candidateOutput, min, max);
+    }
+
+    this.integral = integral;
+    return output;
+  }
+}
+
+export class ClimateController {
+  private readonly temperature: SinglePIController;
+
+  private readonly humidity: SinglePIController;
+
+  private readonly co2: SinglePIController;
+
+  private readonly outputStep: number;
+
+  constructor(options: ClimateControllerOptions = {}) {
+    const temperatureConfig: Required<SinglePIControllerConfig> = {
+      ...DEFAULT_TEMPERATURE_CONFIG,
+      ...options.temperature,
+      min: options.temperature?.min ?? DEFAULT_TEMPERATURE_CONFIG.min,
+      max: options.temperature?.max ?? DEFAULT_TEMPERATURE_CONFIG.max,
+    };
+
+    const humidityConfig: Required<SinglePIControllerConfig> = {
+      ...DEFAULT_HUMIDITY_CONFIG,
+      ...options.humidity,
+      min: options.humidity?.min ?? DEFAULT_HUMIDITY_CONFIG.min,
+      max: options.humidity?.max ?? DEFAULT_HUMIDITY_CONFIG.max,
+    };
+
+    const co2Config: Required<SinglePIControllerConfig> = {
+      ...DEFAULT_CO2_CONFIG,
+      ...options.co2,
+      min: options.co2?.min ?? DEFAULT_CO2_CONFIG.min,
+      max: options.co2?.max ?? DEFAULT_CO2_CONFIG.max,
+    };
+
+    this.temperature = new SinglePIController(temperatureConfig);
+    this.humidity = new SinglePIController(humidityConfig);
+    this.co2 = new SinglePIController(co2Config);
+    this.outputStep = options.outputStep ?? DEFAULT_OUTPUT_STEP;
+  }
+
+  update(
+    setpoints: ClimateControlSetpoints,
+    feedback: ClimateControlFeedback,
+    tickLengthMinutes: number,
+  ): ClimateControlOutput {
+    const dt = Math.max(tickLengthMinutes, 0);
+
+    const temperatureError = setpoints.temperature - feedback.temperature;
+    const rawTemperature = this.temperature.update(temperatureError, dt);
+    const heating = rawTemperature > 0 ? this.quantize(rawTemperature) : 0;
+    const cooling = rawTemperature < 0 ? this.quantize(Math.abs(rawTemperature)) : 0;
+
+    const humidityError = setpoints.humidity - feedback.humidity;
+    const rawHumidity = this.humidity.update(humidityError, dt);
+    const humidify = rawHumidity > 0 ? this.quantize(rawHumidity) : 0;
+    const dehumidify = rawHumidity < 0 ? this.quantize(Math.abs(rawHumidity)) : 0;
+
+    const co2Error = setpoints.co2 - feedback.co2;
+    const rawCo2 = this.co2.update(co2Error, dt);
+    const injection = this.quantize(Math.max(0, rawCo2));
+
+    return {
+      temperatureHeating: heating,
+      temperatureCooling: cooling,
+      humidityHumidify: humidify,
+      humidityDehumidify: dehumidify,
+      co2Injection: injection,
+    };
+  }
+
+  private quantize(value: number): number {
+    const normalized = clamp(value, 0, 100);
+    if (!Number.isFinite(normalized) || normalized === 0) {
+      return 0;
+    }
+
+    const step = Math.max(this.outputStep, 1);
+    const discrete = Math.round(normalized / step) * step;
+    return clamp(discrete, 0, 100);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable climate controller with quantised PI loops for temperature, humidity, and CO₂
- route zone environment device updates through the controller and expose its power levels to device effect calculations
- cover controller scenarios with unit tests and keep existing environment tests passing

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf21f7b4508325a1681c40ca74e5c6