### PR TITLE
feat: add shared UI stream and SSE gateway

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,9 @@ module.exports = {
   ],
   settings: {
     'import/resolver': {
+      node: {
+        moduleDirectory: ['node_modules', 'src/backend/node_modules']
+      },
       typescript: {
         project: [
           './tsconfig.base.json',

--- a/src/backend/server/socketGateway.test.ts
+++ b/src/backend/server/socketGateway.test.ts
@@ -433,6 +433,7 @@ describe('SocketGateway', () => {
       simulationBatchIntervalMs: 30,
       domainBatchIntervalMs: 30,
       roomPurposeSource: roomPurposeRepository,
+      eventBus: facade.eventBus,
     });
     client = createClient(`http://127.0.0.1:${port}`, {
       transports: ['websocket'],

--- a/src/backend/server/sseGateway.ts
+++ b/src/backend/server/sseGateway.ts
@@ -1,0 +1,259 @@
+import type { IncomingMessage, Server as HttpServer, ServerResponse } from 'node:http';
+import type { Observable, Subscription } from 'rxjs';
+
+import type { SimulationFacade, TimeStatus } from '../facade/index.js';
+import type { RoomPurposeSource } from '../../engine/roomPurposes/index.js';
+import {
+  createUiStream,
+  type EventBus,
+  type UiSimulationUpdateEntry,
+  type UiSimulationUpdateMessage,
+  type UiStreamPacket,
+} from '../../runtime/eventBus.js';
+import { buildSimulationSnapshot, type SimulationSnapshot } from '../src/lib/uiSnapshot.js';
+
+const DEFAULT_KEEP_ALIVE_MS = 15000;
+
+const DEFAULT_SIMULATION_BATCH_INTERVAL_MS = 120;
+const DEFAULT_SIMULATION_BATCH_MAX_SIZE = 5;
+const DEFAULT_DOMAIN_BATCH_INTERVAL_MS = 250;
+const DEFAULT_DOMAIN_BATCH_MAX_SIZE = 25;
+
+const formatData = (data: unknown): string => {
+  if (data === undefined) {
+    return 'null';
+  }
+  if (typeof data === 'string') {
+    return data;
+  }
+  return JSON.stringify(data);
+};
+
+const extractPathname = (request: IncomingMessage, fallback: string): string => {
+  if (!request.url) {
+    return fallback;
+  }
+  try {
+    const base = `http://${request.headers.host ?? 'localhost'}`;
+    return new URL(request.url, base).pathname ?? fallback;
+  } catch (error) {
+    return fallback;
+  }
+};
+
+interface SseClient {
+  readonly res: ServerResponse;
+  readonly subscription: Subscription;
+  readonly keepAliveTimer?: NodeJS.Timeout;
+  closed: boolean;
+}
+
+type SimulationUpdateEntry = UiSimulationUpdateEntry<SimulationSnapshot, TimeStatus>;
+type SimulationUpdateMessage = UiSimulationUpdateMessage<SimulationSnapshot, TimeStatus>;
+
+export interface SseGatewayOptions {
+  httpServer: HttpServer;
+  facade: SimulationFacade;
+  roomPurposeSource: RoomPurposeSource;
+  path?: string;
+  keepAliveMs?: number;
+  simulationBatchIntervalMs?: number;
+  simulationBatchMaxSize?: number;
+  domainBatchIntervalMs?: number;
+  domainBatchMaxSize?: number;
+  eventBus?: EventBus;
+  uiStream$?: Observable<UiStreamPacket<SimulationSnapshot, TimeStatus>>;
+}
+
+export class SseGateway {
+  private readonly server: HttpServer;
+
+  private readonly facade: SimulationFacade;
+
+  private readonly roomPurposeSource: RoomPurposeSource;
+
+  private readonly path: string;
+
+  private readonly keepAliveMs: number;
+
+  private readonly uiStream: Observable<UiStreamPacket<SimulationSnapshot, TimeStatus>>;
+
+  private readonly connections = new Set<SseClient>();
+
+  private readonly requestListener: (req: IncomingMessage, res: ServerResponse) => void;
+
+  private disposed = false;
+
+  constructor(options: SseGatewayOptions) {
+    this.server = options.httpServer;
+    this.facade = options.facade;
+    this.roomPurposeSource = options.roomPurposeSource;
+    this.path = options.path ?? '/events';
+    this.keepAliveMs = options.keepAliveMs ?? DEFAULT_KEEP_ALIVE_MS;
+
+    const simulationBatchInterval =
+      options.simulationBatchIntervalMs ?? DEFAULT_SIMULATION_BATCH_INTERVAL_MS;
+    const simulationBatchMaxSize =
+      options.simulationBatchMaxSize ?? DEFAULT_SIMULATION_BATCH_MAX_SIZE;
+    const domainBatchInterval = options.domainBatchIntervalMs ?? DEFAULT_DOMAIN_BATCH_INTERVAL_MS;
+    const domainBatchMaxSize = options.domainBatchMaxSize ?? DEFAULT_DOMAIN_BATCH_MAX_SIZE;
+
+    this.uiStream =
+      options.uiStream$ ??
+      createUiStream<SimulationSnapshot, TimeStatus>({
+        snapshotProvider: () =>
+          this.facade.select((state) => buildSimulationSnapshot(state, this.roomPurposeSource)),
+        timeStatusProvider: () => this.facade.getTimeStatus(),
+        eventBus: options.eventBus,
+        simulationBufferMs: simulationBatchInterval,
+        simulationMaxBatchSize: simulationBatchMaxSize,
+        domainBufferMs: domainBatchInterval,
+        domainMaxBatchSize: domainBatchMaxSize,
+      });
+
+    this.requestListener = (req, res) => this.handleRequest(req, res);
+    this.server.on('request', this.requestListener);
+  }
+
+  close(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.server.off('request', this.requestListener);
+    for (const connection of this.connections) {
+      connection.subscription.unsubscribe();
+      if (connection.keepAliveTimer) {
+        clearInterval(connection.keepAliveTimer);
+      }
+      if (!connection.res.writableEnded) {
+        connection.res.end();
+      }
+      connection.closed = true;
+    }
+    this.connections.clear();
+  }
+
+  private handleRequest(request: IncomingMessage, response: ServerResponse): void {
+    const pathname = extractPathname(request, '/events');
+    if (pathname !== this.path) {
+      return;
+    }
+
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      response.end();
+      return;
+    }
+
+    if (request.method !== 'GET') {
+      response.writeHead(405, {
+        Allow: 'GET, OPTIONS',
+        'Access-Control-Allow-Origin': '*',
+      });
+      response.end();
+      return;
+    }
+
+    this.openStream(request, response);
+  }
+
+  private openStream(request: IncomingMessage, response: ServerResponse): void {
+    response.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+      'X-Accel-Buffering': 'no',
+    });
+    if (typeof response.flushHeaders === 'function') {
+      response.flushHeaders();
+    }
+
+    const snapshot = this.facade.select((state) =>
+      buildSimulationSnapshot(state, this.roomPurposeSource),
+    );
+    const time = this.facade.getTimeStatus();
+    const handshake: SimulationUpdateEntry = {
+      tick: snapshot.tick,
+      ts: Date.now(),
+      events: [],
+      snapshot,
+      time,
+    };
+
+    this.writeEvent(response, 'gateway.protocol', { version: 1 });
+    this.writeEvent(response, 'time.status', { status: time });
+    this.writeEvent(response, 'simulationUpdate', {
+      updates: [handshake],
+    } satisfies SimulationUpdateMessage);
+
+    const client: SseClient = {
+      res: response,
+      subscription: this.uiStream.subscribe({
+        next: (packet) => this.dispatchPacket(response, packet),
+        error: () => {
+          if (!response.writableEnded) {
+            response.end();
+          }
+        },
+      }),
+      keepAliveTimer:
+        this.keepAliveMs > 0
+          ? setInterval(() => this.writeComment(response, 'keep-alive'), this.keepAliveMs)
+          : undefined,
+      closed: false,
+    };
+
+    this.connections.add(client);
+
+    const cleanup = () => {
+      if (client.closed) {
+        return;
+      }
+      client.closed = true;
+      client.subscription.unsubscribe();
+      if (client.keepAliveTimer) {
+        clearInterval(client.keepAliveTimer);
+      }
+      this.connections.delete(client);
+    };
+
+    request.on('close', cleanup);
+    response.on('close', cleanup);
+    response.on('error', cleanup);
+  }
+
+  private dispatchPacket(
+    response: ServerResponse,
+    packet: UiStreamPacket<SimulationSnapshot, TimeStatus>,
+  ): void {
+    if (!response.writable || response.writableEnded) {
+      return;
+    }
+
+    if (packet.channel === 'simulationUpdate' || packet.channel === 'sim.tickCompleted') {
+      this.writeEvent(response, packet.channel, packet.payload);
+      return;
+    }
+
+    this.writeEvent(response, packet.channel, packet.payload ?? null);
+  }
+
+  private writeEvent(response: ServerResponse, event: string, data: unknown): void {
+    response.write(`event: ${event}\n`);
+    const payload = formatData(data);
+    response.write(`data: ${payload}\n\n`);
+  }
+
+  private writeComment(response: ServerResponse, comment: string): void {
+    if (!response.writable || response.writableEnded) {
+      return;
+    }
+    response.write(`: ${comment}\n\n`);
+  }
+}

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -16,6 +16,7 @@ export {
   events as runtimeEvents,
   bufferedEvents,
   events$ as runtimeEvents$,
+  createUiStream,
 } from '../../runtime/eventBus.js';
 export * from './persistence/saveGame.js';
 export * from './persistence/hotReload.js';
@@ -24,6 +25,7 @@ export * from './sim/loop.js';
 export * from './sim/simScheduler.js';
 export * from '../facade/index.js';
 export * from '../server/socketGateway.js';
+export * from '../server/sseGateway.js';
 export * from '../../engine/roomPurposes/index.js';
 
 const moduleFilePath = fileURLToPath(import.meta.url);

--- a/src/backend/src/lib/uiSnapshot.ts
+++ b/src/backend/src/lib/uiSnapshot.ts
@@ -1,0 +1,281 @@
+import { requireRoomPurpose, type RoomPurposeSource } from '../../../engine/roomPurposes/index.js';
+import type {
+  ApplicantState,
+  DeviceInstanceState,
+  EmployeeState,
+  GameState,
+  PlantState,
+  StructureState,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+  ZoneResourceState,
+} from '../state/models.js';
+
+export interface StructureSnapshot {
+  id: string;
+  name: string;
+  status: StructureState['status'];
+  footprint: StructureState['footprint'];
+  rentPerTick: number;
+  roomIds: string[];
+}
+
+export interface RoomSnapshot {
+  id: string;
+  name: string;
+  structureId: string;
+  structureName: string;
+  purposeId: string;
+  purposeKind: string;
+  purposeName: string;
+  purposeFlags?: Record<string, boolean>;
+  area: number;
+  height: number;
+  volume: number;
+  cleanliness: number;
+  maintenanceLevel: number;
+  zoneIds: string[];
+}
+
+export interface DeviceSnapshot {
+  id: string;
+  blueprintId: string;
+  kind: string;
+  name: string;
+  zoneId: string;
+  status: DeviceInstanceState['status'];
+  efficiency: number;
+  runtimeHours: number;
+  maintenance: DeviceInstanceState['maintenance'];
+  settings: Record<string, unknown>;
+}
+
+export interface PlantSnapshot {
+  id: string;
+  strainId: string;
+  stage: PlantState['stage'];
+  health: number;
+  stress: number;
+  biomassDryGrams: number;
+  yieldDryGrams: number;
+}
+
+export interface ZoneHealthSnapshot {
+  diseases: number;
+  pests: number;
+  pendingTreatments: number;
+  appliedTreatments: number;
+  reentryRestrictedUntilTick?: number;
+  preHarvestRestrictedUntilTick?: number;
+}
+
+export interface ZoneSnapshot {
+  id: string;
+  name: string;
+  structureId: string;
+  structureName: string;
+  roomId: string;
+  roomName: string;
+  environment: ZoneEnvironmentState;
+  resources: ZoneResourceState;
+  metrics: ZoneMetricState;
+  devices: DeviceSnapshot[];
+  plants: PlantSnapshot[];
+  health: ZoneHealthSnapshot;
+}
+
+export interface EmployeeSnapshot {
+  id: string;
+  name: string;
+  role: EmployeeState['role'];
+  salaryPerTick: number;
+  morale: number;
+  energy: number;
+  status: EmployeeState['status'];
+  assignedStructureId?: string;
+}
+
+export interface ApplicantSnapshot {
+  id: string;
+  name: string;
+  desiredRole: ApplicantState['desiredRole'];
+  expectedSalary: number;
+}
+
+export interface PersonnelSnapshot {
+  employees: EmployeeSnapshot[];
+  applicants: ApplicantSnapshot[];
+  overallMorale: number;
+}
+
+export interface FinanceSummarySnapshot {
+  cashOnHand: number;
+  reservedCash: number;
+  totalRevenue: number;
+  totalExpenses: number;
+  netIncome: number;
+  lastTickRevenue: number;
+  lastTickExpenses: number;
+}
+
+export interface SimulationSnapshot {
+  tick: number;
+  structures: StructureSnapshot[];
+  rooms: RoomSnapshot[];
+  zones: ZoneSnapshot[];
+  personnel: PersonnelSnapshot;
+  finance: FinanceSummarySnapshot;
+}
+
+const summarizeHealth = (
+  zone: StructureState['rooms'][number]['zones'][number],
+): ZoneHealthSnapshot => {
+  const plantHealthEntries = Object.values(zone.health.plantHealth ?? {});
+  const diseaseCount = plantHealthEntries.reduce(
+    (accumulator, item) => accumulator + (item?.diseases?.length ?? 0),
+    0,
+  );
+  const pestCount = plantHealthEntries.reduce(
+    (accumulator, item) => accumulator + (item?.pests?.length ?? 0),
+    0,
+  );
+
+  return {
+    diseases: diseaseCount,
+    pests: pestCount,
+    pendingTreatments: zone.health.pendingTreatments.length,
+    appliedTreatments: zone.health.appliedTreatments.length,
+    reentryRestrictedUntilTick: zone.health.reentryRestrictedUntilTick,
+    preHarvestRestrictedUntilTick: zone.health.preHarvestRestrictedUntilTick,
+  };
+};
+
+const cloneResources = (resources: ZoneResourceState): ZoneResourceState => ({
+  waterLiters: resources.waterLiters,
+  nutrientSolutionLiters: resources.nutrientSolutionLiters,
+  nutrientStrength: resources.nutrientStrength,
+  substrateHealth: resources.substrateHealth,
+  reservoirLevel: resources.reservoirLevel,
+});
+
+export const buildSimulationSnapshot = (
+  state: GameState,
+  roomPurposeSource: RoomPurposeSource,
+): SimulationSnapshot => {
+  const structures: StructureSnapshot[] = [];
+  const rooms: RoomSnapshot[] = [];
+  const zones: ZoneSnapshot[] = [];
+
+  for (const structure of state.structures) {
+    const roomIds: string[] = [];
+
+    for (const room of structure.rooms) {
+      roomIds.push(room.id);
+      const zoneIds: string[] = [];
+
+      for (const zone of room.zones) {
+        zoneIds.push(zone.id);
+        zones.push({
+          id: zone.id,
+          name: zone.name,
+          structureId: structure.id,
+          structureName: structure.name,
+          roomId: room.id,
+          roomName: room.name,
+          environment: { ...zone.environment },
+          resources: cloneResources(zone.resources),
+          metrics: { ...zone.metrics },
+          devices: zone.devices.map((device) => ({
+            id: device.id,
+            blueprintId: device.blueprintId,
+            kind: device.kind,
+            name: device.name,
+            zoneId: device.zoneId,
+            status: device.status,
+            efficiency: device.efficiency,
+            runtimeHours: device.runtimeHours,
+            maintenance: { ...device.maintenance },
+            settings: { ...device.settings },
+          })),
+          plants: zone.plants.map((plant) => ({
+            id: plant.id,
+            strainId: plant.strainId,
+            stage: plant.stage,
+            health: plant.health,
+            stress: plant.stress,
+            biomassDryGrams: plant.biomassDryGrams,
+            yieldDryGrams: plant.yieldDryGrams,
+          })),
+          health: summarizeHealth(zone),
+        });
+      }
+
+      const purpose = requireRoomPurpose(roomPurposeSource, room.purposeId, { by: 'id' });
+
+      rooms.push({
+        id: room.id,
+        name: room.name,
+        structureId: structure.id,
+        structureName: structure.name,
+        purposeId: room.purposeId,
+        purposeKind: purpose.kind,
+        purposeName: purpose.name,
+        purposeFlags: purpose.flags ? { ...purpose.flags } : undefined,
+        area: room.area,
+        height: room.height,
+        volume: room.volume,
+        cleanliness: room.cleanliness,
+        maintenanceLevel: room.maintenanceLevel,
+        zoneIds,
+      });
+    }
+
+    structures.push({
+      id: structure.id,
+      name: structure.name,
+      status: structure.status,
+      footprint: { ...structure.footprint },
+      rentPerTick: structure.rentPerTick,
+      roomIds,
+    });
+  }
+
+  const personnel: PersonnelSnapshot = {
+    employees: state.personnel.employees.map((employee) => ({
+      id: employee.id,
+      name: employee.name,
+      role: employee.role,
+      salaryPerTick: employee.salaryPerTick,
+      morale: employee.morale,
+      energy: employee.energy,
+      status: employee.status,
+      assignedStructureId: employee.assignedStructureId,
+    })),
+    applicants: state.personnel.applicants.map((applicant) => ({
+      id: applicant.id,
+      name: applicant.name,
+      desiredRole: applicant.desiredRole,
+      expectedSalary: applicant.expectedSalary,
+    })),
+    overallMorale: state.personnel.overallMorale,
+  };
+
+  const finance: FinanceSummarySnapshot = {
+    cashOnHand: state.finances.cashOnHand,
+    reservedCash: state.finances.reservedCash,
+    totalRevenue: state.finances.summary.totalRevenue,
+    totalExpenses: state.finances.summary.totalExpenses,
+    netIncome: state.finances.summary.netIncome,
+    lastTickRevenue: state.finances.summary.lastTickRevenue,
+    lastTickExpenses: state.finances.summary.lastTickExpenses,
+  };
+
+  return {
+    tick: state.clock.tick,
+    structures,
+    rooms,
+    zones,
+    personnel,
+    finance,
+  };
+};

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
       '@/engine': path.resolve(__dirname, '../engine'),
       '@/ui': path.resolve(__dirname, '../frontend/src/ui'),
+      rxjs: path.resolve(__dirname, 'node_modules/rxjs'),
     },
   },
 });

--- a/src/runtime/eventBus.ts
+++ b/src/runtime/eventBus.ts
@@ -1,3 +1,5 @@
+import { Observable, bufferTime, filter as rxFilter, map, merge, share } from 'rxjs';
+
 import {
   EventBus,
   type EventBufferOptions,
@@ -6,8 +8,205 @@ import {
   type EventLevel,
   type SimulationEvent,
 } from '../backend/src/lib/eventBus.js';
+import type { TickCompletedPayload } from '../backend/src/sim/loop.js';
 
 const telemetryEventBus = new EventBus();
+
+const DEFAULT_SIMULATION_BUFFER_MS = 120;
+const DEFAULT_SIMULATION_MAX_BATCH_SIZE = 5;
+const DEFAULT_DOMAIN_BUFFER_MS = 250;
+const DEFAULT_DOMAIN_MAX_BATCH_SIZE = 25;
+const DEFAULT_DOMAIN_EVENT_PATTERN =
+  /^(plant|device|zone|market|finance|env|pest|disease|task|hr|world|health)\./;
+
+export type UiDomainEvent = Pick<
+  SimulationEvent,
+  'type' | 'payload' | 'tick' | 'ts' | 'level' | 'tags'
+>;
+
+export interface UiSimulationUpdateEntry<
+  Snapshot extends { tick: number },
+  TimeStatus,
+  Event extends UiDomainEvent = UiDomainEvent,
+> {
+  tick: number;
+  ts: number;
+  durationMs?: number;
+  phaseTimings?: TickCompletedPayload['phaseTimings'];
+  events: Event[];
+  snapshot: Snapshot;
+  time: TimeStatus;
+}
+
+export interface UiSimulationUpdateMessage<
+  Snapshot extends { tick: number },
+  TimeStatus,
+  Event extends UiDomainEvent = UiDomainEvent,
+> {
+  updates: UiSimulationUpdateEntry<Snapshot, TimeStatus, Event>[];
+}
+
+export interface UiSimulationTickEvent<Event extends UiDomainEvent = UiDomainEvent> {
+  tick: number;
+  ts: number;
+  durationMs?: number;
+  eventCount?: number;
+  phaseTimings?: TickCompletedPayload['phaseTimings'];
+  events: Event[];
+}
+
+export interface UiDomainEventsMessage<Event extends UiDomainEvent = UiDomainEvent> {
+  events: Event[];
+}
+
+export type UiStreamPacket<
+  Snapshot extends { tick: number },
+  TimeStatus,
+  Event extends UiDomainEvent = UiDomainEvent,
+> =
+  | { channel: 'simulationUpdate'; payload: UiSimulationUpdateMessage<Snapshot, TimeStatus, Event> }
+  | { channel: 'sim.tickCompleted'; payload: UiSimulationTickEvent<Event> }
+  | { channel: 'domainEvents'; payload: UiDomainEventsMessage<Event> }
+  | { channel: string; payload: unknown };
+
+export interface UiStreamOptions<Snapshot extends { tick: number }, TimeStatus> {
+  snapshotProvider: () => Snapshot;
+  timeStatusProvider: () => TimeStatus;
+  eventBus?: EventBus;
+  domainFilter?: EventFilter;
+  simulationBufferMs?: number;
+  simulationMaxBatchSize?: number;
+  domainBufferMs?: number;
+  domainMaxBatchSize?: number;
+}
+
+const sanitizeEventForUi = (event: SimulationEvent): UiDomainEvent => ({
+  type: event.type,
+  payload: event.payload,
+  tick: event.tick,
+  ts: event.ts ?? Date.now(),
+  level: event.level,
+  tags: event.tags ? [...event.tags] : undefined,
+});
+
+interface ProcessedTick<Snapshot extends { tick: number }, TimeStatus> {
+  update: UiSimulationUpdateEntry<Snapshot, TimeStatus>;
+  tickEvent: UiSimulationTickEvent;
+}
+
+const toProcessedTick = <Snapshot extends { tick: number }, TimeStatus>(
+  event: SimulationEvent<TickCompletedPayload>,
+  snapshotProvider: () => Snapshot,
+  timeStatusProvider: () => TimeStatus,
+): ProcessedTick<Snapshot, TimeStatus> => {
+  const snapshot = snapshotProvider();
+  const timeStatus = timeStatusProvider();
+  const sanitizedEvents = Array.isArray(event.payload?.events)
+    ? event.payload.events.map(sanitizeEventForUi)
+    : [];
+
+  const tick = event.tick ?? event.payload?.tick ?? snapshot.tick;
+  const ts = event.ts ?? Date.now();
+  const durationMs = event.payload?.durationMs;
+  const phaseTimings = event.payload?.phaseTimings;
+  const eventCount = event.payload?.eventCount ?? sanitizedEvents.length;
+
+  return {
+    update: {
+      tick,
+      ts,
+      durationMs,
+      phaseTimings,
+      events: sanitizedEvents,
+      snapshot,
+      time: timeStatus,
+    },
+    tickEvent: {
+      tick,
+      ts,
+      durationMs,
+      eventCount,
+      phaseTimings,
+      events: sanitizedEvents,
+    },
+  };
+};
+
+export const createUiStream = <Snapshot extends { tick: number }, TimeStatus>(
+  options: UiStreamOptions<Snapshot, TimeStatus>,
+): Observable<UiStreamPacket<Snapshot, TimeStatus>> => {
+  const eventSource = options.eventBus ?? telemetryEventBus;
+  const domainFilter = options.domainFilter ?? {
+    predicate: (event: SimulationEvent) => DEFAULT_DOMAIN_EVENT_PATTERN.test(event.type),
+  };
+
+  const simulationBufferMs = options.simulationBufferMs ?? DEFAULT_SIMULATION_BUFFER_MS;
+  const simulationMaxBatchSize =
+    options.simulationMaxBatchSize ?? DEFAULT_SIMULATION_MAX_BATCH_SIZE;
+  const domainBufferMs = options.domainBufferMs ?? DEFAULT_DOMAIN_BUFFER_MS;
+  const domainMaxBatchSize = options.domainMaxBatchSize ?? DEFAULT_DOMAIN_MAX_BATCH_SIZE;
+
+  const ticks$ = eventSource.events('sim.tickCompleted').pipe(
+    map((event) =>
+      toProcessedTick(
+        event as SimulationEvent<TickCompletedPayload>,
+        options.snapshotProvider,
+        options.timeStatusProvider,
+      ),
+    ),
+    share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }),
+  );
+
+  const simulationUpdates$ = ticks$.pipe(
+    map((processed) => processed.update),
+    bufferTime(simulationBufferMs, undefined, simulationMaxBatchSize),
+    rxFilter((batch) => batch.length > 0),
+    map(
+      (updates) =>
+        ({
+          channel: 'simulationUpdate',
+          payload: { updates } satisfies UiSimulationUpdateMessage<Snapshot, TimeStatus>,
+        }) as const,
+    ),
+  );
+
+  const tickEvents$ = ticks$.pipe(
+    map(
+      (processed) =>
+        ({
+          channel: 'sim.tickCompleted',
+          payload: processed.tickEvent satisfies UiSimulationTickEvent,
+        }) as const,
+    ),
+  );
+
+  const domainEventsSource$ = eventSource
+    .events(domainFilter)
+    .pipe(
+      map(sanitizeEventForUi),
+      share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }),
+    );
+
+  const domainBatches$ = domainEventsSource$.pipe(
+    bufferTime(domainBufferMs, undefined, domainMaxBatchSize),
+    rxFilter((batch) => batch.length > 0),
+    map(
+      (events) =>
+        ({
+          channel: 'domainEvents',
+          payload: { events } satisfies UiDomainEventsMessage,
+        }) as const,
+    ),
+  );
+
+  const domainFanout$ = domainEventsSource$.pipe(
+    map((event) => ({ channel: event.type, payload: event.payload ?? null }) as const),
+  );
+
+  return merge(simulationUpdates$, tickEvents$, domainBatches$, domainFanout$).pipe(
+    share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }),
+  );
+};
 
 const emitInternal = <T>(event: SimulationEvent<T>): void => {
   telemetryEventBus.emit(event);


### PR DESCRIPTION
## Summary
- add a shared `createUiStream` pipeline that sanitises and buffers runtime events for UI consumers
- refactor the socket gateway to forward the shared stream, add an SSE gateway, shared snapshot helpers, and wire them into the dev server with documentation updates
- adjust tooling configuration so vitest/eslint resolve the RxJS dependency used by the runtime stream

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cfd6726810832593ecaf4195a2683d