### PR TITLE
Assign UUIDs to room purposes and centralize ids

### DIFF
--- a/data/blueprints/roomPurposes/breakroom.json
+++ b/data/blueprints/roomPurposes/breakroom.json
@@ -1,6 +1,14 @@
 {
-  "id": "breakroom",
+  "id": "5ab7d9ac-f14a-45d9-b5f9-908182ca4a02",
   "kind": "RoomPurpose",
   "name": "Break Room",
-  "description": "A space for employees to rest and recover energy."
+  "description": "A space for employees to rest and recover energy.",
+  "flags": {
+    "supportsRest": true,
+    "staffOnly": true
+  },
+  "economy": {
+    "areaCost": 280,
+    "baseRentPerTick": 1.5
+  }
 }

--- a/data/blueprints/roomPurposes/growroom.json
+++ b/data/blueprints/roomPurposes/growroom.json
@@ -1,6 +1,14 @@
 {
-  "id": "growroom",
+  "id": "2630459c-fc40-4e91-a69f-b47665b5a917",
   "kind": "RoomPurpose",
   "name": "Grow Room",
-  "description": "A room designed for cultivating plants under controlled conditions."
+  "description": "A room designed for cultivating plants under controlled conditions.",
+  "flags": {
+    "supportsCultivation": true,
+    "requiresControlledEnvironment": true
+  },
+  "economy": {
+    "areaCost": 950,
+    "baseRentPerTick": 4.8
+  }
 }

--- a/data/blueprints/roomPurposes/lab.json
+++ b/data/blueprints/roomPurposes/lab.json
@@ -1,6 +1,14 @@
 {
-  "id": "lab",
+  "id": "05566944-af3c-40f5-9d22-2cbe701457c7",
   "kind": "RoomPurpose",
   "name": "Laboratory",
-  "description": "A facility for research and breeding new plant strains."
+  "description": "A facility for research and breeding new plant strains.",
+  "flags": {
+    "supportsResearch": true,
+    "requiresSterileAccess": true
+  },
+  "economy": {
+    "areaCost": 1200,
+    "baseRentPerTick": 5.5
+  }
 }

--- a/data/blueprints/roomPurposes/salesroom.json
+++ b/data/blueprints/roomPurposes/salesroom.json
@@ -1,6 +1,14 @@
 {
-  "id": "salesroom",
+  "id": "828aa416-37be-4176-bfa6-9ce847e9dfd5",
   "kind": "RoomPurpose",
   "name": "Sales Room",
-  "description": "A commercial space for selling harvested products."
+  "description": "A commercial space for selling harvested products.",
+  "flags": {
+    "customerFacing": true,
+    "requiresPointOfSale": true
+  },
+  "economy": {
+    "areaCost": 600,
+    "baseRentPerTick": 3.2
+  }
 }

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ZoneEnvironmentService } from './zoneEnvironment.js';
+import { ROOM_PURPOSE_IDS } from '../roomPurposeIds.js';
 import type {
   DeviceInstanceState,
   FootprintDimensions,
@@ -93,7 +94,7 @@ const createRoom = (zone: ZoneState): RoomState => ({
   id: 'room-1',
   structureId: 'structure-1',
   name: 'Grow Room',
-  purposeId: 'growroom',
+  purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
   area: 40,
   height: 3,
   volume: 120,

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { PlantHealthEngine } from './healthEngine.js';
 import type { DiseaseBalancingConfig, PestBalancingConfig, TreatmentOption } from './models.js';
 import { createEventCollector, type SimulationEvent } from '../../lib/eventBus.js';
+import { ROOM_PURPOSE_IDS } from '../roomPurposeIds.js';
 import type {
   DiseaseState,
   GameState,
@@ -184,7 +185,7 @@ const createGameState = (): GameState => {
     id: 'room-1',
     structureId: 'structure-1',
     name: 'Grow Room',
-    purposeId: 'growroom',
+    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
     area: 40,
     height: 3,
     volume: 120,

--- a/src/backend/src/engine/roomPurposeIds.ts
+++ b/src/backend/src/engine/roomPurposeIds.ts
@@ -1,0 +1,19 @@
+export const ROOM_PURPOSE_IDS = {
+  GROW_ROOM: '2630459c-fc40-4e91-a69f-b47665b5a917',
+  BREAK_ROOM: '5ab7d9ac-f14a-45d9-b5f9-908182ca4a02',
+  LABORATORY: '05566944-af3c-40f5-9d22-2cbe701457c7',
+  SALES_ROOM: '828aa416-37be-4176-bfa6-9ce847e9dfd5',
+} as const;
+
+export type RoomPurposeId = (typeof ROOM_PURPOSE_IDS)[keyof typeof ROOM_PURPOSE_IDS];
+
+export const ROOM_PURPOSE_IDS_BY_NAME = {
+  'Grow Room': ROOM_PURPOSE_IDS.GROW_ROOM,
+  'Break Room': ROOM_PURPOSE_IDS.BREAK_ROOM,
+  Laboratory: ROOM_PURPOSE_IDS.LABORATORY,
+  'Sales Room': ROOM_PURPOSE_IDS.SALES_ROOM,
+} as const;
+
+export const ROOM_PURPOSE_NAMES_BY_ID = Object.fromEntries(
+  Object.entries(ROOM_PURPOSE_IDS_BY_NAME).map(([name, id]) => [id, name]),
+) as Record<RoomPurposeId, keyof typeof ROOM_PURPOSE_IDS_BY_NAME>;

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { EventBus } from '../lib/eventBus.js';
+import { ROOM_PURPOSE_IDS } from '../engine/roomPurposeIds.js';
 import type {
   DeviceInstanceState,
   GameState,
@@ -185,7 +186,7 @@ const createGameStateWithZone = (): GameState => {
     id: 'room-1',
     structureId: 'structure-1',
     name: 'Grow Room',
-    purposeId: 'growroom',
+    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
     area: 40,
     height: 3,
     volume: 120,

--- a/src/backend/src/state/initialization/tasks.test.ts
+++ b/src/backend/src/state/initialization/tasks.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { RngService } from '../../lib/rng.js';
+import { ROOM_PURPOSE_IDS } from '../../engine/roomPurposeIds.js';
 import type {
   StructureState,
   ZoneHealthState,
@@ -112,7 +113,7 @@ describe('state/initialization/tasks', () => {
       id: 'room-1',
       structureId: 'structure-1',
       name: 'Room Test',
-      purposeId: 'growroom',
+      purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
       area: 60,
       height: 4,
       volume: 240,

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -38,6 +38,7 @@ import {
 import { createFinanceState } from './state/initialization/finance.js';
 import { createPersonnel, loadPersonnelDirectory } from './state/initialization/personnel.js';
 import { createTasks, loadTaskDefinitions } from './state/initialization/tasks.js';
+import { ROOM_PURPOSE_IDS } from './engine/roomPurposeIds.js';
 
 export { loadStructureBlueprints } from './state/initialization/blueprints.js';
 export { loadPersonnelDirectory } from './state/initialization/personnel.js';
@@ -262,7 +263,7 @@ const buildStructureState = (
     id: growRoomId,
     structureId,
     name: 'Grow Room Alpha',
-    purposeId: 'growroom',
+    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
     area: growRoomArea,
     height: footprint.height,
     volume: growRoomArea * footprint.height,
@@ -275,7 +276,7 @@ const buildStructureState = (
     id: generateId(idStream, 'room'),
     structureId,
     name: 'Support Room',
-    purposeId: 'breakroom',
+    purposeId: ROOM_PURPOSE_IDS.BREAK_ROOM,
     area: supportRoomArea,
     height: footprint.height,
     volume: supportRoomArea * footprint.height,

--- a/src/frontend/src/components/WorldExplorer.tsx
+++ b/src/frontend/src/components/WorldExplorer.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ROOM_PURPOSE_IDS } from '@/engine/roomPurposeIds';
 import { useAppStore } from '../store';
 import type { DeviceSnapshot, PlantSnapshot, ZoneSnapshot } from '../types/simulation';
 import { BreedingStationPlaceholder } from './world-explorer/BreedingStationPlaceholder';
@@ -111,7 +112,10 @@ export const WorldExplorer = () => {
           .map((zoneId) => zones[zoneId])
           .filter((zone): zone is NonNullable<typeof zone> => Boolean(zone));
         const resolvedPlants = roomZones.flatMap((zone) => groupPlantsByZone(zone, plants));
-        const totalYield = resolvedPlants.reduce((sum, plant) => sum + (plant.yieldDryGrams ?? 0), 0);
+        const totalYield = resolvedPlants.reduce(
+          (sum, plant) => sum + (plant.yieldDryGrams ?? 0),
+          0,
+        );
         return {
           room,
           zoneCount: roomZones.length,
@@ -122,7 +126,7 @@ export const WorldExplorer = () => {
   }, [activeStructure, rooms, zones, plants]);
 
   const activeRoom = selectedRoomId ? rooms[selectedRoomId] : undefined;
-  const isLabRoom = activeRoom?.purposeId === 'lab';
+  const isLabRoom = activeRoom?.purposeId === ROOM_PURPOSE_IDS.LABORATORY;
 
   const zoneSummaries: ZoneSummary[] = useMemo(() => {
     if (!activeRoom || isLabRoom) {
@@ -132,10 +136,13 @@ export const WorldExplorer = () => {
       .map((zoneId) => zones[zoneId])
       .filter((zone): zone is NonNullable<typeof zone> => Boolean(zone))
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((zone) => ({
-        zone,
-        plants: groupPlantsByZone(zone, plants),
-      } satisfies ZoneSummary));
+      .map(
+        (zone) =>
+          ({
+            zone,
+            plants: groupPlantsByZone(zone, plants),
+          }) satisfies ZoneSummary,
+      );
   }, [activeRoom, zones, plants, isLabRoom]);
 
   const activeZone = selectedZoneId ? zones[selectedZoneId] : undefined;
@@ -291,7 +298,9 @@ export const WorldExplorer = () => {
             disabled={isLabRoom}
             emptyState={
               isLabRoom
-                ? t('labels.labNoZones', { defaultValue: 'Laboratories use breeding stations instead of zones.' })
+                ? t('labels.labNoZones', {
+                    defaultValue: 'Laboratories use breeding stations instead of zones.',
+                  })
                 : undefined
             }
           />
@@ -342,7 +351,9 @@ export const WorldExplorer = () => {
               }
               onHarvestPlant={(plantId) => harvestPlanting(plantId)}
               onHarvestAll={(plantIds) => harvestPlantings(plantIds)}
-              onToggleDeviceGroup={(kind, enabled) => toggleDeviceGroup(resolvedZone.zone.id, kind, enabled)}
+              onToggleDeviceGroup={(kind, enabled) =>
+                toggleDeviceGroup(resolvedZone.zone.id, kind, enabled)
+              }
               onTogglePlan={(enabled) => togglePlantingPlan(resolvedZone.zone.id, enabled)}
             />
           ) : (

--- a/src/frontend/src/components/world-explorer/RoomGrid.tsx
+++ b/src/frontend/src/components/world-explorer/RoomGrid.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ROOM_PURPOSE_IDS } from '@/engine/roomPurposeIds';
 import type { RoomSnapshot } from '../../types/simulation';
 import styles from './HierarchyGrid.module.css';
 
@@ -21,8 +22,8 @@ interface RoomGridProps {
 }
 
 const PURPOSE_LABELS: Record<string, string> = {
-  lab: 'labels.roomPurposeLab',
-  growroom: 'labels.roomPurposeGrow',
+  [ROOM_PURPOSE_IDS.LABORATORY]: 'labels.roomPurposeLab',
+  [ROOM_PURPOSE_IDS.GROW_ROOM]: 'labels.roomPurposeGrow',
 };
 
 export const RoomGrid = ({
@@ -87,7 +88,10 @@ export const RoomGrid = ({
             const isEditing = editingId === room.id;
             const isActive = selectedRoomId === room.id;
             return (
-              <article key={room.id} className={`${styles.card} ${isActive ? styles.cardActive : ''}`.trim()}>
+              <article
+                key={room.id}
+                className={`${styles.card} ${isActive ? styles.cardActive : ''}`.trim()}
+              >
                 <header className={styles.cardHeader}>
                   <div className={styles.cardTitleGroup}>
                     {isEditing ? (
@@ -123,7 +127,9 @@ export const RoomGrid = ({
                       <span>
                         {t('labels.roomArea', {
                           defaultValue: '{{value}} m²',
-                          value: room.area?.toLocaleString(undefined, { maximumFractionDigits: 1 }) ?? '—',
+                          value:
+                            room.area?.toLocaleString(undefined, { maximumFractionDigits: 1 }) ??
+                            '—',
                         })}
                       </span>
                     </span>
@@ -154,7 +160,11 @@ export const RoomGrid = ({
                       type="button"
                       className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                       onClick={() => {
-                        if (window.confirm(t('labels.confirmDeleteRoom', { defaultValue: 'Delete this room?' }))) {
+                        if (
+                          window.confirm(
+                            t('labels.confirmDeleteRoom', { defaultValue: 'Delete this room?' }),
+                          )
+                        ) {
                           onDelete(room.id);
                         }
                       }}

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["*"],
+      "@/ui/*": ["ui/*"],
+      "@/engine/*": ["../../backend/src/engine/*"]
+    }
   },
   "include": ["src", "vite.config.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- assign stable UUIDs and metadata to the shipped room purpose blueprints
- add shared room purpose id constants and update backend code to consume them
- align the UI helpers with the new identifiers so labels resolve correctly

## Testing
- pnpm --filter @weebbreed/backend test -- roomPurposeRegistry

------
https://chatgpt.com/codex/tasks/task_e_68cfab41bb688325be189b8b4bd1f60e