### PR TITLE
chore: wire cross-env for backend dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "cross-env": "^10.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-import-resolver-typescript": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@20.19.17)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1))
+      cross-env:
+        specifier: ^10.0.0
+        version: 10.0.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -74,6 +77,10 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+    devDependencies:
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.17)(typescript@5.9.2)
 
   src/frontend:
     dependencies:
@@ -267,6 +274,9 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -1164,6 +1174,11 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-env@10.0.0:
+    resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3036,6 +3051,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.25.10':
     optional: true
 
@@ -3846,6 +3863,11 @@ snapshots:
       vary: 1.1.2
 
   create-require@1.1.1: {}
+
+  cross-env@10.0.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,0 +1,28 @@
+# Backend Development
+
+## Running the development server
+
+The backend uses [`ts-node`](https://typestrong.org/ts-node/) in ESM mode during
+development so that we can execute the TypeScript sources directly. Several of
+the runtime modules import the data blueprints using `.js` specifiers even
+though the sources live alongside them as `.ts` files under `src/backend/data/`.
+
+To make sure those imports resolve correctly we have to enable the experimental
+module resolver that ships with `ts-node`. This is now wired into the `dev`
+script together with [`cross-env`](https://github.com/kentcdodds/cross-env) so
+the required environment variable is set in a cross-platform way:
+
+Setting `NODE_OPTIONS=--loader=ts-node/esm` ensures Node always attaches
+ts-node's ESM loader before executing the entrypoint, which keeps `.ts` modules
+loadable when the project is executed on different platforms.
+
+```bash
+pnpm --filter @weebbreed/backend dev
+# which runs:
+#   cross-env NODE_OPTIONS=--loader=ts-node/esm TS_NODE_EXPERIMENTAL_RESOLVER=1 \
+#   ts-node --esm src/index.ts
+```
+
+Running the script without `TS_NODE_EXPERIMENTAL_RESOLVER=1` will lead to
+`MODULE_NOT_FOUND` errors when `ts-node` tries to resolve the `.js` specifiers,
+so the flag is mandatory for local development.

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "ts-node --esm src/index.ts",
+    "dev": "cross-env NODE_OPTIONS=--loader=ts-node/esm TS_NODE_EXPERIMENTAL_RESOLVER=1 ts-node --esm src/index.ts",
     "build": "tsc --project tsconfig.json",
     "lint": "eslint --ext .ts src data",
     "test": "vitest --run --passWithNoTests",
@@ -19,5 +19,8 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2"
   }
 }

--- a/src/backend/src/lib/eventBus.ts
+++ b/src/backend/src/lib/eventBus.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject, bufferTime, filter as rxFilter, share } from 'rxjs';
+import { Observable, OperatorFunction, Subject, bufferTime, filter as rxFilter, share } from 'rxjs';
 
 type MaybeArray<T> = T | T[];
 
@@ -122,8 +122,13 @@ export class EventBus {
   buffered(options?: EventBufferOptions): Observable<SimulationEvent[]> {
     const { timeMs = 250, maxBufferSize, filter } = options ?? {};
     const stream = this.events(filter);
+    const bufferOperator: OperatorFunction<SimulationEvent, SimulationEvent[]> =
+      typeof maxBufferSize === 'number'
+        ? bufferTime<SimulationEvent>(timeMs, undefined, maxBufferSize)
+        : bufferTime<SimulationEvent>(timeMs);
+
     return stream.pipe(
-      bufferTime(timeMs, undefined, maxBufferSize),
+      bufferOperator,
       rxFilter((batch) => batch.length > 0),
     );
   }

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -8,5 +8,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts", "data/**/*.ts", "facade/**/*.ts", "server/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
 }


### PR DESCRIPTION
## Summary
- add cross-env to the workspace toolchain so shared scripts can set env vars portably
- run the backend dev entrypoint through cross-env with ts-node's experimental resolver and loader, adding ts-node dev config to keep ESM resolution stable
- document the requirement in the backend README and tighten EventBus buffering types to satisfy the stricter ts-node compilation

## Testing
- pnpm run dev *(fails: backend ts-node compilation reports existing type errors but no longer throws module-not-found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3003e5e48325a35444c13847b21e