### PR TITLE
feat(runtime): add telemetry event bus module

### DIFF
--- a/docs/system/runtime-event-bus-migration.md
+++ b/docs/system/runtime-event-bus-migration.md
@@ -1,0 +1,44 @@
+# Runtime Event Bus Migration Notes
+
+## Overview
+
+The telemetry event bus now lives in `src/runtime/eventBus.ts`. The module exposes a
+singleton `eventBus`, a convenience `emit(type, payload?, tick?, level?)` helper, and
+observable accessors (`events`, `bufferedEvents`, `events$`). Downstream packages should
+consume this runtime module rather than instantiating their own telemetry bus.
+
+Key behavioural tweaks:
+
+- `EventBus.emit` supports both the original object form and the new signature
+  `emit(type, payload?, tick?, level?)`. Timestamps continue to default to `Date.now()`
+  when not provided.
+- `createEventCollector` exposes a `queue` function with the same signature to ease
+  refactors inside tick handlers. Passing an explicit `tick` overrides the collector’s
+  default; otherwise the current tick is applied automatically.
+
+## Migration Guidance
+
+1. Replace imports of `../src/lib/eventBus.js` (or equivalent) for runtime telemetry with
+   `../../runtime/eventBus.js`. The runtime module re-exports `EventBus`,
+   `createEventCollector`, and the relevant types.
+2. Update `eventBus.emit({ ... })` calls to use the helper signature where convenient:
+
+   ```ts
+   emit('plant.stageChanged', { plantId }, currentTick, 'info');
+   ```
+
+3. When queuing events during tick processing, prefer `collector.queue('type', payload,
+tick, level)` to benefit from the default tick handling.
+
+### Suggested Codemod
+
+For simple cases, a jscodeshift transform that visits `CallExpression`s on `emit` or
+`queue` can convert literal object calls to the new signature. The transform should:
+
+- Turn `bus.emit({ type: 'x', payload, tick, level })` into `bus.emit('x', payload, tick,
+level)`.
+- Turn `collector.queue({ type: 'x', payload, tick })` into
+  `collector.queue('x', payload, tick)`.
+
+Always verify transformed files and ensure custom event structures (e.g., tags) are
+handled manually.

--- a/src/backend/server/socketGateway.test.ts
+++ b/src/backend/server/socketGateway.test.ts
@@ -11,7 +11,7 @@ import type {
   SetSpeedIntent,
   Unsubscribe,
 } from '../facade/index.js';
-import { EventBus, type SimulationEvent } from '../src/lib/eventBus.js';
+import { EventBus, type SimulationEvent } from '../../runtime/eventBus.js';
 import { TICK_PHASES, type PhaseTiming, type TickCompletedPayload } from '../src/sim/loop.js';
 import type { GameState } from '../src/state/models.js';
 import { SocketGateway, type SimulationSnapshot } from './socketGateway.js';
@@ -394,13 +394,7 @@ class StubFacade {
       phaseTimings: createPhaseTimings(),
       events,
     };
-    this.eventBus.emit({
-      type: 'sim.tickCompleted',
-      tick,
-      ts: Date.now(),
-      level: 'info',
-      payload,
-    });
+    this.eventBus.emit('sim.tickCompleted', payload, tick, 'info');
   }
 
   dispose(): void {

--- a/src/backend/server/socketGateway.ts
+++ b/src/backend/server/socketGateway.ts
@@ -13,7 +13,7 @@ import type {
   SetSpeedIntent,
   Unsubscribe,
 } from '../facade/index.js';
-import type { SimulationEvent } from '../src/lib/eventBus.js';
+import type { SimulationEvent } from '../../runtime/eventBus.js';
 import type { TickCompletedPayload } from '../src/sim/loop.js';
 import type {
   ApplicantState,

--- a/src/backend/src/engine/economy/costAccounting.ts
+++ b/src/backend/src/engine/economy/costAccounting.ts
@@ -254,10 +254,9 @@ export class CostAccountingService {
     summary.lastTickExpenses = accumulator.expenses;
     summary.netIncome = summary.totalRevenue - summary.totalExpenses;
 
-    events.queue({
-      type: 'finance.tick',
-      level: 'info',
-      payload: {
+    events.queue(
+      'finance.tick',
+      {
         tick,
         timestamp,
         revenue: accumulator.revenue,
@@ -268,7 +267,9 @@ export class CostAccountingService {
         utilities: accumulator.utilities,
         maintenance: accumulator.maintenanceDetails,
       },
-    });
+      tick,
+      'info',
+    );
   }
 
   private clampUtilityConsumption(
@@ -463,17 +464,18 @@ export class CostAccountingService {
       accumulator.opex += amount;
     }
 
-    events.queue({
-      type: detailKind === 'capex' ? 'finance.capex' : 'finance.opex',
-      level: 'info',
-      payload: {
+    events.queue(
+      detailKind === 'capex' ? 'finance.capex' : 'finance.opex',
+      {
         tick,
         amount,
         category,
         description,
         ...metadata,
       },
-    });
+      tick,
+      'info',
+    );
   }
 
   private createLedgerEntry(finances: FinanceState, entry: Omit<LedgerEntry, 'id'>): LedgerEntry {

--- a/src/backend/src/engine/health/healthEngine.ts
+++ b/src/backend/src/engine/health/healthEngine.ts
@@ -162,16 +162,16 @@ export class PlantHealthEngine {
               if (pest.symptomTimerTicks <= 0 || pest.population >= PEST_DETECTION_THRESHOLD) {
                 pest.detected = true;
                 pest.detectionTick = tick;
-                context.events.queue({
-                  type: 'pest.detected',
-                  payload: {
+                context.events.queue(
+                  'pest.detected',
+                  {
                     zoneId: zone.id,
                     plantId: plant.id,
                     pestId: pest.pestId,
                     infestationId: pest.id,
                   },
                   tick,
-                });
+                );
               }
             }
 
@@ -367,9 +367,9 @@ export class PlantHealthEngine {
               };
               zoneHealth.appliedTreatments.push(record);
 
-              context.events.queue({
-                type: 'treatment.applied',
-                payload: {
+              context.events.queue(
+                'treatment.applied',
+                {
                   zoneId: zone.id,
                   plantIds: treatedPlants,
                   optionId: option.id,
@@ -377,8 +377,8 @@ export class PlantHealthEngine {
                   reentryRestrictedUntilTick: zoneHealth.reentryRestrictedUntilTick,
                   preHarvestRestrictedUntilTick: zoneHealth.preHarvestRestrictedUntilTick,
                 },
-                tick: context.tick,
-              });
+                context.tick,
+              );
             }
           }
 

--- a/src/backend/src/engine/workforce/workforceEngine.ts
+++ b/src/backend/src/engine/workforce/workforceEngine.ts
@@ -605,9 +605,9 @@ export class WorkforceEngine {
       metadata,
     };
 
-    context.events.queue({
-      type: 'task.created',
-      payload: {
+    context.events.queue(
+      'task.created',
+      {
         taskId: task.id,
         definitionId: task.definitionId,
         priority: task.priority,
@@ -616,9 +616,9 @@ export class WorkforceEngine {
         zoneId: context.zone.id,
         safety: metadata.safety,
       },
-      tick: context.tick,
-      level: 'info',
-    });
+      context.tick,
+      'info',
+    );
 
     context.taskSystem.backlog.push(task);
   }
@@ -894,17 +894,17 @@ export class WorkforceEngine {
       employee.hoursWorkedToday += allocation.totalHours;
       employee.overtimeHours += allocation.overtimeHours;
       if (allocation.overtimeHours > 0) {
-        events.queue({
-          type: 'hr.overtimeAccrued',
-          payload: {
+        events.queue(
+          'hr.overtimeAccrued',
+          {
             employeeId: employee.id,
             hours: allocation.overtimeHours,
             totalOvertimeHours: employee.overtimeHours,
             taskId: task.id,
           },
           tick,
-          level: 'info',
-        });
+          'info',
+        );
       }
 
       const baseEnergyCost = allocation.totalHours * this.policies.energy.energyCostPerHour;
@@ -958,17 +958,17 @@ export class WorkforceEngine {
     if (zone) {
       zone.activeTaskIds = zone.activeTaskIds.filter((id) => id !== task.id);
     }
-    events.queue({
-      type: 'task.completed',
-      payload: {
+    events.queue(
+      'task.completed',
+      {
         taskId: task.id,
         definitionId: task.definitionId,
         employeeId: employee.id,
         zoneId: task.location?.zoneId,
       },
       tick,
-      level: 'info',
-    });
+      'info',
+    );
   }
 
   private allocateWorkHours(employee: EmployeeState, hoursPerTick: number): WorkHoursAllocation {

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -8,6 +8,15 @@ import { DataLoaderError, type DataLoadSummary } from '../data/dataLoader.js';
 export * from './state/models.js';
 export * from './lib/rng.js';
 export * from './lib/eventBus.js';
+export {
+  eventBus as telemetryEventBus,
+  emit,
+  emitEvent,
+  emitMany,
+  events as runtimeEvents,
+  bufferedEvents,
+  events$ as runtimeEvents$,
+} from '../../runtime/eventBus.js';
 export * from './persistence/saveGame.js';
 export * from './persistence/hotReload.js';
 export * from './stateFactory.js';

--- a/src/backend/src/lib/eventBus.test.ts
+++ b/src/backend/src/lib/eventBus.test.ts
@@ -20,7 +20,7 @@ describe('EventBus', () => {
     const subscriptionA = bus.events().subscribe((event) => receivedA.push(event));
     const subscriptionB = bus.events().subscribe((event) => receivedB.push(event));
 
-    bus.emit({ type: 'sim.tickCompleted', tick: 1 });
+    bus.emit('sim.tickCompleted', undefined, 1);
 
     expect(receivedA).toHaveLength(1);
     expect(receivedB).toHaveLength(1);
@@ -35,8 +35,8 @@ describe('EventBus', () => {
     const received: SimulationEvent[] = [];
     const subscription = bus.events({ type: 'plant.*' }).subscribe((event) => received.push(event));
 
-    bus.emit({ type: 'plant.stageChanged', tick: 2 });
-    bus.emit({ type: 'sim.tickCompleted', tick: 2 });
+    bus.emit('plant.stageChanged', undefined, 2);
+    bus.emit('sim.tickCompleted', undefined, 2);
 
     expect(received).toHaveLength(1);
     expect(received[0].type).toBe('plant.stageChanged');
@@ -49,8 +49,8 @@ describe('EventBus', () => {
     const batches: SimulationEvent[][] = [];
     const subscription = bus.buffered({ timeMs: 100 }).subscribe((batch) => batches.push(batch));
 
-    bus.emit({ type: 'plant.stageChanged', tick: 3 });
-    bus.emit({ type: 'plant.harvested', tick: 3 });
+    bus.emit('plant.stageChanged', undefined, 3);
+    bus.emit('plant.harvested', undefined, 3);
 
     await vi.advanceTimersByTimeAsync(100);
 

--- a/src/backend/src/persistence/hotReload.ts
+++ b/src/backend/src/persistence/hotReload.ts
@@ -74,14 +74,15 @@ export class BlueprintHotReloadManager {
       if (!result) {
         return;
       }
-      context.events.queue({
-        type: 'sim.hotReloaded',
-        level: 'info',
-        payload: {
+      context.events.queue(
+        'sim.hotReloaded',
+        {
           appliedTick: context.tick,
           summary: normaliseSummary(result),
         },
-      });
+        context.tick,
+        'info',
+      );
     };
   }
 

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -237,12 +237,12 @@ describe('SimulationLoop', () => {
       phases: {
         applyDevices: (ctx) => {
           executed.push(ctx.phase);
-          ctx.events.queue({ type: 'device.applied', level: 'info' });
+          ctx.events.queue('device.applied', undefined, ctx.tick, 'info');
         },
         deriveEnvironment: (ctx) => executed.push(ctx.phase),
         irrigationAndNutrients: (ctx) => {
           executed.push(ctx.phase);
-          ctx.events.queue({ type: 'env.irrigated', payload: { liters: 10 } });
+          ctx.events.queue('env.irrigated', { liters: 10 }, ctx.tick);
         },
         updatePlants: (ctx) => executed.push(ctx.phase),
         harvestAndInventory: (ctx) => executed.push(ctx.phase),
@@ -272,10 +272,7 @@ describe('SimulationLoop', () => {
       eventBus: bus,
       phases: {
         applyDevices: (ctx: SimulationPhaseContext) => {
-          ctx.events.queue({
-            type: 'phase.entered',
-            payload: { phase: ctx.phase, tick: ctx.tick },
-          });
+          ctx.events.queue('phase.entered', { phase: ctx.phase, tick: ctx.tick }, ctx.tick);
         },
       },
     });

--- a/src/backend/src/sim/loop.ts
+++ b/src/backend/src/sim/loop.ts
@@ -9,8 +9,13 @@ import {
   type HarvestQualityOptions,
 } from '../engine/harvest/harvestQualityService.js';
 import type { GameState } from '../state/models.js';
-import type { EventCollector, SimulationEvent } from '../lib/eventBus.js';
-import { EventBus, createEventCollector } from '../lib/eventBus.js';
+import { eventBus as telemetryEventBus } from '../../../runtime/eventBus.js';
+import {
+  EventBus,
+  createEventCollector,
+  type EventCollector,
+  type SimulationEvent,
+} from '../lib/eventBus.js';
 
 export const TICK_PHASES = [
   'applyDevices',
@@ -121,7 +126,7 @@ class TickStateMachine {
 
 export interface SimulationLoopOptions {
   state: GameState;
-  eventBus: EventBus;
+  eventBus?: EventBus;
   phases?: SimulationPhaseHandlers;
   environment?: ZoneEnvironmentOptions;
   harvestQuality?: HarvestQualityOptions;
@@ -146,7 +151,7 @@ export class SimulationLoop {
 
   constructor(options: SimulationLoopOptions) {
     this.state = options.state;
-    this.eventBus = options.eventBus;
+    this.eventBus = options.eventBus ?? telemetryEventBus;
     const phases = options.phases ?? {};
     this.degradationService = new DeviceDegradationService();
     this.harvestQualityService = new HarvestQualityService(options.harvestQuality);

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -19,7 +19,8 @@
     "data/**/*.ts",
     "facade/**/*.ts",
     "server/**/*.ts",
-    "../engine/**/*.ts"
+    "../engine/**/*.ts",
+    "../runtime/**/*.ts"
   ],
   "exclude": ["dist", "node_modules"]
 }

--- a/src/runtime/eventBus.ts
+++ b/src/runtime/eventBus.ts
@@ -1,0 +1,56 @@
+import {
+  EventBus,
+  type EventBufferOptions,
+  type EventCollector,
+  type EventFilter,
+  type EventLevel,
+  type SimulationEvent,
+} from '../backend/src/lib/eventBus.js';
+
+const telemetryEventBus = new EventBus();
+
+const emitInternal = <T>(event: SimulationEvent<T>): void => {
+  telemetryEventBus.emit(event);
+};
+
+export const emit = <T>(
+  type: SimulationEvent<T>['type'],
+  payload?: T,
+  tick?: number,
+  level?: EventLevel,
+): void => {
+  const event: SimulationEvent<T> = {
+    type,
+    payload,
+  };
+
+  if (tick !== undefined) {
+    event.tick = tick;
+  }
+
+  if (level !== undefined) {
+    event.level = level;
+  }
+
+  emitInternal(event);
+};
+
+export const emitEvent = <T>(event: SimulationEvent<T>): void => {
+  emitInternal(event);
+};
+
+export const emitMany = (events: Iterable<SimulationEvent>): void => {
+  telemetryEventBus.emitMany(events);
+};
+
+export const events = (filter?: EventFilter) => telemetryEventBus.events(filter);
+
+export const bufferedEvents = (options?: EventBufferOptions) => telemetryEventBus.buffered(options);
+
+export const events$ = telemetryEventBus.asObservable();
+
+export { telemetryEventBus as eventBus };
+
+export type { EventBufferOptions, EventCollector, EventFilter, EventLevel, SimulationEvent };
+
+export { EventBus, createEventCollector } from '../backend/src/lib/eventBus.js';


### PR DESCRIPTION
## Summary
- add a runtime telemetry event bus module that exposes emit helpers and observable streams
- extend the event bus and collector APIs to support the new signature and update backend emitters accordingly
- default the facade and simulation loop to the runtime bus and document migration guidance for downstream packages

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test
- pnpm --filter @weebbreed/backend build *(fails: repository-wide TypeScript errors outside the touched code)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd262367c832598493da30f819704