### PR TITLE
Use registry metadata for room purpose display

### DIFF
--- a/src/backend/server/socketGateway.ts
+++ b/src/backend/server/socketGateway.ts
@@ -106,6 +106,7 @@ interface RoomSnapshot {
   purposeId: string;
   purposeKind: string;
   purposeName: string;
+  purposeFlags?: Record<string, boolean>;
   area: number;
   height: number;
   volume: number;
@@ -413,6 +414,7 @@ const buildSnapshot = (
         purposeId: room.purposeId,
         purposeKind: purpose.kind,
         purposeName: purpose.name,
+        purposeFlags: purpose.flags ? { ...purpose.flags } : undefined,
         area: room.area,
         height: room.height,
         volume: room.volume,

--- a/src/frontend/src/components/WorldExplorer.tsx
+++ b/src/frontend/src/components/WorldExplorer.tsx
@@ -125,7 +125,7 @@ export const WorldExplorer = () => {
   }, [activeStructure, rooms, zones, plants]);
 
   const activeRoom = selectedRoomId ? rooms[selectedRoomId] : undefined;
-  const isLabRoom = (activeRoom?.purposeKind ?? '').toLowerCase() === 'lab';
+  const isLabRoom = Boolean(activeRoom?.purposeFlags?.supportsResearch);
 
   const zoneSummaries: ZoneSummary[] = useMemo(() => {
     if (!activeRoom || isLabRoom) {

--- a/src/frontend/src/components/world-explorer/RoomGrid.test.tsx
+++ b/src/frontend/src/components/world-explorer/RoomGrid.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RoomSnapshot } from '../../types/simulation';
+import { RoomGrid, type RoomSummary } from './RoomGrid';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => {
+      if (key === 'labels.roomPurposes.lab') {
+        return 'Translated Lab';
+      }
+      if (typeof options?.defaultValue === 'string') {
+        return options.defaultValue;
+      }
+      return key;
+    },
+  }),
+}));
+
+describe('RoomGrid', () => {
+  it('renders the room purpose from snapshot metadata', () => {
+    const room: RoomSnapshot = {
+      id: 'room-1',
+      name: 'Lab Alpha',
+      structureId: 'structure-1',
+      structureName: 'Structure A',
+      purposeId: 'purpose-lab',
+      purposeKind: 'lab',
+      purposeName: 'Laboratory',
+      purposeFlags: { supportsResearch: true },
+      area: 100,
+      height: 4,
+      volume: 400,
+      cleanliness: 0.95,
+      maintenanceLevel: 0.9,
+      zoneIds: [],
+    };
+
+    const summary: RoomSummary = {
+      room,
+      zoneCount: 0,
+      plantCount: 0,
+      totalYield: 0,
+    };
+
+    const markup = renderToStaticMarkup(
+      <RoomGrid
+        rooms={[summary]}
+        selectedRoomId={undefined}
+        onSelect={() => {}}
+        onRename={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('Laboratory');
+    expect(markup).not.toContain('Translated Lab');
+  });
+});

--- a/src/frontend/src/components/world-explorer/RoomGrid.tsx
+++ b/src/frontend/src/components/world-explorer/RoomGrid.tsx
@@ -43,18 +43,14 @@ export const RoomGrid = ({
   };
 
   const purposeLabel = (room: RoomSnapshot) => {
-    const slug = room.purposeKind?.trim().toLowerCase();
-    if (slug) {
-      const slugKey = `labels.roomPurposes.${slug}`;
-      const translated = t(slugKey, { defaultValue: room.purposeName ?? slug });
-      if (translated !== slugKey) {
-        return translated;
-      }
+    const name = room.purposeName?.trim();
+    if (name) {
+      return name;
     }
 
-    const name = room.purposeName?.trim();
-    if (name && name.length > 0) {
-      return name;
+    const fallbackKind = room.purposeKind?.trim();
+    if (fallbackKind) {
+      return fallbackKind;
     }
 
     return t('labels.roomPurposeGeneric', { defaultValue: 'General' });

--- a/src/frontend/src/i18n/locales/en/simulation.json
+++ b/src/frontend/src/i18n/locales/en/simulation.json
@@ -73,12 +73,6 @@
     "duplicateRoom": "Duplicate room",
     "confirmDeleteRoom": "Delete this room?",
     "deleteRoom": "Delete room",
-    "roomPurposes": {
-      "lab": "Laboratory",
-      "growroom": "Grow room",
-      "breakroom": "Break room",
-      "salesroom": "Sales room"
-    },
     "roomPurposeGeneric": "General",
     "roomArea": "{{value}} m²",
     "renameZone": "Rename zone",

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -133,6 +133,7 @@ export interface RoomSnapshot {
   purposeId: string;
   purposeKind: string;
   purposeName: string;
+  purposeFlags?: Record<string, boolean>;
   area: number;
   height: number;
   volume: number;


### PR DESCRIPTION
## Summary
- include room purpose names and flags from the registry in the server snapshot payload
- update the world explorer UI to consume the metadata instead of hard-coded labels and remove redundant translations
- add a RoomGrid test to ensure the rendered purpose comes from the snapshot metadata

## Testing
- pnpm --filter @weebbreed/frontend test
- pnpm --filter @weebbreed/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68cfcd8a1e3883258888601f6b2b7314