### PR TITLE
Refine modal interactions and apply blur when active

### DIFF
--- a/src/frontend/src/App.module.css
+++ b/src/frontend/src/App.module.css
@@ -5,7 +5,23 @@
   max-width: var(--layout-max-width);
   display: flex;
   flex-direction: column;
+}
+
+.contentArea {
+  display: flex;
+  flex-direction: column;
   gap: var(--space-6);
+  transition: filter 180ms ease;
+}
+
+.blurred {
+  filter: blur(3px);
+  pointer-events: none;
+}
+
+:global(.content-area.blurred) {
+  filter: blur(3px);
+  pointer-events: none;
 }
 
 .main {

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -29,34 +29,42 @@ const PlaceholderView = ({ translationKey }: { translationKey: string }) => {
 
 const App = () => {
   const currentView = useAppStore((state) => state.currentView);
+  const activeModal = useAppStore((state) => state.activeModal);
   const bridge = useSimulationBridge({ autoConnect: true, url: SOCKET_URL });
+
+  const contentAreaClasses = [styles.contentArea, 'content-area'];
+  if (activeModal) {
+    contentAreaClasses.push(styles.blurred, 'blurred');
+  }
 
   return (
     <div className={styles.app}>
-      <Dashboard bridge={bridge} />
-      <NavigationTabs />
+      <div className={contentAreaClasses.join(' ')}>
+        <Dashboard bridge={bridge} />
+        <NavigationTabs />
 
-      <main className={styles.main}>
-        {currentView === 'overview' ? (
-          <Fragment>
-            <SimulationControls bridge={bridge} />
-            <SimulationOverview />
-            <TelemetryCharts />
-            <TelemetryTable />
-            <EventLog />
-          </Fragment>
-        ) : null}
+        <main className={styles.main}>
+          {currentView === 'overview' ? (
+            <Fragment>
+              <SimulationControls bridge={bridge} />
+              <SimulationOverview />
+              <TelemetryCharts />
+              <TelemetryTable />
+              <EventLog />
+            </Fragment>
+          ) : null}
 
-        {currentView === 'world' ? <WorldExplorer /> : null}
+          {currentView === 'world' ? <WorldExplorer /> : null}
 
-        {currentView === 'personnel' ? <PersonnelView /> : null}
+          {currentView === 'personnel' ? <PersonnelView /> : null}
 
-        {currentView === 'finance' ? <FinanceView /> : null}
+          {currentView === 'finance' ? <FinanceView /> : null}
 
-        {currentView === 'settings' ? (
-          <PlaceholderView translationKey="views.settingsDescription" />
-        ) : null}
-      </main>
+          {currentView === 'settings' ? (
+            <PlaceholderView translationKey="views.settingsDescription" />
+          ) : null}
+        </main>
+      </div>
 
       <ModalRoot />
     </div>

--- a/src/frontend/src/components/ModalRoot.module.css
+++ b/src/frontend/src/components/ModalRoot.module.css
@@ -134,6 +134,19 @@
     background 0.18s ease;
 }
 
+.cancel {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--color-text-muted, #cbd5f5);
+}
+
+.cancel:hover,
+.cancel:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-text-secondary, #e2e8f0);
+  outline: none;
+}
+
 .confirm {
   background: linear-gradient(135deg, rgba(124, 58, 237, 0.9), rgba(139, 92, 246, 0.82));
   border: 1px solid rgba(124, 58, 237, 0.45);

--- a/src/frontend/src/components/ModalRoot.tsx
+++ b/src/frontend/src/components/ModalRoot.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
+import type { ModalDescriptor } from '../store';
 import type { FacadeIntentCommand } from '../types/simulation';
 import styles from './ModalRoot.module.css';
 
@@ -11,6 +12,7 @@ type ModalRenderer = (
   payload: Record<string, unknown> | undefined,
   onSubmit: SubmitHandler,
   state: ModalRenderState,
+  onCancel: () => void,
 ) => JSX.Element | null;
 
 interface ModalRenderState {
@@ -29,7 +31,7 @@ const createIntent = (intent: FacadeIntentCommand, send: (intent: FacadeIntentCo
   send(intent);
 };
 
-const installDeviceModal: ModalRenderer = (t, payload, onSubmit, state) => {
+const installDeviceModal: ModalRenderer = (t, payload, onSubmit, state, onCancel) => {
   const zoneId = (payload?.zoneId as string) ?? state.defaultZoneId;
   return (
     <form className={styles.form} onSubmit={onSubmit}>
@@ -45,6 +47,9 @@ const installDeviceModal: ModalRenderer = (t, payload, onSubmit, state) => {
       <input type="hidden" name="zoneId" value={zoneId ?? ''} />
 
       <footer className={styles.actions}>
+        <button type="button" className={styles.cancel} onClick={onCancel}>
+          {t('modals.cancel')}
+        </button>
         <button type="submit" className={styles.confirm}>
           {t('modals.apply')}
         </button>
@@ -53,7 +58,7 @@ const installDeviceModal: ModalRenderer = (t, payload, onSubmit, state) => {
   );
 };
 
-const plantingModal: ModalRenderer = (t, payload, onSubmit, state) => {
+const plantingModal: ModalRenderer = (t, payload, onSubmit, state, onCancel) => {
   const zoneId = (payload?.zoneId as string) ?? state.defaultZoneId;
   return (
     <form className={styles.form} onSubmit={onSubmit}>
@@ -66,6 +71,9 @@ const plantingModal: ModalRenderer = (t, payload, onSubmit, state) => {
       <input type="hidden" name="zoneId" value={zoneId ?? ''} />
 
       <footer className={styles.actions}>
+        <button type="button" className={styles.cancel} onClick={onCancel}>
+          {t('modals.cancel')}
+        </button>
         <button type="submit" className={styles.confirm}>
           {t('modals.apply')}
         </button>
@@ -74,7 +82,7 @@ const plantingModal: ModalRenderer = (t, payload, onSubmit, state) => {
   );
 };
 
-const automationPlanModal: ModalRenderer = (t, payload, onSubmit, state) => {
+const automationPlanModal: ModalRenderer = (t, payload, onSubmit, state, onCancel) => {
   const zoneId = (payload?.zoneId as string) ?? state.defaultZoneId;
   return (
     <form className={styles.form} onSubmit={onSubmit}>
@@ -92,6 +100,9 @@ const automationPlanModal: ModalRenderer = (t, payload, onSubmit, state) => {
       <input type="hidden" name="zoneId" value={zoneId ?? ''} />
 
       <footer className={styles.actions}>
+        <button type="button" className={styles.cancel} onClick={onCancel}>
+          {t('modals.cancel')}
+        </button>
         <button type="submit" className={styles.confirm}>
           {t('modals.apply')}
         </button>
@@ -100,7 +111,7 @@ const automationPlanModal: ModalRenderer = (t, payload, onSubmit, state) => {
   );
 };
 
-const treatmentModal: ModalRenderer = (t, payload, onSubmit, state) => {
+const treatmentModal: ModalRenderer = (t, payload, onSubmit, state, onCancel) => {
   const zoneId = (payload?.zoneId as string) ?? state.defaultZoneId;
   return (
     <form className={styles.form} onSubmit={onSubmit}>
@@ -116,6 +127,9 @@ const treatmentModal: ModalRenderer = (t, payload, onSubmit, state) => {
       <input type="hidden" name="zoneId" value={zoneId ?? ''} />
 
       <footer className={styles.actions}>
+        <button type="button" className={styles.cancel} onClick={onCancel}>
+          {t('modals.cancel')}
+        </button>
         <button type="submit" className={styles.confirm}>
           {t('modals.apply')}
         </button>
@@ -124,7 +138,7 @@ const treatmentModal: ModalRenderer = (t, payload, onSubmit, state) => {
   );
 };
 
-const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
+const createEntityModal: ModalRenderer = (t, payload, onSubmit, state, onCancel) => {
   const entity = payload?.entity as string | undefined;
   if (entity === 'room') {
     return (
@@ -151,6 +165,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         <input id="room-height" name="height" type="number" min={1} step={0.1} defaultValue={3} />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -188,6 +205,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         <input id="zone-target" name="targetPlantCount" type="number" min={1} defaultValue={8} />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -220,6 +240,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -238,6 +261,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         <input id="training-hours" name="hours" type="number" min={1} defaultValue={4} />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -256,6 +282,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         <input id="inventory-quantity" name="quantity" type="number" min={1} required />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -298,6 +327,9 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
         />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -309,7 +341,7 @@ const createEntityModal: ModalRenderer = (t, payload, onSubmit, state) => {
   return null;
 };
 
-const updateEntityModal: ModalRenderer = (t, payload, onSubmit) => {
+const updateEntityModal: ModalRenderer = (t, payload, onSubmit, _state, onCancel) => {
   const entity = payload?.entity as string | undefined;
   if (entity === 'room') {
     return (
@@ -325,6 +357,9 @@ const updateEntityModal: ModalRenderer = (t, payload, onSubmit) => {
         <input id="update-room-area" name="area" type="number" min={1} step={0.5} />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -344,6 +379,9 @@ const updateEntityModal: ModalRenderer = (t, payload, onSubmit) => {
         <input id="assignment-zone" name="zoneId" />
 
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.confirm}>
             {t('modals.apply')}
           </button>
@@ -355,7 +393,7 @@ const updateEntityModal: ModalRenderer = (t, payload, onSubmit) => {
   return null;
 };
 
-const deleteEntityModal: ModalRenderer = (t, payload, onSubmit) => {
+const deleteEntityModal: ModalRenderer = (t, payload, onSubmit, _state, onCancel) => {
   const entity = payload?.entity as string | undefined;
   if (entity === 'employee') {
     return (
@@ -363,6 +401,9 @@ const deleteEntityModal: ModalRenderer = (t, payload, onSubmit) => {
         <input type="hidden" name="employeeId" value={(payload?.employeeId as string) ?? ''} />
         <p>{t('modals.terminateEmployeeDescription')}</p>
         <footer className={styles.actions}>
+          <button type="button" className={styles.cancel} onClick={onCancel}>
+            {t('modals.cancel')}
+          </button>
           <button type="submit" className={styles.danger}>
             {t('modals.confirmDelete')}
           </button>
@@ -390,22 +431,47 @@ export const ModalRoot = () => {
   const issueFacadeIntent = useAppStore((state) => state.issueFacadeIntent);
   const issueControlCommand = useAppStore((state) => state.issueControlCommand);
   const timeStatus = useAppStore((state) => state.timeStatus);
+  const wasRunningBeforeModal = useAppStore((state) => state.wasRunningBeforeModal);
+  const setWasRunningBeforeModal = useAppStore((state) => state.setWasRunningBeforeModal);
   const stateRef = useRef<ModalRenderState>({});
-  const shouldResumeRef = useRef(false);
+  const previousModalRef = useRef<ModalDescriptor | null>(null);
 
   const renderer = activeModal ? MODAL_RENDERERS[activeModal.kind] : undefined;
 
   useEffect(() => {
-    if (activeModal?.autoPause && timeStatus && !timeStatus.paused) {
-      issueControlCommand({ action: 'pause' });
-      shouldResumeRef.current = true;
+    const previousModal = previousModalRef.current;
+    const hasNewModal = Boolean(activeModal && activeModal !== previousModal);
+    const hasClosedModal = Boolean(!activeModal && previousModal);
+
+    if (hasNewModal) {
+      const hadPreviousModal = Boolean(previousModal);
+      const wasRunning = Boolean(timeStatus?.running && !timeStatus?.paused);
+
+      if (!hadPreviousModal) {
+        setWasRunningBeforeModal(wasRunning);
+      }
+
+      if (activeModal?.autoPause && wasRunning) {
+        issueControlCommand({ action: 'pause' });
+      }
     }
 
-    if (!activeModal && shouldResumeRef.current) {
-      issueControlCommand({ action: 'resume' });
-      shouldResumeRef.current = false;
+    if (hasClosedModal) {
+      if (wasRunningBeforeModal) {
+        issueControlCommand({ action: 'resume' });
+      }
+
+      setWasRunningBeforeModal(false);
     }
-  }, [activeModal, issueControlCommand, timeStatus]);
+
+    previousModalRef.current = activeModal ?? null;
+  }, [
+    activeModal,
+    issueControlCommand,
+    setWasRunningBeforeModal,
+    timeStatus,
+    wasRunningBeforeModal,
+  ]);
 
   useEffect(() => {
     if (activeModal?.payload?.zoneId && typeof activeModal.payload.zoneId === 'string') {
@@ -416,6 +482,10 @@ export const ModalRoot = () => {
   if (!activeModal || !renderer) {
     return null;
   }
+
+  const handleCancel = () => {
+    closeModal();
+  };
 
   const handleSubmit: SubmitHandler = (event) => {
     event.preventDefault();
@@ -658,7 +728,7 @@ export const ModalRoot = () => {
   };
 
   return (
-    <div className={styles.backdrop} role="presentation" onClick={closeModal}>
+    <div className={styles.backdrop} role="presentation">
       <div
         className={styles.modal}
         role="dialog"
@@ -679,7 +749,7 @@ export const ModalRoot = () => {
         {activeModal.description ? (
           <p className={styles.description}>{activeModal.description}</p>
         ) : null}
-        {renderer(t, activeModal.payload, handleSubmit, stateRef.current)}
+        {renderer(t, activeModal.payload, handleSubmit, stateRef.current, handleCancel)}
       </div>
     </div>
   );

--- a/src/frontend/src/store/slices/modalSlice.ts
+++ b/src/frontend/src/store/slices/modalSlice.ts
@@ -3,6 +3,9 @@ import type { AppStoreState, ModalDescriptor, ModalSlice } from '../types';
 
 export const createModalSlice: StateCreator<AppStoreState, [], [], ModalSlice> = (set) => ({
   activeModal: null,
+  wasRunningBeforeModal: false,
   openModal: (modal: ModalDescriptor) => set(() => ({ activeModal: modal })),
   closeModal: () => set(() => ({ activeModal: null })),
+  setWasRunningBeforeModal: (wasRunning: boolean) =>
+    set(() => ({ wasRunningBeforeModal: wasRunning })),
 });

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -108,10 +108,7 @@ export interface SimulationSlice {
   removeRoom: (roomId: string) => void;
   removeZone: (zoneId: string) => void;
   applyWater: (zoneId: string, liters: number) => void;
-  applyNutrients: (
-    zoneId: string,
-    nutrients: { N: number; P: number; K: number },
-  ) => void;
+  applyNutrients: (zoneId: string, nutrients: { N: number; P: number; K: number }) => void;
   toggleDeviceGroup: (zoneId: string, deviceKind: string, enabled: boolean) => void;
   harvestPlanting: (plantingId: string) => void;
   harvestPlantings: (plantingIds: string[]) => void;
@@ -152,8 +149,10 @@ export interface ModalDescriptor {
 
 export interface ModalSlice {
   activeModal: ModalDescriptor | null;
+  wasRunningBeforeModal: boolean;
   openModal: (modal: ModalDescriptor) => void;
   closeModal: () => void;
+  setWasRunningBeforeModal: (wasRunning: boolean) => void;
 }
 
 export type AppStoreState = SimulationSlice & NavigationSlice & ModalSlice;


### PR DESCRIPTION
## Summary
- track whether the simulation was running before a modal opens and pause/resume through the modal slice and ModalRoot effect
- add explicit cancel buttons to modal footers and rely on those controls (and the header button) instead of backdrop clicks
- wrap the main content area so it can be blurred when a modal is active, matching the spec’s visual guidance

## Testing
- pnpm --filter @weebbreed/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68cf9c1b8490832591a92236cfb85ce9