### PR TITLE
Integrate cost accounting into simulation loop

### DIFF
--- a/src/backend/data/blueprintRepository.ts
+++ b/src/backend/data/blueprintRepository.ts
@@ -7,6 +7,7 @@ import {
   DataLoaderError,
   loadBlueprintData,
 } from './dataLoader.js';
+import type { DevicePriceEntry, StrainPriceEntry } from './schemas/index.js';
 
 export type HotReloadDisposition = 'commit' | 'defer';
 export type HotReloadHandler = (
@@ -80,6 +81,14 @@ export class BlueprintRepository {
 
   getUtilityPrices() {
     return this.data.prices.utility;
+  }
+
+  listDevicePrices(): Array<[string, DevicePriceEntry]> {
+    return Array.from(this.data.prices.devices.entries());
+  }
+
+  listStrainPrices(): Array<[string, StrainPriceEntry]> {
+    return Array.from(this.data.prices.strains.entries());
   }
 
   getSummary(): DataLoadSummary {

--- a/src/backend/facade/index.ts
+++ b/src/backend/facade/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../src/lib/eventBus.js';
 import { eventBus as telemetryEventBus } from '../../runtime/eventBus.js';
 import type { GameState, SimulationClockState } from '../src/state/models.js';
-import { SimulationLoop } from '../src/sim/loop.js';
+import { SimulationLoop, type SimulationLoopAccountingOptions } from '../src/sim/loop.js';
 import { SimulationScheduler } from '../src/sim/simScheduler.js';
 import type { SimulationSchedulerOptions } from '../src/sim/simScheduler.js';
 import type { ZoneEnvironmentOptions } from '../src/engine/environment/zoneEnvironment.js';
@@ -455,6 +455,7 @@ export interface SimulationFacadeOptions {
   loop?: SimulationLoop;
   services?: EngineServices;
   scheduler?: SimulationFacadeSchedulerOptions;
+  accounting?: SimulationLoopAccountingOptions;
 }
 
 export interface TimeStatus {
@@ -635,6 +636,7 @@ export class SimulationFacade {
         state: this.state,
         eventBus: this.eventBus,
         environment: options.environment,
+        accounting: options.accounting,
       });
     this.services = {
       world: options.services?.world ? { ...options.services.world } : {},

--- a/src/backend/src/engine/economy/catalog.ts
+++ b/src/backend/src/engine/economy/catalog.ts
@@ -1,0 +1,18 @@
+import type { BlueprintRepository } from '../../../data/blueprintRepository.js';
+import type { PriceCatalog } from './pricing.js';
+
+export const createPriceCatalogFromRepository = (repository: BlueprintRepository): PriceCatalog => {
+  const devicePrices = new Map(repository.listDevicePrices());
+  const strainPrices = new Map(repository.listStrainPrices());
+  const utilityPrices = repository.getUtilityPrices();
+
+  return {
+    devicePrices,
+    strainPrices,
+    utilityPrices: {
+      pricePerKwh: utilityPrices.pricePerKwh,
+      pricePerLiterWater: utilityPrices.pricePerLiterWater,
+      pricePerGramNutrients: utilityPrices.pricePerGramNutrients,
+    },
+  };
+};

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -245,7 +245,7 @@ describe('ZoneEnvironmentService', () => {
 
     const service = new ZoneEnvironmentService();
 
-    service.applyDeviceDeltas(state, 15);
+    service.applyDeviceDeltas(state, 15, undefined);
 
     expect(zone.environment.temperature).toBeCloseTo(25.25, 2);
     expect(zone.environment.ppfd).toBeCloseTo(21.6, 4);

--- a/src/backend/src/engine/environment/zoneEnvironment.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.ts
@@ -158,7 +158,11 @@ export class ZoneEnvironmentService {
     this.controllerOptions = options.controller ?? {};
   }
 
-  applyDeviceDeltas(state: GameState, tickLengthMinutes: number): void {
+  applyDeviceDeltas(
+    state: GameState,
+    tickLengthMinutes: number,
+    accounting?: SimulationPhaseContext['accounting'],
+  ): void {
     const tickHours = computeTickHours(tickLengthMinutes);
 
     for (const structure of state.structures) {
@@ -187,6 +191,9 @@ export class ZoneEnvironmentService {
           zone.environment.ppfd = Math.max(0, zone.environment.ppfd + effect.ppfdDelta);
 
           this.deviceEffects.set(zone.id, { airflow: effect.airflow });
+          if (accounting && effect.energyKwh > 0) {
+            accounting.recordUtility({ energyKwh: effect.energyKwh });
+          }
         }
       }
     }
@@ -334,7 +341,7 @@ export class ZoneEnvironmentService {
 
   createApplyDevicePhaseHandler() {
     return (context: SimulationPhaseContext) => {
-      this.applyDeviceDeltas(context.state, context.tickLengthMinutes);
+      this.applyDeviceDeltas(context.state, context.tickLengthMinutes, context.accounting);
     };
   }
 

--- a/src/backend/src/sim/loop.accounting.test.ts
+++ b/src/backend/src/sim/loop.accounting.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '../lib/eventBus.js';
+import { SimulationLoop } from './loop.js';
+import type {
+  DeviceInstanceState,
+  GameState,
+  StructureState,
+  ZoneEnvironmentState,
+  ZoneHealthState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneState,
+} from '../state/models.js';
+import { CostAccountingService } from '../engine/economy/costAccounting.js';
+import type { PriceCatalog } from '../engine/economy/pricing.js';
+
+const createAccountingTestState = (): GameState => {
+  const createdAt = new Date().toISOString();
+  const environment: ZoneEnvironmentState = {
+    temperature: 24,
+    relativeHumidity: 0.6,
+    co2: 800,
+    ppfd: 0,
+    vpd: 1,
+  };
+
+  const createDevice = (id: string, blueprintId: string): DeviceInstanceState => ({
+    id,
+    blueprintId,
+    kind: blueprintId.replace('-blueprint', ''),
+    name: id,
+    zoneId: 'zone-1',
+    status: 'operational',
+    efficiency: 1,
+    runtimeHours: 0,
+    maintenance: {
+      lastServiceTick: 0,
+      nextDueTick: 1000,
+      condition: 1,
+      runtimeHoursAtLastService: 0,
+      degradation: 0,
+    },
+    settings: {},
+  });
+
+  const zone: ZoneState = {
+    id: 'zone-1',
+    roomId: 'room-1',
+    name: 'Accounting Zone',
+    cultivationMethodId: 'method-1',
+    strainId: 'strain-1',
+    environment,
+    resources: {
+      waterLiters: 0,
+      nutrientSolutionLiters: 0,
+      nutrientStrength: 0,
+      substrateHealth: 1,
+      reservoirLevel: 0.5,
+    } satisfies ZoneResourceState,
+    plants: [],
+    devices: [
+      createDevice('lamp-1', 'Lamp-blueprint'),
+      createDevice('hvac-1', 'ClimateUnit-blueprint'),
+      createDevice('co2-1', 'CO2Injector-blueprint'),
+    ],
+    metrics: {
+      averageTemperature: environment.temperature,
+      averageHumidity: environment.relativeHumidity,
+      averageCo2: environment.co2,
+      averagePpfd: environment.ppfd,
+      stressLevel: 0,
+      lastUpdatedTick: 0,
+    } satisfies ZoneMetricState,
+    health: {
+      plantHealth: {},
+      pendingTreatments: [],
+      appliedTreatments: [],
+    } satisfies ZoneHealthState,
+    activeTaskIds: [],
+  };
+
+  const room: StructureState['rooms'][number] = {
+    id: 'room-1',
+    structureId: 'structure-1',
+    name: 'Grow Room',
+    purposeId: 'purpose-1',
+    area: 40,
+    height: 3,
+    volume: 120,
+    zones: [zone],
+    cleanliness: 1,
+    maintenanceLevel: 1,
+  };
+
+  const structure: StructureState = {
+    id: 'structure-1',
+    blueprintId: 'structure-blueprint',
+    name: 'Structure',
+    status: 'active',
+    footprint: {
+      length: 10,
+      width: 4,
+      height: 3,
+      area: 40,
+      volume: 120,
+    },
+    rooms: [room],
+    rentPerTick: 0,
+    upfrontCostPaid: 0,
+  };
+
+  return {
+    metadata: {
+      gameId: 'game-1',
+      createdAt,
+      seed: 'seed',
+      difficulty: 'normal',
+      simulationVersion: '0.0.0',
+      tickLengthMinutes: 60,
+      economics: {
+        initialCapital: 0,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0,
+        rentPerSqmRoomPerTick: 0,
+      },
+    },
+    clock: {
+      tick: 0,
+      isPaused: false,
+      startedAt: createdAt,
+      lastUpdatedAt: createdAt,
+      targetTickRate: 1,
+    },
+    structures: [structure],
+    inventory: {
+      resources: {
+        waterLiters: 1_000,
+        nutrientsGrams: 500,
+        co2Kg: 0,
+        substrateKg: 0,
+        packagingUnits: 0,
+        sparePartsValue: 0,
+      },
+      seeds: [],
+      devices: [],
+      harvest: [],
+      consumables: {},
+    },
+    finances: {
+      cashOnHand: 0,
+      reservedCash: 0,
+      outstandingLoans: [],
+      ledger: [],
+      summary: {
+        totalRevenue: 0,
+        totalExpenses: 0,
+        totalPayroll: 0,
+        totalMaintenance: 0,
+        netIncome: 0,
+        lastTickRevenue: 0,
+        lastTickExpenses: 0,
+      },
+    },
+    personnel: {
+      employees: [],
+      applicants: [],
+      trainingPrograms: [],
+      overallMorale: 0,
+    },
+    tasks: {
+      backlog: [],
+      active: [],
+      completed: [],
+      cancelled: [],
+    },
+    notes: [],
+  };
+};
+
+describe('SimulationLoop accounting integration', () => {
+  it('applies utility, maintenance, and capex costs with finance events', async () => {
+    const state = createAccountingTestState();
+    state.finances.cashOnHand = 2000;
+    const priceCatalog: PriceCatalog = {
+      devicePrices: new Map([
+        [
+          'Lamp-blueprint',
+          {
+            capitalExpenditure: 1200,
+            baseMaintenanceCostPerTick: 0.3,
+            costIncreasePer1000Ticks: 0.05,
+          },
+        ],
+        [
+          'ClimateUnit-blueprint',
+          {
+            capitalExpenditure: 800,
+            baseMaintenanceCostPerTick: 0.25,
+            costIncreasePer1000Ticks: 0.05,
+          },
+        ],
+        [
+          'CO2Injector-blueprint',
+          {
+            capitalExpenditure: 400,
+            baseMaintenanceCostPerTick: 0.1,
+            costIncreasePer1000Ticks: 0.02,
+          },
+        ],
+      ]),
+      strainPrices: new Map(),
+      utilityPrices: {
+        pricePerKwh: 0.5,
+        pricePerLiterWater: 0.1,
+        pricePerGramNutrients: 0.2,
+      },
+    };
+
+    const costService = new CostAccountingService(priceCatalog);
+    const bus = new EventBus();
+    const loop = new SimulationLoop({
+      state,
+      eventBus: bus,
+      accounting: { service: costService },
+      phases: {
+        applyDevices: (context) => {
+          context.accounting.recordUtility({ energyKwh: 5 });
+        },
+        irrigationAndNutrients: (context) => {
+          context.accounting.recordUtility({ waterLiters: 10, nutrientsGrams: 2 });
+        },
+        accounting: (context) => {
+          context.accounting.recordDevicePurchase('Lamp-blueprint', 1, 'Purchased lamp');
+        },
+      },
+    });
+
+    const emittedTypes: string[] = [];
+    const subscription = bus.events().subscribe((event) => emittedTypes.push(event.type));
+    const result = await loop.processTick();
+    subscription.unsubscribe();
+
+    const opexEvents = result.events.filter((event) => event.type === 'finance.opex');
+    const capexEvents = result.events.filter((event) => event.type === 'finance.capex');
+    const tickEvents = result.events.filter((event) => event.type === 'finance.tick');
+
+    expect(capexEvents).toHaveLength(1);
+    expect(tickEvents).toHaveLength(1);
+
+    const utilityEvent = opexEvents.find(
+      (event) =>
+        typeof event.payload === 'object' &&
+        event.payload !== null &&
+        'utilities' in (event.payload as object),
+    );
+    expect(utilityEvent).toBeDefined();
+
+    const maintenanceEvents = opexEvents.filter(
+      (event) =>
+        typeof event.payload === 'object' &&
+        event.payload !== null &&
+        'deviceId' in (event.payload as object),
+    );
+    expect(maintenanceEvents).toHaveLength(3);
+
+    const readAmount = (event: (typeof result.events)[number] | undefined): number => {
+      if (!event || typeof event.payload !== 'object' || event.payload === null) {
+        return 0;
+      }
+      const payload = event.payload as { amount?: number };
+      return typeof payload.amount === 'number' ? payload.amount : 0;
+    };
+
+    const utilityAmount = readAmount(utilityEvent);
+    const maintenanceTotal = maintenanceEvents.reduce((sum, event) => sum + readAmount(event), 0);
+    const capexAmount = readAmount(capexEvents[0]);
+
+    expect(utilityAmount).toBeCloseTo(3.9, 6);
+    expect(capexAmount).toBeCloseTo(1200, 6);
+    expect(maintenanceTotal).toBeGreaterThan(0);
+
+    const expectedTotalExpenses = utilityAmount + maintenanceTotal + capexAmount;
+    expect(state.finances.summary.totalExpenses).toBeCloseTo(expectedTotalExpenses, 6);
+    expect(state.finances.summary.totalMaintenance).toBeCloseTo(maintenanceTotal, 6);
+    expect(state.finances.cashOnHand).toBeCloseTo(2000 - expectedTotalExpenses, 6);
+    expect(state.finances.ledger).toHaveLength(5);
+
+    const tickPayload = tickEvents[0]?.payload as
+      | { capex?: number; opex?: number; maintenance?: unknown; netIncome?: number }
+      | undefined;
+    expect(tickPayload?.capex).toBeCloseTo(capexAmount, 6);
+    expect(tickPayload?.opex).toBeCloseTo(utilityAmount + maintenanceTotal, 6);
+    expect(tickPayload?.netIncome).toBeCloseTo(
+      -(utilityAmount + maintenanceTotal + capexAmount),
+      6,
+    );
+
+    expect(emittedTypes).toContain('finance.capex');
+    expect(emittedTypes).toContain('finance.tick');
+  });
+});


### PR DESCRIPTION
## Summary
- expose price listings on the blueprint repository and add a helper to build a pricing catalog for accounting
- instantiate and wire the cost accounting service into the simulation loop, capturing utility usage, maintenance, and device purchases
- record device energy draw during environment updates, pass accounting context through phases, and add an integration test covering finance events

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cff279df5c8325b849f058920d2e22