### PR TITLE
Expand cultivation method compatibility schema

### DIFF
--- a/src/backend/data/dataLoader.test.ts
+++ b/src/backend/data/dataLoader.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadBlueprintData } from './dataLoader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fixtureDataDirectory = path.resolve(__dirname, '../../..', 'data');
+
+describe('loadBlueprintData', () => {
+  it('validates cultivation method blueprints with compatibility thresholds', async () => {
+    const result = await loadBlueprintData(fixtureDataDirectory);
+
+    const cultivationMethods = result.data.cultivationMethods;
+    expect(cultivationMethods.size).toBeGreaterThan(0);
+
+    const scrog = cultivationMethods.get('41229377-ef2d-4723-931f-72eea87d7a62');
+    expect(scrog?.strainTraitCompatibility?.preferred?.['genotype.sativa']?.min).toBe(0.5);
+    expect(scrog?.strainTraitCompatibility?.conflicting?.['genotype.indica']?.min).toBe(0.7);
+
+    const sog = cultivationMethods.get('659ba4d7-a5fc-482e-98d4-b614341883ac');
+    expect(sog?.strainTraitCompatibility?.preferred?.['photoperiod.vegetationDays']?.max).toBe(21);
+    expect(sog?.strainTraitCompatibility?.conflicting?.['photoperiod.vegetationDays']?.min).toBe(
+      28,
+    );
+  });
+});

--- a/src/backend/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/data/schemas/cultivationMethodSchema.ts
@@ -2,6 +2,20 @@ import { z } from 'zod';
 
 const rangeTuple = z.tuple([z.number(), z.number()]);
 
+export const strainTraitThresholdSchema = z
+  .object({
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .passthrough();
+
+export const strainTraitCompatibilitySchema = z
+  .object({
+    preferred: z.record(z.string(), strainTraitThresholdSchema).optional(),
+    conflicting: z.record(z.string(), strainTraitThresholdSchema).optional(),
+  })
+  .passthrough();
+
 export const cultivationMethodSchema = z
   .object({
     id: z.string().uuid(),
@@ -31,7 +45,7 @@ export const cultivationMethodSchema = z
       })
       .passthrough()
       .optional(),
-    strainTraitCompatibility: z.record(z.string(), z.number()).optional(),
+    strainTraitCompatibility: strainTraitCompatibilitySchema.optional(),
     idealConditions: z
       .object({
         idealTemperature: rangeTuple.optional(),
@@ -52,3 +66,5 @@ export const cultivationMethodSchema = z
   .passthrough();
 
 export type CultivationMethodBlueprint = z.infer<typeof cultivationMethodSchema>;
+export type StrainTraitCompatibility = z.infer<typeof strainTraitCompatibilitySchema>;
+export type StrainTraitThreshold = z.infer<typeof strainTraitThresholdSchema>;


### PR DESCRIPTION
## Summary
- allow cultivation method compatibility data to capture preferred/conflicting trait thresholds with optional min/max bounds
- expose the richer compatibility types from the schema for downstream inference
- cover the cultivation method blueprints with a loader test to confirm the new compatibility shape validates

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf3929e33483259f22033b5da04682