### PR TITLE
Replace navigation tabs with breadcrumb navigation

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { WorldExplorer } from './components/WorldExplorer';
 import { PersonnelView } from './components/PersonnelView';
 import { FinanceView } from './components/FinanceView';
 import { Dashboard } from './components/Dashboard';
+import { NavigationTabs } from './components/NavigationTabs';
 import { useSimulationBridge } from './hooks/useSimulationBridge';
 import { SOCKET_URL } from './config/socket';
 import { useAppStore } from './store';
@@ -33,6 +34,7 @@ const App = () => {
   return (
     <div className={styles.app}>
       <Dashboard bridge={bridge} />
+      <NavigationTabs />
 
       <main className={styles.main}>
         {currentView === 'overview' ? (

--- a/src/frontend/src/components/NavigationTabs.module.css
+++ b/src/frontend/src/components/NavigationTabs.module.css
@@ -1,54 +1,103 @@
 .nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  background: rgba(15, 23, 42, 0.55);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
-}
-
-.tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.tab {
+  width: 100%;
   padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-muted);
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid transparent;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
+  margin-bottom: var(--space-4);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(6px);
 }
 
-.tab:hover {
-  color: var(--color-text-secondary);
-  border-color: rgba(139, 92, 246, 0.25);
-}
-
-.active {
-  color: var(--color-text-primary);
-  background: linear-gradient(135deg, rgba(124, 58, 237, 0.85), rgba(139, 92, 246, 0.8));
-  border-color: rgba(124, 58, 237, 0.45);
-  box-shadow: 0 12px 30px -18px rgba(124, 58, 237, 0.75);
-}
-
-.historyButton {
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(15, 23, 42, 0.7);
   color: var(--color-text-secondary);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
 }
 
-.historyButton:hover:not(:disabled) {
+.backButton:hover,
+.backButton:focus-visible {
   color: var(--color-text-primary);
-  border-color: rgba(139, 92, 246, 0.35);
+  border-color: rgba(139, 92, 246, 0.4);
+  background: rgba(76, 29, 149, 0.55);
+  box-shadow: 0 10px 24px -16px rgba(124, 58, 237, 0.6);
+  outline: none;
+}
+
+.backButton .material-symbols-outlined {
+  font-size: 1.5rem;
+}
+
+.list {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.linkButton {
+  border: none;
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text-secondary);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.linkButton:hover,
+.linkButton:focus-visible {
+  color: var(--color-text-primary);
+  background: rgba(124, 58, 237, 0.18);
+  box-shadow: 0 12px 32px -20px rgba(124, 58, 237, 0.65);
+  outline: none;
+}
+
+.text {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+}
+
+.current {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: rgba(124, 58, 237, 0.15);
+}
+
+.separator {
+  color: rgba(148, 163, 184, 0.5);
+  font-weight: 500;
 }

--- a/src/frontend/src/components/NavigationTabs.tsx
+++ b/src/frontend/src/components/NavigationTabs.tsx
@@ -1,39 +1,149 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
-import type { NavigationView } from '../store';
+import {
+  selectSelectedRoom,
+  selectSelectedStructure,
+  selectSelectedZone,
+} from '../store/selectors';
 import styles from './NavigationTabs.module.css';
 
-const tabs: NavigationView[] = ['overview', 'world', 'personnel', 'finance', 'settings'];
+interface BreadcrumbSegment {
+  key: string;
+  label: string;
+  onClick?: () => void;
+}
 
 export const NavigationTabs = () => {
-  const { t } = useTranslation('navigation');
+  const { t } = useTranslation(['simulation', 'navigation']);
   const currentView = useAppStore((state) => state.currentView);
+  const selectedStructure = useAppStore(selectSelectedStructure);
+  const selectedStructureId = useAppStore((state) => state.selectedStructureId);
+  const selectedRoom = useAppStore(selectSelectedRoom);
+  const selectedRoomId = useAppStore((state) => state.selectedRoomId);
+  const selectedZone = useAppStore(selectSelectedZone);
+  const selectedZoneId = useAppStore((state) => state.selectedZoneId);
   const setCurrentView = useAppStore((state) => state.setCurrentView);
-  const goBack = useAppStore((state) => state.goBack);
-  const history = useAppStore((state) => state.history);
+  const resetSelection = useAppStore((state) => state.resetSelection);
+  const selectStructure = useAppStore((state) => state.selectStructure);
+  const selectRoom = useAppStore((state) => state.selectRoom);
+  const navigateUp = useAppStore((state) => state.navigateUp);
+
+  const segments = useMemo<BreadcrumbSegment[]>(() => {
+    const items: BreadcrumbSegment[] = [
+      {
+        key: 'structures-root',
+        label: t('labels.structures'),
+        onClick: () => {
+          resetSelection();
+          setCurrentView('world');
+        },
+      },
+    ];
+
+    if (selectedStructure || selectedStructureId) {
+      const structureKey = selectedStructure?.id ?? selectedStructureId ?? 'structure';
+      items.push({
+        key: structureKey,
+        label: selectedStructure?.name ?? structureKey,
+        onClick:
+          selectedRoom || selectedZone
+            ? () => {
+                if (selectedStructure?.id) {
+                  selectStructure(selectedStructure.id);
+                } else if (selectedStructureId) {
+                  selectStructure(selectedStructureId);
+                }
+              }
+            : undefined,
+      });
+    }
+
+    if (selectedRoom || selectedRoomId) {
+      const roomKey = selectedRoom?.id ?? selectedRoomId ?? 'room';
+      items.push({
+        key: roomKey,
+        label: selectedRoom?.name ?? roomKey,
+        onClick: selectedZone
+          ? () => {
+              if (selectedRoom?.id) {
+                selectRoom(selectedRoom.id);
+              } else if (selectedRoomId) {
+                selectRoom(selectedRoomId);
+              }
+            }
+          : undefined,
+      });
+    }
+
+    if (selectedZone || selectedZoneId) {
+      const zoneKey = selectedZone?.id ?? selectedZoneId ?? 'zone';
+      items.push({
+        key: zoneKey,
+        label: selectedZone?.name ?? zoneKey,
+      });
+    }
+
+    return items;
+  }, [
+    resetSelection,
+    selectRoom,
+    selectStructure,
+    selectedRoom,
+    selectedRoomId,
+    selectedStructure,
+    selectedStructureId,
+    selectedZone,
+    selectedZoneId,
+    setCurrentView,
+    t,
+  ]);
+
+  if (currentView !== 'world' || segments.length <= 1) {
+    return null;
+  }
 
   return (
-    <nav className={styles.nav}>
-      <div className={styles.tabs}>
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            type="button"
-            onClick={() => setCurrentView(tab)}
-            className={`${styles.tab} ${tab === currentView ? styles.active : ''}`}
-          >
-            {t(tab)}
-          </button>
-        ))}
-      </div>
+    <nav className={styles.nav} aria-label={t('labels.breadcrumbs')}>
       <button
         type="button"
-        className={styles.historyButton}
-        onClick={goBack}
-        disabled={history.length === 0}
+        className={styles.backButton}
+        onClick={navigateUp}
+        aria-label={t('navigation:goBack')}
       >
-        {t('goBack')}
+        <span className="material-symbols-outlined" aria-hidden>
+          arrow_back
+        </span>
       </button>
+      <ol className={styles.list}>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1;
+          if (isLast) {
+            return (
+              <li key={segment.key} className={styles.item}>
+                <span className={styles.current} aria-current="page">
+                  {segment.label}
+                </span>
+              </li>
+            );
+          }
+
+          return (
+            <li key={segment.key} className={styles.item}>
+              {segment.onClick ? (
+                <button type="button" className={styles.linkButton} onClick={segment.onClick}>
+                  {segment.label}
+                </button>
+              ) : (
+                <span className={styles.text}>{segment.label}</span>
+              )}
+              <span className={styles.separator} aria-hidden>
+                /
+              </span>
+            </li>
+          );
+        })}
+      </ol>
     </nav>
   );
 };

--- a/src/frontend/src/store/selectors.ts
+++ b/src/frontend/src/store/selectors.ts
@@ -67,3 +67,18 @@ export const selectAlertCount = (state: AppStoreState): number => {
     return count + (event.severity === 'warning' || event.severity === 'error' ? 1 : 0);
   }, 0);
 };
+
+export const selectSelectedStructure = (state: AppStoreState) => {
+  const structureId = state.selectedStructureId;
+  return structureId ? state.structures[structureId] : undefined;
+};
+
+export const selectSelectedRoom = (state: AppStoreState) => {
+  const roomId = state.selectedRoomId;
+  return roomId ? state.rooms[roomId] : undefined;
+};
+
+export const selectSelectedZone = (state: AppStoreState) => {
+  const zoneId = state.selectedZoneId;
+  return zoneId ? state.zones[zoneId] : undefined;
+};

--- a/src/frontend/src/store/slices/navigationSlice.ts
+++ b/src/frontend/src/store/slices/navigationSlice.ts
@@ -1,13 +1,10 @@
 import type { StateCreator } from 'zustand';
 import type { AppStoreState, NavigationSlice, NavigationView } from '../types';
 
-const HISTORY_LIMIT = 10;
-
 export const createNavigationSlice: StateCreator<AppStoreState, [], [], NavigationSlice> = (
   set,
 ) => ({
   currentView: 'overview',
-  history: [],
   selectedStructureId: undefined,
   selectedRoomId: undefined,
   selectedZoneId: undefined,
@@ -17,37 +14,37 @@ export const createNavigationSlice: StateCreator<AppStoreState, [], [], Navigati
         return {};
       }
 
-      const nextHistory = [...state.history, state.currentView];
-      if (nextHistory.length > HISTORY_LIMIT) {
-        nextHistory.shift();
-      }
-
       return {
         currentView: view,
-        history: nextHistory,
         ...(view !== 'world'
           ? { selectedStructureId: undefined, selectedRoomId: undefined, selectedZoneId: undefined }
           : {}),
       };
     }),
-  goBack: () =>
+  navigateUp: () =>
     set((state) => {
-      if (state.history.length === 0) {
-        return {};
+      if (state.currentView !== 'world') {
+        return { currentView: 'overview' };
       }
 
-      const nextHistory = [...state.history];
-      const previous = nextHistory.pop() ?? 'overview';
+      if (state.selectedZoneId) {
+        return { selectedZoneId: undefined };
+      }
 
-      return {
-        currentView: previous,
-        history: nextHistory,
-        ...(previous !== 'world'
-          ? { selectedStructureId: undefined, selectedRoomId: undefined, selectedZoneId: undefined }
-          : {}),
-      };
+      if (state.selectedRoomId) {
+        return { selectedRoomId: undefined, selectedZoneId: undefined };
+      }
+
+      if (state.selectedStructureId) {
+        return {
+          selectedStructureId: undefined,
+          selectedRoomId: undefined,
+          selectedZoneId: undefined,
+        };
+      }
+
+      return {};
     }),
-  clearHistory: () => set(() => ({ history: [] })),
   selectStructure: (structureId) =>
     set(() => ({
       selectedStructureId: structureId,

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -103,13 +103,11 @@ export interface SimulationSlice {
 
 export interface NavigationSlice {
   currentView: NavigationView;
-  history: NavigationView[];
   selectedStructureId?: string;
   selectedRoomId?: string;
   selectedZoneId?: string;
   setCurrentView: (view: NavigationView) => void;
-  goBack: () => void;
-  clearHistory: () => void;
+  navigateUp: () => void;
   selectStructure: (structureId?: string) => void;
   selectRoom: (roomId?: string) => void;
   selectZone: (zoneId?: string) => void;


### PR DESCRIPTION
## Summary
- replace the world navigation tabs with a breadcrumb trail driven by the selected structure, room, and zone
- add selectors and navigation helpers for navigating up the hierarchy and reset redundant history logic
- surface the breadcrumb below the dashboard with refreshed styling and ensure App wires it in

## Testing
- pnpm --filter @weebbreed/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68cf941ff7688325878426b47874cd64