### PR TITLE
feat(backend): add development socket server entrypoint

### DIFF
--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -9,8 +9,15 @@ tree mirrors the compiled layout without any experimental Node flags.
 ```bash
 pnpm --filter @weebbreed/backend dev
 # which runs:
-#   tsx watch src/index.ts
+#   tsx watch server/devServer.ts
 ```
+
+The development entry point boots the blueprint repository, seeds the initial
+game state, exposes the Socket.IO gateway on
+`http://localhost:$WEEBBREED_BACKEND_PORT` (defaults to `7331`), and starts the
+simulation clock. Adjust the listening port or RNG seed via the
+`WEEBBREED_BACKEND_PORT` and `WEEBBREED_BACKEND_SEED` environment variables as
+needed.
 
 `tsx` performs on-the-fly compilation and file watching out of the box, so the
 development workflow no longer depends on the deprecated `--loader`

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch server/devServer.ts",
     "build": "tsc --project tsconfig.json",
     "lint": "eslint --ext .ts src data",
     "test": "vitest --run --passWithNoTests",

--- a/src/backend/server/devServer.ts
+++ b/src/backend/server/devServer.ts
@@ -1,0 +1,138 @@
+import { createServer, type Server } from 'node:http';
+import process from 'node:process';
+
+import {
+  RngService,
+  SimulationFacade,
+  SocketGateway,
+  bootstrap,
+  createInitialState,
+  type StateFactoryContext,
+  type TimeStatus,
+} from '../src/index.js';
+
+const DEFAULT_PORT = 7331;
+const DEFAULT_SEED = 'dev-server';
+
+const resolvePort = (value: string | undefined): number => {
+  if (!value) {
+    return DEFAULT_PORT;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    console.warn(
+      `Invalid WEEBBREED_BACKEND_PORT value '${value}', falling back to ${DEFAULT_PORT}.`,
+    );
+    return DEFAULT_PORT;
+  }
+
+  return parsed;
+};
+
+const startHttpServer = (server: Server, port: number): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const handleError = (error: Error) => {
+      server.off('error', handleError);
+      reject(error);
+    };
+
+    server.once('error', handleError);
+    server.listen(port, () => {
+      server.off('error', handleError);
+      resolve();
+    });
+  });
+};
+
+const formatTimeStatus = (status: TimeStatus | undefined): string => {
+  if (!status) {
+    return 'unknown status';
+  }
+  return `running=${status.running} paused=${status.paused} tick=${status.tick}`;
+};
+
+const main = async (): Promise<void> => {
+  const { repository, dataDirectory, summary } = await bootstrap();
+  console.info(
+    `[devServer] Loaded blueprint repository from ${dataDirectory} (${summary.loadedFiles} files).`,
+  );
+
+  const rngSeed = process.env.WEEBBREED_BACKEND_SEED ?? process.env.WEEBBREED_SEED ?? DEFAULT_SEED;
+  const rng = new RngService(rngSeed);
+  const context: StateFactoryContext = {
+    repository,
+    rng,
+    dataDirectory,
+  };
+
+  const state = await createInitialState(context);
+  console.info('[devServer] Initial game state created.');
+
+  const server = createServer();
+  const facade = new SimulationFacade({ state });
+  const gateway = new SocketGateway({ httpServer: server, facade });
+
+  const port = resolvePort(process.env.WEEBBREED_BACKEND_PORT);
+  await startHttpServer(server, port);
+  console.info(`[devServer] Listening on http://localhost:${port}.`);
+
+  const startResult = await facade.time.start();
+  if (!startResult.ok) {
+    const details = startResult.errors?.map((error) => error.message).join(', ') ?? 'unknown error';
+    console.error(`[devServer] Failed to start simulation clock: ${details}`);
+  } else {
+    const statusDescription = formatTimeStatus(startResult.data);
+    console.info(`[devServer] Simulation clock started (${statusDescription}).`);
+  }
+
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    console.info(`[devServer] Received ${signal}, shutting down...`);
+
+    try {
+      gateway.close();
+    } catch (error) {
+      console.error('[devServer] Error while closing gateway:', error);
+    }
+
+    try {
+      await new Promise<void>((resolve) => {
+        server.close((closeError) => {
+          if (closeError) {
+            console.error('[devServer] Error while closing HTTP server:', closeError);
+          }
+          resolve();
+        });
+      });
+    } catch (error) {
+      console.error('[devServer] Unexpected error while closing HTTP server:', error);
+    }
+
+    if (startResult.ok) {
+      try {
+        await facade.time.pause();
+      } catch (error) {
+        console.error('[devServer] Error while pausing simulation during shutdown:', error);
+      }
+    }
+
+    console.info('[devServer] Shutdown complete.');
+  };
+
+  const handleSignal = (signal: NodeJS.Signals) => {
+    void shutdown(signal);
+  };
+
+  process.once('SIGINT', handleSignal);
+  process.once('SIGTERM', handleSignal);
+};
+
+main().catch((error) => {
+  console.error('[devServer] Fatal error during startup:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a development server entry that bootstraps blueprints, seeds state, exposes the Socket.IO gateway, and starts the simulation clock
- run the dev script via `tsx watch server/devServer.ts` and document the new entry point and environment toggles

## Testing
- pnpm --filter @weebbreed/backend lint

------
https://chatgpt.com/codex/tasks/task_e_68cf79f0c7e883259a7108c9865431e8