### PR TITLE
Add room-purpose compatibility enforcement for devices

### DIFF
--- a/data/blueprints/devices/climate_unit_01.json
+++ b/data/blueprints/devices/climate_unit_01.json
@@ -5,6 +5,7 @@
   "quality": 0.9,
   "complexity": 0.4,
   "lifespanInHours": 35040,
+  "roomPurposes": ["growroom"],
   "settings": {
     "power": 1.2,
     "coolingCapacity": 1.6,

--- a/data/blueprints/devices/co2injector-01.json
+++ b/data/blueprints/devices/co2injector-01.json
@@ -5,6 +5,7 @@
   "quality": 0.85,
   "complexity": 0.15,
   "lifespanInHours": 8760,
+  "roomPurposes": ["growroom"],
   "settings": {
     "power": 0.05,
     "targetCO2": 1100,
@@ -14,13 +15,7 @@
   },
   "meta": {
     "description": "Automated CO2 injector for controlled enrichment.",
-    "advantages": [
-      "Precise dosing",
-      "Energy efficient"
-    ],
-    "disadvantages": [
-      "Requires CO2 supply",
-      "Overuse can harm plants"
-    ]
+    "advantages": ["Precise dosing", "Energy efficient"],
+    "disadvantages": ["Requires CO2 supply", "Overuse can harm plants"]
   }
 }

--- a/data/blueprints/devices/dehumidifier-01.json
+++ b/data/blueprints/devices/dehumidifier-01.json
@@ -5,20 +5,14 @@
   "quality": 0.8,
   "complexity": 0.25,
   "lifespanInHours": 26280,
+  "roomPurposes": ["growroom"],
   "settings": {
     "latentRemovalKgPerTick": 0.05,
     "power": 0.3
   },
   "meta": {
     "description": "Compact unit for reducing ambient humidity.",
-    "advantages": [
-      "Efficient moisture removal",
-      "Low energy consumption"
-    ],
-    "disadvantages": [
-      "Limited capacity for large rooms",
-      "Generates heat"
-    ]
+    "advantages": ["Efficient moisture removal", "Low energy consumption"],
+    "disadvantages": ["Limited capacity for large rooms", "Generates heat"]
   }
 }
-

--- a/data/blueprints/devices/exhaust_fan_01.json
+++ b/data/blueprints/devices/exhaust_fan_01.json
@@ -1,4 +1,3 @@
-
 {
   "id": "f5d5c5a0-1b2c-4d3e-8f9a-0b1c2d3e4f5a",
   "kind": "Ventilation",
@@ -6,6 +5,7 @@
   "quality": 0.7,
   "complexity": 0.1,
   "lifespanInHours": 17520,
+  "roomPurposes": ["growroom"],
   "settings": {
     "power": 0.05,
     "airflow": 170

--- a/data/blueprints/devices/humidity_control_unit_01.json
+++ b/data/blueprints/devices/humidity_control_unit_01.json
@@ -5,6 +5,7 @@
   "quality": 0.8,
   "complexity": 0.3,
   "lifespanInHours": 8760,
+  "roomPurposes": ["growroom"],
   "settings": {
     "power": 0.35,
     "humidifyRateKgPerTick": 0.1,
@@ -14,14 +15,7 @@
   },
   "meta": {
     "description": "A standard unit to control humidity.",
-    "advantages": [
-      "Handles both humidification and dehumidification",
-      "Simple to operate"
-    ],
-    "disadvantages": [
-      "Limited capacity for large rooms",
-      "Requires regular maintenance"
-    ]
+    "advantages": ["Handles both humidification and dehumidification", "Simple to operate"],
+    "disadvantages": ["Limited capacity for large rooms", "Requires regular maintenance"]
   }
 }
-

--- a/data/blueprints/devices/veg_light_01.json
+++ b/data/blueprints/devices/veg_light_01.json
@@ -5,27 +5,18 @@
   "quality": 0.95,
   "complexity": 0.2,
   "lifespanInHours": 52560,
+  "roomPurposes": ["growroom"],
   "settings": {
     "power": 0.6,
     "ppfd": 800,
     "coverageArea": 1.2,
-    "spectralRange": [
-      400,
-      700
-    ],
+    "spectralRange": [400, 700],
     "heatFraction": 0.3
   },
   "meta": {
     "description": "Full-spectrum LED grow light optimized for the vegetative phase of cannabis plants. Balanced light distribution with low heat generation.",
-    "advantages": [
-      "High energy efficiency",
-      "Low heat output",
-      "Ideal for early growth stages"
-    ],
-    "disadvantages": [
-      "Limited effectiveness for flowering",
-      "Higher upfront cost compared to HPS"
-    ],
+    "advantages": ["High energy efficiency", "Low heat output", "Ideal for early growth stages"],
+    "disadvantages": ["Limited effectiveness for flowering", "Higher upfront cost compared to HPS"],
     "notes": "Best used in enclosed environments with adequate canopy management."
   }
 }

--- a/src/backend/data/schemas/deviceSchema.ts
+++ b/src/backend/data/schemas/deviceSchema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+const roomPurposeCompatibilitySchema = z.union([z.literal('*'), z.array(z.string().min(1)).min(1)]);
+
 const rangeTuple = z.tuple([z.number(), z.number()]);
 
 export const deviceSchema = z
@@ -10,6 +12,7 @@ export const deviceSchema = z
     quality: z.number(),
     complexity: z.number(),
     lifespanInHours: z.number(),
+    roomPurposes: roomPurposeCompatibilitySchema,
     settings: z
       .object({
         power: z.number().optional(),
@@ -34,4 +37,5 @@ export const deviceSchema = z
   })
   .passthrough();
 
+export type DeviceRoomPurposeCompatibility = z.infer<typeof roomPurposeCompatibilitySchema>;
 export type DeviceBlueprint = z.infer<typeof deviceSchema>;

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -132,6 +132,7 @@ export const createDeviceBlueprint = (
   quality: overrides.quality ?? 0.95,
   complexity: overrides.complexity ?? 0.5,
   lifespanInHours: overrides.lifespanInHours ?? 20_000,
+  roomPurposes: overrides.roomPurposes ?? ['growroom'],
   settings: clone({
     power: 0.8,
     coverageArea: 12,


### PR DESCRIPTION
## Summary
- add a roomPurposes compatibility field to the device schema and blueprint data
- filter device selection for zones by the target room purpose and validate installations
- expand fixtures and tests to cover compatibility filtering and rejection cases

## Testing
- pnpm --filter @weebbreed/backend test


------
https://chatgpt.com/codex/tasks/task_e_68cfc1feeef083259ae5e6a5f77b21d9