### PR TITLE
Refactor state initialization into modular components

### DIFF
--- a/src/backend/src/state/initialization/blueprints.test.ts
+++ b/src/backend/src/state/initialization/blueprints.test.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { createDeviceBlueprint, createStructureBlueprint } from '../../testing/fixtures.js';
+import { RngService } from '../../lib/rng.js';
+import { chooseDeviceBlueprints, loadStructureBlueprints, selectBlueprint } from './blueprints.js';
+
+describe('state/initialization/blueprints', () => {
+  it('selects the preferred blueprint when available', () => {
+    const rng = new RngService('blueprint-select');
+    const preferred = { id: 'preferred', name: 'Preferred' };
+    const options = [{ id: 'a', name: 'Alpha' }, preferred, { id: 'b', name: 'Beta' }];
+
+    const chosen = selectBlueprint(options, rng.getStream('options'), preferred.id);
+
+    expect(chosen).toBe(preferred);
+  });
+
+  it('chooses representative device blueprints per desired kind', () => {
+    const rng = new RngService('device-choice');
+    const lamp = createDeviceBlueprint({ kind: 'Lamp', id: 'lamp-choice' });
+    const climate = createDeviceBlueprint({ kind: 'ClimateUnit', id: 'climate-choice' });
+    const dehumidifier = createDeviceBlueprint({ kind: 'Dehumidifier', id: 'dehu-choice' });
+    const misc = createDeviceBlueprint({ kind: 'IrrigationPump', id: 'misc-choice' });
+
+    const selected = chooseDeviceBlueprints(
+      [lamp, climate, dehumidifier, misc],
+      rng.getStream('devices'),
+    );
+    const kinds = selected.map((device) => device.kind);
+
+    expect(kinds).toContain('Lamp');
+    expect(kinds).toContain('ClimateUnit');
+    expect(kinds).toContain('Dehumidifier');
+    expect(kinds).not.toContain('IrrigationPump');
+  });
+
+  it('loads structure blueprints from disk and normalises the footprint keys', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-blueprints-'));
+    try {
+      const structuresDir = path.join(tempDir, 'blueprints', 'structures');
+      await fs.mkdir(structuresDir, { recursive: true });
+      const blueprint = createStructureBlueprint({
+        id: 'structure-1',
+        footprint: { length: 12, width: 7, height: 5 },
+      });
+
+      const raw = {
+        id: blueprint.id,
+        name: blueprint.name,
+        footprint: {
+          length_m: blueprint.footprint.length,
+          width_m: blueprint.footprint.width,
+          height_m: blueprint.footprint.height,
+        },
+        rentalCostPerSqmPerMonth: blueprint.rentalCostPerSqmPerMonth,
+        upfrontFee: blueprint.upfrontFee,
+      } satisfies Record<string, unknown>;
+
+      await fs.writeFile(path.join(structuresDir, 'structure.json'), JSON.stringify(raw));
+
+      const loaded = await loadStructureBlueprints(tempDir);
+
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0]).toMatchObject({
+        id: blueprint.id,
+        footprint: blueprint.footprint,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/src/state/initialization/blueprints.ts
+++ b/src/backend/src/state/initialization/blueprints.ts
@@ -1,0 +1,119 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { DeviceBlueprint } from '../../../data/schemas/index.js';
+import type { StructureBlueprint } from '../models.js';
+import type { RngStream } from '../../lib/rng.js';
+import { readJsonFile } from './common.js';
+
+interface RawStructureBlueprint {
+  id: string;
+  name: string;
+  footprint: {
+    length_m: number;
+    width_m: number;
+    height_m: number;
+  };
+  rentalCostPerSqmPerMonth: number;
+  upfrontFee: number;
+}
+
+const normaliseStructureBlueprint = (blueprint: RawStructureBlueprint): StructureBlueprint => ({
+  id: blueprint.id,
+  name: blueprint.name,
+  footprint: {
+    length: blueprint.footprint.length_m,
+    width: blueprint.footprint.width_m,
+    height: blueprint.footprint.height_m,
+  },
+  rentalCostPerSqmPerMonth: blueprint.rentalCostPerSqmPerMonth,
+  upfrontFee: blueprint.upfrontFee,
+});
+
+export const loadStructureBlueprints = async (
+  dataDirectory: string,
+): Promise<StructureBlueprint[]> => {
+  const directory = path.join(dataDirectory, 'blueprints', 'structures');
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(directory);
+  } catch (error) {
+    const cause = error as NodeJS.ErrnoException;
+    if (cause.code === 'ENOENT') {
+      return [];
+    }
+    throw new Error(`Failed to read structure blueprints directory: ${cause.message}`);
+  }
+
+  const blueprints: StructureBlueprint[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) {
+      continue;
+    }
+    const filePath = path.join(directory, entry);
+    const raw = await readJsonFile<RawStructureBlueprint>(filePath);
+    if (!raw) {
+      continue;
+    }
+    blueprints.push(normaliseStructureBlueprint(raw));
+  }
+  return blueprints;
+};
+
+export const sortBlueprints = <T extends { id: string; name?: string }>(
+  items: readonly T[],
+): T[] => {
+  return [...items].sort((a, b) => {
+    const left = a.name ?? a.id;
+    const right = b.name ?? b.id;
+    return left.localeCompare(right);
+  });
+};
+
+export const selectBlueprint = <T extends { id: string; name?: string }>(
+  items: readonly T[],
+  stream: RngStream,
+  preferredId?: string,
+): T => {
+  if (items.length === 0) {
+    throw new Error('No blueprints available for selection.');
+  }
+  if (preferredId) {
+    const match = items.find((item) => item.id === preferredId);
+    if (match) {
+      return match;
+    }
+  }
+  if (items.length === 1) {
+    return items[0];
+  }
+  const sorted = sortBlueprints(items);
+  const index = stream.nextInt(sorted.length);
+  return sorted[index];
+};
+
+export const chooseDeviceBlueprints = (
+  devices: DeviceBlueprint[],
+  stream: RngStream,
+): DeviceBlueprint[] => {
+  const byKind = new Map<string, DeviceBlueprint[]>();
+  for (const device of devices) {
+    const kindEntries = byKind.get(device.kind) ?? [];
+    kindEntries.push(device);
+    byKind.set(device.kind, kindEntries);
+  }
+
+  const selected: DeviceBlueprint[] = [];
+  const desiredKinds = ['Lamp', 'ClimateUnit', 'Dehumidifier'];
+  for (const kind of desiredKinds) {
+    const options = byKind.get(kind);
+    if (options && options.length > 0) {
+      selected.push(selectBlueprint(options, stream));
+    }
+  }
+
+  if (selected.length === 0 && devices.length > 0) {
+    selected.push(selectBlueprint(devices, stream));
+  }
+
+  return selected;
+};

--- a/src/backend/src/state/initialization/common.ts
+++ b/src/backend/src/state/initialization/common.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from 'fs';
+import type { RngStream } from '../../lib/rng.js';
+
+export const generateId = (stream: RngStream, prefix: string, length = 10): string =>
+  `${prefix}_${stream.nextString(length)}`;
+
+export const readJsonFile = async <T>(filePath: string): Promise<T | undefined> => {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const cause = error as NodeJS.ErrnoException;
+    if (cause.code === 'ENOENT') {
+      return undefined;
+    }
+    throw new Error(`Failed to read JSON file at ${filePath}: ${cause.message}`);
+  }
+};

--- a/src/backend/src/state/initialization/finance.test.ts
+++ b/src/backend/src/state/initialization/finance.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBlueprintRepositoryStub,
+  createDeviceBlueprint,
+  createStructureBlueprint,
+} from '../../testing/fixtures.js';
+import type { EconomicsSettings } from '../models.js';
+import { RngService } from '../../lib/rng.js';
+import { createFinanceState } from './finance.js';
+
+describe('state/initialization/finance', () => {
+  it('records initial capital, upfront fees, and device purchases in the ledger', () => {
+    const structure = createStructureBlueprint({
+      upfrontFee: 7500,
+      footprint: { length: 10, width: 8, height: 4 },
+    });
+    const lamp = createDeviceBlueprint({ kind: 'Lamp', id: 'lamp-finance' });
+    const climate = createDeviceBlueprint({ kind: 'ClimateUnit', id: 'climate-finance' });
+    const repository = createBlueprintRepositoryStub({
+      devices: [lamp, climate],
+    });
+    const economics: EconomicsSettings = {
+      initialCapital: 1_000_000,
+      itemPriceMultiplier: 1,
+      harvestPriceMultiplier: 1,
+      rentPerSqmStructurePerTick: 0.15,
+      rentPerSqmRoomPerTick: 0.3,
+    };
+    const rng = new RngService('finance-state');
+    const idStream = rng.getStream('ids');
+
+    const state = createFinanceState(
+      '2024-01-01T00:00:00Z',
+      economics,
+      structure,
+      [lamp, climate],
+      repository,
+      idStream,
+    );
+
+    const ledgerDescriptions = state.ledger.map((entry) => entry.description);
+    expect(ledgerDescriptions).toContain('Initial capital injection');
+    expect(ledgerDescriptions).toContain(`Lease upfront payment for ${structure.name}`);
+    expect(ledgerDescriptions).toContain('Initial device purchases');
+
+    expect(state.cashOnHand).toBeLessThan(economics.initialCapital);
+    expect(state.summary.totalExpenses).toBeGreaterThan(0);
+  });
+});

--- a/src/backend/src/state/initialization/finance.ts
+++ b/src/backend/src/state/initialization/finance.ts
@@ -1,0 +1,96 @@
+import type { BlueprintRepository } from '../../../data/blueprintRepository.js';
+import type { DeviceBlueprint, DevicePriceEntry } from '../../../data/schemas/index.js';
+import type {
+  EconomicsSettings,
+  FinanceState,
+  FinancialSummary,
+  LedgerEntry,
+  StructureBlueprint,
+} from '../models.js';
+import type { RngStream } from '../../lib/rng.js';
+import { generateId } from './common.js';
+
+const sumDeviceCapitalCosts = (
+  devices: DeviceBlueprint[],
+  priceLookup: (id: string) => DevicePriceEntry | undefined,
+): number => {
+  return devices.reduce((sum, device) => {
+    const price = priceLookup(device.id);
+    return sum + (price?.capitalExpenditure ?? 0);
+  }, 0);
+};
+
+export const createFinanceState = (
+  createdAt: string,
+  economics: EconomicsSettings,
+  blueprint: StructureBlueprint,
+  installedDevices: DeviceBlueprint[],
+  repository: BlueprintRepository,
+  idStream: RngStream,
+): FinanceState => {
+  const ledgerEntries: LedgerEntry[] = [];
+  const addEntry = (
+    entry: Omit<LedgerEntry, 'id' | 'tick' | 'timestamp'> & { tick?: number; timestamp?: string },
+  ) => {
+    ledgerEntries.push({
+      id: generateId(idStream, 'ledger'),
+      tick: entry.tick ?? 0,
+      timestamp: entry.timestamp ?? createdAt,
+      amount: entry.amount,
+      type: entry.type,
+      category: entry.category,
+      description: entry.description,
+    });
+  };
+
+  addEntry({
+    amount: economics.initialCapital,
+    type: 'income',
+    category: 'capital',
+    description: 'Initial capital injection',
+  });
+
+  if (blueprint.upfrontFee > 0) {
+    addEntry({
+      amount: -blueprint.upfrontFee,
+      type: 'expense',
+      category: 'structure',
+      description: `Lease upfront payment for ${blueprint.name}`,
+    });
+  }
+
+  const deviceCosts = sumDeviceCapitalCosts(installedDevices, (id) =>
+    repository.getDevicePrice(id),
+  );
+  if (deviceCosts > 0) {
+    addEntry({
+      amount: -deviceCosts,
+      type: 'expense',
+      category: 'device',
+      description: 'Initial device purchases',
+    });
+  }
+
+  const cashOnHand = economics.initialCapital - blueprint.upfrontFee - deviceCosts;
+  const totalExpenses = blueprint.upfrontFee + deviceCosts;
+
+  const summary: FinancialSummary = {
+    totalRevenue: economics.initialCapital,
+    totalExpenses,
+    totalPayroll: 0,
+    totalMaintenance: 0,
+    netIncome: economics.initialCapital - totalExpenses,
+    lastTickRevenue: economics.initialCapital,
+    lastTickExpenses: totalExpenses,
+  };
+
+  return {
+    cashOnHand,
+    reservedCash: 0,
+    outstandingLoans: [],
+    ledger: ledgerEntries,
+    summary,
+  };
+};
+
+export { sumDeviceCapitalCosts };

--- a/src/backend/src/state/initialization/personnel.test.ts
+++ b/src/backend/src/state/initialization/personnel.test.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { RngService } from '../../lib/rng.js';
+import { createPersonnel, loadPersonnelDirectory } from './personnel.js';
+
+describe('state/initialization/personnel', () => {
+  it('loads personnel name directories with graceful fallbacks', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-personnel-'));
+    try {
+      const personnelDir = path.join(tempDir, 'personnel');
+      await fs.mkdir(personnelDir, { recursive: true });
+      await fs.writeFile(path.join(personnelDir, 'firstNames.json'), JSON.stringify(['Alex']));
+      await fs.writeFile(path.join(personnelDir, 'lastNames.json'), JSON.stringify(['Patel']));
+      await fs.writeFile(
+        path.join(personnelDir, 'traits.json'),
+        JSON.stringify([
+          {
+            id: 'trait_detail',
+            name: 'Detail Oriented',
+            description: 'Keeps things tidy.',
+            type: 'positive',
+          },
+        ]),
+      );
+
+      const directory = await loadPersonnelDirectory(tempDir);
+
+      expect(directory.firstNames).toContain('Alex');
+      expect(directory.lastNames).toContain('Patel');
+      expect(directory.traits[0]?.id).toBe('trait_detail');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates personnel with role-based shift preferences and morale averages', () => {
+    const rng = new RngService('personnel-roster');
+    const idStream = rng.getStream('ids');
+    const directory = {
+      firstNames: ['Morgan', 'Drew', 'Sasha'],
+      lastNames: ['Nguyen', 'Lopez'],
+      traits: [],
+    };
+
+    const roster = createPersonnel(
+      'structure-alpha',
+      { Manager: 1, Janitor: 1, Gardener: 2 },
+      directory,
+      rng,
+      idStream,
+    );
+
+    expect(roster.employees).toHaveLength(4);
+    const manager = roster.employees.find((employee) => employee.role === 'Manager');
+    const janitor = roster.employees.find((employee) => employee.role === 'Janitor');
+
+    expect(manager?.shift.shiftId).toBe('shift.day');
+    expect(janitor?.shift.shiftId).toBe('shift.night');
+    expect(roster.overallMorale).toBeGreaterThan(0);
+    expect(roster.overallMorale).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/backend/src/state/initialization/personnel.ts
+++ b/src/backend/src/state/initialization/personnel.ts
@@ -1,0 +1,225 @@
+import path from 'path';
+import type {
+  PersonnelNameDirectory,
+  PersonnelRoster,
+  EmployeeRole,
+  EmployeeState,
+  EmployeeSkills,
+  EmployeeShiftAssignment,
+} from '../models.js';
+import { RngService, RngStream } from '../../lib/rng.js';
+import { generateId, readJsonFile } from './common.js';
+
+const DEFAULT_SALARY_BY_ROLE: Record<EmployeeRole, number> = {
+  Gardener: 24,
+  Technician: 28,
+  Janitor: 18,
+  Operator: 22,
+  Manager: 35,
+};
+
+const MINUTES_PER_DAY = 24 * 60;
+
+const SHIFT_TEMPLATES: readonly EmployeeShiftAssignment[] = [
+  { shiftId: 'shift.day', name: 'Day Shift', startHour: 6, durationHours: 12, overlapMinutes: 60 },
+  {
+    shiftId: 'shift.night',
+    name: 'Night Shift',
+    startHour: 18,
+    durationHours: 12,
+    overlapMinutes: 60,
+  },
+];
+
+const ROLE_SHIFT_PREFERENCES: Partial<Record<EmployeeRole, string>> = {
+  Janitor: 'shift.night',
+  Operator: 'shift.day',
+  Manager: 'shift.day',
+};
+
+export const loadPersonnelDirectory = async (
+  dataDirectory: string,
+): Promise<PersonnelNameDirectory> => {
+  const personnelDir = path.join(dataDirectory, 'personnel');
+  const [firstNames, lastNames, traits] = await Promise.all([
+    readJsonFile<string[]>(path.join(personnelDir, 'firstNames.json')),
+    readJsonFile<string[]>(path.join(personnelDir, 'lastNames.json')),
+    readJsonFile<PersonnelNameDirectory['traits']>(path.join(personnelDir, 'traits.json')),
+  ]);
+
+  return {
+    firstNames: firstNames ?? [],
+    lastNames: lastNames ?? [],
+    traits: traits ?? [],
+  };
+};
+
+const drawUnique = <T>(items: readonly T[], count: number, stream: RngStream): T[] => {
+  if (items.length === 0 || count <= 0) {
+    return [];
+  }
+  const pool = [...items];
+  const picks = Math.min(count, pool.length);
+  const result: T[] = [];
+  for (let index = 0; index < picks; index += 1) {
+    const chosenIndex = stream.nextInt(pool.length);
+    result.push(pool.splice(chosenIndex, 1)[0]);
+  }
+  return result;
+};
+
+const createEmployeeSkills = (role: EmployeeRole): EmployeeSkills => {
+  switch (role) {
+    case 'Gardener':
+      return { Gardening: 4, Cleanliness: 2 };
+    case 'Technician':
+      return { Maintenance: 4, Logistics: 2 };
+    case 'Janitor':
+      return { Cleanliness: 4, Logistics: 1 };
+    case 'Operator':
+      return { Logistics: 3, Administration: 2 };
+    case 'Manager':
+      return { Administration: 4, Logistics: 2 };
+    default:
+      return {};
+  }
+};
+
+const createExperienceStub = (skills: EmployeeSkills): EmployeeSkills => {
+  return Object.fromEntries(Object.keys(skills).map((skill) => [skill, 0])) as EmployeeSkills;
+};
+
+const isShiftActiveAtMinute = (shift: EmployeeShiftAssignment, minuteOfDay: number): boolean => {
+  if (!Number.isFinite(shift.startHour) || !Number.isFinite(shift.durationHours)) {
+    return true;
+  }
+  const overlap = Math.max(shift.overlapMinutes, 0);
+  const startMinutes =
+    (((shift.startHour * 60 - overlap) % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+  const durationMinutes = Math.max(shift.durationHours * 60, 0);
+  if (durationMinutes >= MINUTES_PER_DAY) {
+    return true;
+  }
+  const endMinutes = (startMinutes + overlap + durationMinutes) % MINUTES_PER_DAY;
+  if (startMinutes < endMinutes) {
+    return minuteOfDay >= startMinutes && minuteOfDay < endMinutes;
+  }
+  return minuteOfDay >= startMinutes || minuteOfDay < endMinutes;
+};
+
+export const createPersonnel = (
+  structureId: string,
+  counts: Record<EmployeeRole, number>,
+  directory: PersonnelNameDirectory | undefined,
+  rng: RngService,
+  idStream: RngStream,
+): PersonnelRoster => {
+  const firstNames = directory?.firstNames ?? [];
+  const lastNames = directory?.lastNames ?? [];
+  const traits = directory?.traits ?? [];
+  const nameStream = rng.getStream('personnel-names');
+  const traitStream = rng.getStream('personnel-traits');
+  const moraleStream = rng.getStream('personnel-morale');
+  const employees: EmployeeState[] = [];
+  const shiftCounts = new Map<string, number>();
+  let shiftCursor = 0;
+
+  const recordShift = (shift: EmployeeShiftAssignment) => {
+    const current = shiftCounts.get(shift.shiftId) ?? 0;
+    shiftCounts.set(shift.shiftId, current + 1);
+  };
+
+  const chooseBalancedShift = (): EmployeeShiftAssignment => {
+    const templates = SHIFT_TEMPLATES.map((template) => ({
+      template,
+      count: shiftCounts.get(template.shiftId) ?? 0,
+    }));
+    if (templates.length === 0) {
+      return {
+        shiftId: 'shift.default',
+        name: 'Default Shift',
+        startHour: 0,
+        durationHours: 24,
+        overlapMinutes: 0,
+      } satisfies EmployeeShiftAssignment;
+    }
+    const minCount = Math.min(...templates.map((entry) => entry.count));
+    for (let offset = 0; offset < templates.length; offset += 1) {
+      const index = (shiftCursor + offset) % templates.length;
+      const entry = templates[index];
+      if (entry.count === minCount) {
+        shiftCursor = (index + 1) % templates.length;
+        recordShift(entry.template);
+        return { ...entry.template } satisfies EmployeeShiftAssignment;
+      }
+    }
+    const fallback = templates[0];
+    shiftCursor = (shiftCursor + 1) % templates.length;
+    recordShift(fallback.template);
+    return { ...fallback.template } satisfies EmployeeShiftAssignment;
+  };
+
+  const assignShift = (role: EmployeeRole): EmployeeShiftAssignment => {
+    const preferredId = ROLE_SHIFT_PREFERENCES[role];
+    if (preferredId) {
+      const template =
+        SHIFT_TEMPLATES.find((item) => item.shiftId === preferredId) ?? SHIFT_TEMPLATES[0];
+      const index = SHIFT_TEMPLATES.findIndex((item) => item.shiftId === template.shiftId);
+      if (index >= 0) {
+        shiftCursor = (index + 1) % SHIFT_TEMPLATES.length;
+      }
+      recordShift(template);
+      return { ...template } satisfies EmployeeShiftAssignment;
+    }
+    return chooseBalancedShift();
+  };
+
+  for (const role of Object.keys(counts) as EmployeeRole[]) {
+    const count = counts[role] ?? 0;
+    for (let index = 0; index < count; index += 1) {
+      const firstName = firstNames.length > 0 ? nameStream.pick(firstNames) : `Crew${index + 1}`;
+      const lastName = lastNames.length > 0 ? nameStream.pick(lastNames) : role;
+      const fullName = `${firstName} ${lastName}`;
+      const skills = createEmployeeSkills(role);
+      const employeeTraits = drawUnique(
+        traits,
+        traits.length > 0 ? 1 + Number(traitStream.nextBoolean(0.35)) : 0,
+        traitStream,
+      ).map((trait) => trait.id);
+      const shift = assignShift(role);
+      const isActiveAtStart = isShiftActiveAtMinute(shift, 0);
+      employees.push({
+        id: generateId(idStream, 'emp'),
+        name: fullName,
+        role,
+        salaryPerTick: DEFAULT_SALARY_BY_ROLE[role] ?? 20,
+        status: isActiveAtStart ? 'idle' : 'offShift',
+        morale: 0.82 + moraleStream.nextRange(0, 0.08),
+        energy: 1,
+        skills,
+        experience: createExperienceStub(skills),
+        traits: employeeTraits,
+        certifications: [],
+        shift,
+        hoursWorkedToday: 0,
+        overtimeHours: 0,
+        lastShiftResetTick: 0,
+        assignedStructureId: structureId,
+      });
+    }
+  }
+
+  const morale =
+    employees.length > 0
+      ? employees.reduce((sum, employee) => sum + employee.morale, 0) / employees.length
+      : 1;
+
+  return {
+    employees,
+    applicants: [],
+    trainingPrograms: [],
+    overallMorale: morale,
+  };
+};
+
+export { DEFAULT_SALARY_BY_ROLE, SHIFT_TEMPLATES, ROLE_SHIFT_PREFERENCES };

--- a/src/backend/src/state/initialization/tasks.test.ts
+++ b/src/backend/src/state/initialization/tasks.test.ts
@@ -1,0 +1,170 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { RngService } from '../../lib/rng.js';
+import type {
+  StructureState,
+  ZoneHealthState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneEnvironmentState,
+  DeviceInstanceState,
+} from '../models.js';
+import { createTasks, loadTaskDefinitions } from './tasks.js';
+
+describe('state/initialization/tasks', () => {
+  it('loads task definitions from configuration files', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-tasks-'));
+    try {
+      const configDir = path.join(tempDir, 'configs');
+      await fs.mkdir(configDir, { recursive: true });
+      const definitions = {
+        execute_planting_plan: {
+          costModel: { basis: 'perAction', laborMinutes: 90 },
+          priority: 6,
+          requiredRole: 'Gardener',
+          requiredSkill: 'Gardening',
+          minSkillLevel: 2,
+          description: 'Plant seeds',
+        },
+      } satisfies Record<string, unknown>;
+
+      await fs.writeFile(
+        path.join(configDir, 'task_definitions.json'),
+        JSON.stringify(definitions),
+      );
+
+      const loaded = await loadTaskDefinitions(tempDir);
+      expect(loaded.execute_planting_plan?.priority).toBe(6);
+      expect(loaded.execute_planting_plan?.costModel.laborMinutes).toBe(90);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates seed tasks with metadata populated from structure context', () => {
+    const rng = new RngService('task-seeding');
+    const idStream = rng.getStream('ids');
+
+    const environment: ZoneEnvironmentState = {
+      temperature: 24,
+      relativeHumidity: 0.6,
+      co2: 900,
+      ppfd: 550,
+      vpd: 1.2,
+    };
+    const resources: ZoneResourceState = {
+      waterLiters: 800,
+      nutrientSolutionLiters: 400,
+      nutrientStrength: 1,
+      substrateHealth: 1,
+      reservoirLevel: 0.75,
+    };
+    const metrics: ZoneMetricState = {
+      averageTemperature: 24,
+      averageHumidity: 0.6,
+      averageCo2: 900,
+      averagePpfd: 550,
+      stressLevel: 0,
+      lastUpdatedTick: 0,
+    };
+    const health: ZoneHealthState = {
+      plantHealth: {},
+      pendingTreatments: [],
+      appliedTreatments: [],
+    };
+    const device: DeviceInstanceState = {
+      id: 'device-1',
+      blueprintId: 'blueprint-1',
+      kind: 'Lamp',
+      name: 'Test Lamp',
+      zoneId: 'zone-1',
+      status: 'operational',
+      efficiency: 1,
+      runtimeHours: 0,
+      maintenance: {
+        lastServiceTick: 0,
+        nextDueTick: 240,
+        condition: 1,
+        runtimeHoursAtLastService: 0,
+        degradation: 0,
+      },
+      settings: {},
+    };
+
+    const zone = {
+      id: 'zone-1',
+      roomId: 'room-1',
+      name: 'Zone Test',
+      cultivationMethodId: 'method-1',
+      strainId: 'strain-1',
+      environment,
+      resources,
+      plants: [],
+      devices: [device],
+      metrics,
+      health,
+      activeTaskIds: [],
+    } as StructureState['rooms'][number]['zones'][number];
+
+    const room = {
+      id: 'room-1',
+      structureId: 'structure-1',
+      name: 'Room Test',
+      purposeId: 'growroom',
+      area: 60,
+      height: 4,
+      volume: 240,
+      zones: [zone],
+      cleanliness: 1,
+      maintenanceLevel: 1,
+    } as StructureState['rooms'][number];
+
+    const structure: StructureState = {
+      id: 'structure-1',
+      blueprintId: 'structure-blueprint',
+      name: 'Structure Test',
+      status: 'active',
+      footprint: { length: 10, width: 6, height: 4, area: 60, volume: 240 },
+      rooms: [room],
+      rentPerTick: 0,
+      upfrontCostPaid: 0,
+    };
+
+    const definitions = {
+      execute_planting_plan: {
+        id: 'execute_planting_plan',
+        costModel: { basis: 'perAction', laborMinutes: 120 },
+        priority: 7,
+        requiredRole: 'Gardener',
+        requiredSkill: 'Gardening',
+        minSkillLevel: 2,
+        description: 'Execute planting',
+      },
+      maintain_device: {
+        id: 'maintain_device',
+        costModel: { basis: 'perAction', laborMinutes: 60 },
+        priority: 5,
+        requiredRole: 'Technician',
+        requiredSkill: 'Maintenance',
+        minSkillLevel: 2,
+        description: 'Maintain devices',
+      },
+    };
+
+    const tasks = createTasks(structure, room, zone, 12, definitions, idStream);
+
+    expect(tasks.backlog).toHaveLength(3);
+    const plantingTask = tasks.backlog.find(
+      (task) => task.definitionId === 'execute_planting_plan',
+    );
+    expect(plantingTask?.priority).toBe(7);
+    expect(plantingTask?.metadata).toMatchObject({
+      structureName: 'Structure Test',
+      zoneName: 'Zone Test',
+    });
+    const maintenanceTask = tasks.backlog.find((task) => task.definitionId === 'maintain_device');
+    expect(maintenanceTask?.metadata).toMatchObject({ deviceCount: 1 });
+  });
+});

--- a/src/backend/src/state/initialization/tasks.ts
+++ b/src/backend/src/state/initialization/tasks.ts
@@ -1,0 +1,100 @@
+import path from 'path';
+import type {
+  EmployeeRole,
+  SkillName,
+  StructureState,
+  TaskDefinition,
+  TaskDefinitionMap,
+  TaskSystemState,
+  TaskState,
+} from '../models.js';
+import type { RngStream } from '../../lib/rng.js';
+import { generateId, readJsonFile } from './common.js';
+
+interface RawTaskDefinition {
+  costModel: {
+    basis: string;
+    laborMinutes: number;
+  };
+  priority: number;
+  requiredRole: string;
+  requiredSkill: string;
+  minSkillLevel: number;
+  description: string;
+}
+
+export const loadTaskDefinitions = async (dataDirectory: string): Promise<TaskDefinitionMap> => {
+  const configFile = path.join(dataDirectory, 'configs', 'task_definitions.json');
+  const raw = await readJsonFile<Record<string, RawTaskDefinition>>(configFile);
+
+  if (!raw) {
+    return {};
+  }
+
+  const definitions: TaskDefinitionMap = {};
+  for (const [id, value] of Object.entries(raw)) {
+    const basis = value.costModel?.basis as TaskDefinition['costModel']['basis'] | undefined;
+    definitions[id] = {
+      id,
+      costModel: {
+        basis: basis ?? 'perAction',
+        laborMinutes: value.costModel?.laborMinutes ?? 0,
+      },
+      priority: value.priority,
+      requiredRole: value.requiredRole as EmployeeRole,
+      requiredSkill: value.requiredSkill as SkillName,
+      minSkillLevel: value.minSkillLevel,
+      description: value.description,
+    } satisfies TaskDefinition;
+  }
+
+  return definitions;
+};
+
+export const createTasks = (
+  structure: StructureState,
+  room: StructureState['rooms'][number],
+  zone: StructureState['rooms'][number]['zones'][number],
+  plantCount: number,
+  definitions: TaskDefinitionMap | undefined,
+  idStream: RngStream,
+): TaskSystemState => {
+  const backlog: TaskState[] = [];
+  const createTask = (
+    definitionId: string,
+    fallbackPriority: number,
+    metadata: Record<string, unknown>,
+  ) => {
+    const definition = definitions?.[definitionId];
+    backlog.push({
+      id: generateId(idStream, 'task'),
+      definitionId,
+      status: 'pending',
+      priority: definition?.priority ?? fallbackPriority,
+      createdAtTick: 0,
+      dueTick: definition ? Math.round(definition.priority * 4) : undefined,
+      location: {
+        structureId: structure.id,
+        roomId: room.id,
+        zoneId: zone.id,
+      },
+      metadata: {
+        zoneName: zone.name,
+        structureName: structure.name,
+        ...(definition ? { description: definition.description } : {}),
+        ...metadata,
+      },
+    });
+  };
+
+  createTask('execute_planting_plan', 5, { plantCount });
+  createTask('refill_supplies_water', 4, {});
+  createTask('maintain_device', 3, { deviceCount: zone.devices.length });
+
+  return {
+    backlog,
+    active: [],
+    completed: [],
+    cancelled: [],
+  };
+};


### PR DESCRIPTION
## Summary
- extract blueprint, personnel, finance, and task initialization into dedicated modules consumed by the state factory
- update `createInitialState` to orchestrate the new modules while re-exporting the existing helper entry points
- add unit tests covering blueprint loading, personnel roster creation, finance ledger seeding, and task queue seeding

## Testing
- pnpm test (in `src/backend`)


------
https://chatgpt.com/codex/tasks/task_e_68cf2af478ac8325a6dc793d88425286