### PR TITLE
Add slug-aware room purpose schema and lookups

### DIFF
--- a/data/blueprints/roomPurposes/breakroom.json
+++ b/data/blueprints/roomPurposes/breakroom.json
@@ -1,6 +1,6 @@
 {
   "id": "5ab7d9ac-f14a-45d9-b5f9-908182ca4a02",
-  "kind": "RoomPurpose",
+  "kind": "breakroom",
   "name": "Break Room",
   "description": "A space for employees to rest and recover energy.",
   "flags": {

--- a/data/blueprints/roomPurposes/growroom.json
+++ b/data/blueprints/roomPurposes/growroom.json
@@ -1,6 +1,6 @@
 {
   "id": "2630459c-fc40-4e91-a69f-b47665b5a917",
-  "kind": "RoomPurpose",
+  "kind": "growroom",
   "name": "Grow Room",
   "description": "A room designed for cultivating plants under controlled conditions.",
   "flags": {

--- a/data/blueprints/roomPurposes/lab.json
+++ b/data/blueprints/roomPurposes/lab.json
@@ -1,6 +1,6 @@
 {
   "id": "05566944-af3c-40f5-9d22-2cbe701457c7",
-  "kind": "RoomPurpose",
+  "kind": "lab",
   "name": "Laboratory",
   "description": "A facility for research and breeding new plant strains.",
   "flags": {

--- a/data/blueprints/roomPurposes/salesroom.json
+++ b/data/blueprints/roomPurposes/salesroom.json
@@ -1,6 +1,6 @@
 {
   "id": "828aa416-37be-4176-bfa6-9ce847e9dfd5",
-  "kind": "RoomPurpose",
+  "kind": "salesroom",
   "name": "Sales Room",
   "description": "A commercial space for selling harvested products.",
   "flags": {

--- a/docs/room-purpose-registry.md
+++ b/docs/room-purpose-registry.md
@@ -12,12 +12,14 @@ the runtime helpers only need a source that implements `listRoomPurposes()` (the
 The helpers live at `src/engine/roomPurposes/index.ts` and export repository-oriented utilities:
 
 - `listRoomPurposes(source)` — Returns all known room purposes from a repository-like source.
-- `getRoomPurpose(source, value, { by })` — Retrieves a purpose by id (default) or name; lookups are
-  case-insensitive and return `undefined` when no match is found.
+- `getRoomPurpose(source, value, { by })` — Retrieves a purpose by id (default), name, or slug
+  (`kind`); lookups are case-insensitive and return `undefined` when no match is found.
 - `requireRoomPurpose(source, value, { by })` — Same as `getRoomPurpose` but throws when the lookup
   fails.
 - `resolveRoomPurposeId(source, name)` — Convenience helper that resolves an id from a room purpose
   name (throws when unknown).
+- `getRoomPurposeByKind(source, kind)` / `requireRoomPurposeByKind(source, kind)` — Convenience
+  wrappers around slug lookups.
 
 Example:
 
@@ -39,7 +41,11 @@ Each blueprint is validated against the following Zod schema:
   "required": ["id", "kind", "name"],
   "properties": {
     "id": { "type": "string", "format": "uuid" },
-    "kind": { "type": "string", "const": "RoomPurpose" },
+    "kind": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "description": "Lowercase slug that uniquely identifies the purpose"
+    },
     "name": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
     "flags": { "type": "object", "additionalProperties": { "type": "boolean" } },
@@ -56,5 +62,6 @@ Each blueprint is validated against the following Zod schema:
 }
 ```
 
-Additional fields are allowed to accommodate future gameplay metadata. The `kind` discriminator and
-UUID `id` ensure interoperability with other blueprint loaders.
+Additional fields are allowed to accommodate future gameplay metadata. The lowercase `kind` slug and
+UUID `id` ensure interoperability with other blueprint loaders while giving designers a human-readable
+identifier that can be referenced from JSON (e.g. `allowedRoomPurposes`).

--- a/src/backend/data/schemas/roomPurposeSchema.ts
+++ b/src/backend/data/schemas/roomPurposeSchema.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
 import type { RoomPurpose } from '../../../engine/roomPurposes/index.js';
 
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 export const roomPurposeSchema: z.ZodType<RoomPurpose> = z
   .object({
     id: z.string().uuid(),
-    kind: z.literal('RoomPurpose'),
+    kind: z.string().min(1).regex(slugPattern, {
+      message: 'kind must be a lowercase slug (letters, numbers, dashes).',
+    }),
     name: z.string().min(1),
     description: z.string().optional(),
     flags: z.record(z.boolean()).optional(),

--- a/src/backend/src/engine/roomPurposes.test.ts
+++ b/src/backend/src/engine/roomPurposes.test.ts
@@ -30,6 +30,12 @@ describe('roomPurposes module', () => {
     expect(getRoomPurpose(repository, upperId, { by: 'id' })).toMatchObject({ name: 'Grow Room' });
   });
 
+  it('resolves purposes by slug case-insensitively', () => {
+    const growRoom = requireRoomPurpose(repository, 'GROWROOM', { by: 'kind' });
+    expect(growRoom.kind).toBe('growroom');
+    expect(growRoom.name).toBe('Grow Room');
+  });
+
   it('throws when requiring an unknown purpose', () => {
     expect(() => requireRoomPurpose(repository, 'Unknown Purpose', { by: 'name' })).toThrow(
       /Unknown room purpose name/i,

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -165,7 +165,7 @@ export const createStructureBlueprint = (
 
 export const createRoomPurpose = (overrides: Partial<RoomPurpose> = {}): RoomPurpose => ({
   id: overrides.id ?? '2630459c-fc40-4e91-a69f-b47665b5a917',
-  kind: 'RoomPurpose',
+  kind: overrides.kind ?? 'growroom',
   name: overrides.name ?? 'Grow Room',
   description:
     overrides.description ?? 'A room designed for cultivating plants under controlled conditions.',
@@ -203,12 +203,14 @@ export const createBlueprintRepositoryStub = (
   const roomPurposes = options.roomPurposes ?? [
     createRoomPurpose({
       id: '2630459c-fc40-4e91-a69f-b47665b5a917',
+      kind: 'growroom',
       name: 'Grow Room',
       flags: { supportsCultivation: true },
       economy: { areaCost: 900, baseRentPerTick: 4.5 },
     }),
     createRoomPurpose({
       id: '5ab7d9ac-f14a-45d9-b5f9-908182ca4a02',
+      kind: 'breakroom',
       name: 'Break Room',
       flags: { supportsRest: true },
       economy: { areaCost: 250, baseRentPerTick: 1.2 },


### PR DESCRIPTION
## Summary
- require lowercase slug values in the room purpose schema and deduplicate blueprints by slug
- store slug strings in every shipped room-purpose blueprint and expose slug-based helpers in the room purpose module
- update fixtures, documentation, and tests to cover slug lookups alongside id and name resolution

## Testing
- `pnpm --filter @weebbreed/backend test`


------
https://chatgpt.com/codex/tasks/task_e_68cfbb7114a083259976fb64a9891eac