### PR TITLE
Fix Zod number schema chaining in facade

### DIFF
--- a/src/backend/facade/index.ts
+++ b/src/backend/facade/index.ts
@@ -74,7 +74,7 @@ const uuid = z.string().uuid();
 const nonEmptyString = z.string().trim().min(1, { message: 'Value must not be empty.' });
 const finiteNumber = z
   .number({ invalid_type_error: 'Value must be a number.' })
-  .refine((value) => Number.isFinite(value), { message: 'Value must be finite.' });
+  .finite({ message: 'Value must be finite.' });
 const positiveNumber = finiteNumber.gt(0, { message: 'Value must be greater than zero.' });
 const nonNegativeNumber = finiteNumber.min(0, {
   message: 'Value must be greater than or equal to zero.',


### PR DESCRIPTION
## Summary
- replace the custom finite number refine helper with Zod's built-in `finite` constraint
- allow the positive and non-negative number schemas to reuse the corrected helper without runtime errors

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf7621dcec8325b82eebc894f3039f