### PR TITLE
feat(frontend): make socket endpoint configurable

### DIFF
--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -16,6 +16,14 @@ consumers. All payloads are JSON and use SI units unless stated otherwise.
      structure is identical to the regular update batches documented below and
      always contains exactly one entry.
 
+### Frontend Configuration
+
+- The Vite dashboard reads the socket endpoint from the `VITE_SOCKET_URL`
+  environment variable. Create a `.env` file next to the frontend package (see
+  `.env.example`) to point the UI at a different host/port during development.
+- When the variable is omitted the UI falls back to
+  `http://localhost:7331/socket.io`, matching the default backend dev server.
+
 ## Outgoing Events
 
 ### `simulationUpdate`

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,0 +1,2 @@
+# URL used by the frontend to connect to the Socket.IO gateway
+VITE_SOCKET_URL=http://localhost:7331/socket.io

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { WorldExplorer } from './components/WorldExplorer';
 import { PersonnelView } from './components/PersonnelView';
 import { FinanceView } from './components/FinanceView';
 import { useSimulationBridge } from './hooks/useSimulationBridge';
+import { SOCKET_URL } from './config/socket';
 import { useAppStore } from './store';
 
 const PlaceholderView = ({ translationKey }: { translationKey: string }) => {
@@ -28,7 +29,7 @@ const PlaceholderView = ({ translationKey }: { translationKey: string }) => {
 const App = () => {
   const { t } = useTranslation(['common', 'simulation']);
   const currentView = useAppStore((state) => state.currentView);
-  const bridge = useSimulationBridge({ autoConnect: true });
+  const bridge = useSimulationBridge({ autoConnect: true, url: SOCKET_URL });
 
   return (
     <div className={styles.app}>

--- a/src/frontend/src/config/socket.ts
+++ b/src/frontend/src/config/socket.ts
@@ -1,0 +1,17 @@
+const DEFAULT_SOCKET_URL = 'http://localhost:7331/socket.io';
+
+const normalizeUrl = (value: string | undefined): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : undefined;
+};
+
+export const getSocketUrl = (): string => {
+  const envUrl = normalizeUrl(import.meta.env.VITE_SOCKET_URL);
+  return envUrl ?? DEFAULT_SOCKET_URL;
+};
+
+export const SOCKET_URL = getSocketUrl();

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -2,6 +2,22 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
+const DEFAULT_SOCKET_URL = 'http://localhost:7331/socket.io';
+
+const getProxyTarget = (): string | undefined => {
+  const rawValue = (process.env.VITE_SOCKET_URL ?? '').trim();
+  const effectiveValue = rawValue.length ? rawValue : DEFAULT_SOCKET_URL;
+
+  try {
+    const parsed = new URL(effectiveValue, 'http://localhost');
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+};
+
+const socketProxyTarget = getProxyTarget();
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -11,6 +27,17 @@ export default defineConfig({
       '@/engine': path.resolve(__dirname, '../backend/src/engine'),
     },
   },
+  server: socketProxyTarget
+    ? {
+        proxy: {
+          '/socket.io': {
+            target: socketProxyTarget,
+            changeOrigin: true,
+            ws: true,
+          },
+        },
+      }
+    : undefined,
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- add a frontend socket config helper that resolves VITE_SOCKET_URL with a sensible default
- pass the resolved socket URL into the simulation bridge and add a Vite dev-server proxy for /socket.io
- document the new environment variable and provide a frontend .env.example for local setup

## Testing
- pnpm --filter @weebreed/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68cf7eacc41883258f21f400e109097b