### PR TITLE
Load room purposes at startup and use dynamic ids

### DIFF
--- a/src/backend/server/socketGateway.ts
+++ b/src/backend/server/socketGateway.ts
@@ -1,6 +1,7 @@
 import type { Server as HttpServer } from 'node:http';
 import { Server as IOServer, type ServerOptions as IOServerOptions, type Socket } from 'socket.io';
 import { z, type ZodError } from 'zod';
+import { requirePurposeById } from '../src/engine/roomPurposeRegistry.js';
 import type {
   CommandError,
   CommandResult,
@@ -103,6 +104,7 @@ interface RoomSnapshot {
   structureId: string;
   structureName: string;
   purposeId: string;
+  purposeName: string;
   area: number;
   height: number;
   volume: number;
@@ -192,7 +194,7 @@ interface FinanceSummarySnapshot {
   lastTickExpenses: number;
 }
 
-interface SimulationSnapshot {
+export interface SimulationSnapshot {
   tick: number;
   clock: {
     tick: number;
@@ -402,6 +404,7 @@ const buildSnapshot = (state: GameState): SimulationSnapshot => {
         structureId: structure.id,
         structureName: structure.name,
         purposeId: room.purposeId,
+        purposeName: requirePurposeById(room.purposeId).name,
         area: room.area,
         height: room.height,
         volume: room.volume,

--- a/src/backend/src/engine/environment/deviceDegradation.test.ts
+++ b/src/backend/src/engine/environment/deviceDegradation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { DeviceDegradationService } from './deviceDegradation.js';
 import type {
   DeviceInstanceState,
@@ -7,6 +7,8 @@ import type {
   ZoneMetricState,
   ZoneResourceState,
 } from '../../state/models.js';
+import { resolvePurposeIdByName } from '../roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
 
 const LAMBDA = 1e-5;
 const EXPONENT = 0.9;
@@ -151,7 +153,7 @@ const createStateWithDevice = (device: DeviceInstanceState): GameState => {
           id: 'room-1',
           structureId: 'structure-1',
           name: 'Room 1',
-          purposeId: 'grow-room',
+          purposeId: growRoomPurposeId,
           area: 100,
           height: 4,
           volume: 400,
@@ -181,6 +183,13 @@ const createStateWithDevice = (device: DeviceInstanceState): GameState => {
   ];
   return state;
 };
+
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+});
 
 const computeWear = (runtimeHours: number): number => {
   if (runtimeHours <= 0) {

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { ZoneEnvironmentService } from './zoneEnvironment.js';
-import { ROOM_PURPOSE_IDS } from '../roomPurposeIds.js';
+import { resolvePurposeIdByName } from '../roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
 import type {
   DeviceInstanceState,
   FootprintDimensions,
@@ -46,6 +47,13 @@ const createHealth = (): ZoneHealthState => ({
   plantHealth: {},
   pendingTreatments: [],
   appliedTreatments: [],
+});
+
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
 });
 
 const createDevice = (
@@ -94,7 +102,7 @@ const createRoom = (zone: ZoneState): RoomState => ({
   id: 'room-1',
   structureId: 'structure-1',
   name: 'Grow Room',
-  purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
+  purposeId: growRoomPurposeId,
   area: 40,
   height: 3,
   volume: 120,

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { PlantHealthEngine } from './healthEngine.js';
 import type { DiseaseBalancingConfig, PestBalancingConfig, TreatmentOption } from './models.js';
 import { createEventCollector, type SimulationEvent } from '../../lib/eventBus.js';
-import { ROOM_PURPOSE_IDS } from '../roomPurposeIds.js';
+import { resolvePurposeIdByName } from '../roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
 import type {
   DiseaseState,
   GameState,
@@ -161,6 +162,13 @@ const createZoneHealth = (plants: PlantState[]): ZoneHealthState => {
   } satisfies ZoneHealthState;
 };
 
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+});
+
 const createGameState = (): GameState => {
   const createdAt = '2024-01-01T00:00:00.000Z';
   const environment = createEnvironment();
@@ -185,7 +193,7 @@ const createGameState = (): GameState => {
     id: 'room-1',
     structureId: 'structure-1',
     name: 'Grow Room',
-    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
+    purposeId: growRoomPurposeId,
     area: 40,
     height: 3,
     volume: 120,

--- a/src/backend/src/engine/workforce/workforceEngine.test.ts
+++ b/src/backend/src/engine/workforce/workforceEngine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createEventCollector } from '../../lib/eventBus.js';
 import type { SimulationEvent } from '../../lib/eventBus.js';
 import type {
@@ -11,6 +11,15 @@ import type {
   ZoneState,
 } from '../../state/models.js';
 import { WorkforceEngine } from './workforceEngine.js';
+import { resolvePurposeIdByName } from '../roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+});
 
 const createBaseState = (): GameState => {
   const zone: ZoneState = {
@@ -103,7 +112,7 @@ const createBaseState = (): GameState => {
             id: 'room-1',
             structureId: 'structure-1',
             name: 'Grow Room',
-            purposeId: 'grow',
+            purposeId: growRoomPurposeId,
             area: 100,
             height: 4,
             volume: 400,

--- a/src/backend/src/engine/workforce/workforceIntegration.test.ts
+++ b/src/backend/src/engine/workforce/workforceIntegration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createEventCollector } from '../../lib/eventBus.js';
 import type { SimulationEvent } from '../../lib/eventBus.js';
 import type {
@@ -9,6 +9,15 @@ import type {
   ZoneState,
 } from '../../state/models.js';
 import { WorkforceEngine } from './workforceEngine.js';
+import { resolvePurposeIdByName } from '../roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+});
 
 const createBaseState = (): GameState => {
   const zone: ZoneState = {
@@ -84,7 +93,7 @@ const createBaseState = (): GameState => {
             id: 'room-1',
             structureId: 'structure-1',
             name: 'Grow Room',
-            purposeId: 'grow',
+            purposeId: growRoomPurposeId,
             area: 100,
             height: 4,
             volume: 400,

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { inspect } from 'node:util';
 import { BlueprintRepository } from '../data/index.js';
 import { DataLoaderError, type DataLoadSummary } from '../data/dataLoader.js';
+import { loadRoomPurposes } from './engine/roomPurposeRegistry.js';
 
 export * from './state/models.js';
 export * from './lib/rng.js';
@@ -15,6 +16,7 @@ export * from './sim/loop.js';
 export * from './sim/simScheduler.js';
 export * from '../facade/index.js';
 export * from '../server/socketGateway.js';
+export * from './engine/roomPurposeRegistry.js';
 
 const moduleFilePath = fileURLToPath(import.meta.url);
 const moduleHref = pathToFileURL(moduleFilePath).href;
@@ -148,13 +150,15 @@ export const bootstrap = async (
   const dataDirectory = await resolveDataDirectory(options);
   const repository = await BlueprintRepository.loadFrom(dataDirectory);
   const summary = repository.getSummary();
+  await loadRoomPurposes({ dataDirectory });
 
   if (process.env.NODE_ENV !== 'production') {
     repository.onHotReload(
-      (result) => {
+      async (result) => {
         console.info(
           `[hot-reload] Blueprint data reloaded (${result.summary.loadedFiles} files validated).`,
         );
+        await loadRoomPurposes({ dataDirectory });
       },
       {
         onHotReloadError: (error) => {

--- a/src/backend/src/persistence/schemas.test.ts
+++ b/src/backend/src/persistence/schemas.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { SAVEGAME_KIND, saveGameEnvelopeSchema } from './schemas.js';
 import { createInitialState } from '../stateFactory.js';
 import { createStateFactoryContext } from '../testing/fixtures.js';
+import { loadTestRoomPurposes } from '../testing/loadTestRoomPurposes.js';
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+});
 
 describe('saveGameEnvelopeSchema', () => {
   it('accepts a well-formed save game envelope', async () => {

--- a/src/backend/src/persistence/schemas.ts
+++ b/src/backend/src/persistence/schemas.ts
@@ -8,6 +8,7 @@ const isoDateString = z
   });
 
 const nonEmptyString = z.string().min(1);
+const uuidString = z.string().uuid();
 
 const positiveNumber = z.number().positive();
 
@@ -186,7 +187,7 @@ const roomStateSchema = z.object({
   id: nonEmptyString,
   structureId: nonEmptyString,
   name: nonEmptyString,
-  purposeId: nonEmptyString,
+  purposeId: uuidString,
   area: z.number(),
   height: z.number(),
   volume: z.number(),

--- a/src/backend/src/sim/integrationScenarios.test.ts
+++ b/src/backend/src/sim/integrationScenarios.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { EventBus } from '../lib/eventBus.js';
 import { SimulationLoop } from './loop.js';
 import { createInitialState } from '../stateFactory.js';
@@ -17,6 +17,11 @@ import type { PhenologyState } from '../engine/plants/phenology.js';
 import { updatePlantGrowth } from '../engine/plants/growthModel.js';
 import type { BlueprintRepository } from '../../data/blueprintRepository.js';
 import type { SimulationPhaseContext } from './loop.js';
+import { loadTestRoomPurposes } from '../testing/loadTestRoomPurposes.js';
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+});
 
 interface TickMetrics {
   biomassDelta: number;

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { EventBus } from '../lib/eventBus.js';
-import { ROOM_PURPOSE_IDS } from '../engine/roomPurposeIds.js';
+import { resolvePurposeIdByName } from '../engine/roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../testing/loadTestRoomPurposes.js';
 import type {
   DeviceInstanceState,
   GameState,
@@ -186,7 +187,7 @@ const createGameStateWithZone = (): GameState => {
     id: 'room-1',
     structureId: 'structure-1',
     name: 'Grow Room',
-    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
+    purposeId: growRoomPurposeId,
     area: 40,
     height: 3,
     volume: 120,
@@ -215,6 +216,13 @@ const createGameStateWithZone = (): GameState => {
   state.structures = [structure];
   return state;
 };
+
+let growRoomPurposeId: string;
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+  growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+});
 
 describe('SimulationLoop', () => {
   it('executes phases in order and emits events after commit', async () => {

--- a/src/backend/src/state/initialization/tasks.test.ts
+++ b/src/backend/src/state/initialization/tasks.test.ts
@@ -1,9 +1,10 @@
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { RngService } from '../../lib/rng.js';
-import { ROOM_PURPOSE_IDS } from '../../engine/roomPurposeIds.js';
+import { resolvePurposeIdByName } from '../../engine/roomPurposeRegistry.js';
+import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
 import type {
   StructureState,
   ZoneHealthState,
@@ -15,6 +16,13 @@ import type {
 import { createTasks, loadTaskDefinitions } from './tasks.js';
 
 describe('state/initialization/tasks', () => {
+  let growRoomPurposeId: string;
+
+  beforeAll(async () => {
+    await loadTestRoomPurposes();
+    growRoomPurposeId = resolvePurposeIdByName('Grow Room');
+  });
+
   it('loads task definitions from configuration files', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-tasks-'));
     try {
@@ -113,7 +121,7 @@ describe('state/initialization/tasks', () => {
       id: 'room-1',
       structureId: 'structure-1',
       name: 'Room Test',
-      purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
+      purposeId: growRoomPurposeId,
       area: 60,
       height: 4,
       volume: 240,

--- a/src/backend/src/stateFactory.test.ts
+++ b/src/backend/src/stateFactory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import type { TaskDefinitionMap } from './state/models.js';
 import { createInitialState } from './stateFactory.js';
 import {
@@ -11,6 +11,11 @@ import {
   createStrainPriceMap,
   createStructureBlueprint,
 } from './testing/fixtures.js';
+import { loadTestRoomPurposes } from './testing/loadTestRoomPurposes.js';
+
+beforeAll(async () => {
+  await loadTestRoomPurposes();
+});
 
 describe('createInitialState', () => {
   it('initialises backlog tasks using provided definitions', async () => {

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -38,7 +38,7 @@ import {
 import { createFinanceState } from './state/initialization/finance.js';
 import { createPersonnel, loadPersonnelDirectory } from './state/initialization/personnel.js';
 import { createTasks, loadTaskDefinitions } from './state/initialization/tasks.js';
-import { ROOM_PURPOSE_IDS } from './engine/roomPurposeIds.js';
+import { resolvePurposeIdByName } from './engine/roomPurposeRegistry.js';
 
 export { loadStructureBlueprints } from './state/initialization/blueprints.js';
 export { loadPersonnelDirectory } from './state/initialization/personnel.js';
@@ -241,6 +241,7 @@ const buildStructureState = (
   const plantCount = Math.min(capacity, plantCountOverride ?? Math.min(12, capacity));
   const plants = createPlants(plantCount, zoneId, strain, idStream, plantStream);
   const environment = createZoneEnvironment();
+  const growRoomPurposeId = resolvePurposeIdByName('Grow Room');
   const zone: StructureCreationResult['growZone'] = {
     id: zoneId,
     roomId: '',
@@ -263,7 +264,7 @@ const buildStructureState = (
     id: growRoomId,
     structureId,
     name: 'Grow Room Alpha',
-    purposeId: ROOM_PURPOSE_IDS.GROW_ROOM,
+    purposeId: growRoomPurposeId,
     area: growRoomArea,
     height: footprint.height,
     volume: growRoomArea * footprint.height,
@@ -272,11 +273,12 @@ const buildStructureState = (
     maintenanceLevel: 0.9,
   } satisfies StructureState['rooms'][number];
 
+  const breakRoomPurposeId = resolvePurposeIdByName('Break Room');
   const supportRoom = {
     id: generateId(idStream, 'room'),
     structureId,
     name: 'Support Room',
-    purposeId: ROOM_PURPOSE_IDS.BREAK_ROOM,
+    purposeId: breakRoomPurposeId,
     area: supportRoomArea,
     height: footprint.height,
     volume: supportRoomArea * footprint.height,

--- a/src/backend/src/testing/loadTestRoomPurposes.ts
+++ b/src/backend/src/testing/loadTestRoomPurposes.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadRoomPurposes } from '../engine/roomPurposeRegistry.js';
+
+const repoRoot = path.resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
+const shippedDataDirectory = path.join(repoRoot, 'data');
+
+let loadPromise: Promise<void> | null = null;
+
+export const loadTestRoomPurposes = async (): Promise<void> => {
+  if (!loadPromise) {
+    loadPromise = loadRoomPurposes({ dataDirectory: shippedDataDirectory });
+  }
+
+  await loadPromise;
+};
+
+export const getShippedRoomPurposeDirectory = (): string => shippedDataDirectory;


### PR DESCRIPTION
## Summary
- load room purpose blueprints during bootstrap and re-export the registry helpers for downstream use
- replace hard-coded room purpose ids with registry lookups in the state factory and socket snapshots while surfacing purpose names to clients
- add a shared test helper to load the registry and update backend tests plus schemas to work with UUID purpose ids

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cfafeddbb4832593ce97e82a07379a