### PR TITLE
Add device price registry with strict require semantics

### DIFF
--- a/src/backend/src/engine/economy/devicePriceRegistry.test.ts
+++ b/src/backend/src/engine/economy/devicePriceRegistry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { BlueprintRepository } from '../../../data/blueprintRepository.js';
+import type { PriceCatalog } from './pricing.js';
+import { DevicePriceRegistry, MissingDevicePriceError } from './devicePriceRegistry.js';
+
+const ENTRY = {
+  capitalExpenditure: 750,
+  baseMaintenanceCostPerTick: 0.002,
+  costIncreasePer1000Ticks: 0.0004,
+};
+
+describe('DevicePriceRegistry', () => {
+  it('returns device prices when present in the catalog', () => {
+    const catalog: PriceCatalog = {
+      devicePrices: new Map([['known-device', ENTRY]]),
+      strainPrices: new Map(),
+      utilityPrices: {
+        pricePerKwh: 0.15,
+        pricePerLiterWater: 0.02,
+        pricePerGramNutrients: 0.1,
+      },
+    };
+
+    const registry = DevicePriceRegistry.fromCatalog(catalog);
+    expect(registry.get('known-device')).toEqual(ENTRY);
+    expect(registry.require('known-device')).toEqual(ENTRY);
+  });
+
+  it('throws a MissingDevicePriceError with metadata when the price is absent', () => {
+    const catalog: PriceCatalog = {
+      devicePrices: new Map(),
+      strainPrices: new Map(),
+      utilityPrices: {
+        pricePerKwh: 0.15,
+        pricePerLiterWater: 0.02,
+        pricePerGramNutrients: 0.1,
+      },
+    };
+    const registry = DevicePriceRegistry.fromCatalog(catalog);
+
+    try {
+      registry.require('unknown-device', {
+        context: 'unit-test',
+        blueprintName: 'Ghost Device',
+        quantity: 3,
+      });
+      expect.fail('Expected require to throw for unknown device.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(MissingDevicePriceError);
+      expect((error as MissingDevicePriceError).deviceId).toBe('unknown-device');
+      expect((error as MissingDevicePriceError).metadata).toMatchObject({
+        context: 'unit-test',
+        blueprintName: 'Ghost Device',
+        quantity: 3,
+      });
+      expect((error as Error).message).toContain('context: unit-test');
+      expect((error as Error).message).toContain('blueprint: Ghost Device');
+      expect((error as Error).message).toContain('quantity: 3');
+    }
+  });
+
+  it('wraps a blueprint repository lookup', () => {
+    const repository = {
+      getDevicePrice: (id: string) => (id === 'repo-device' ? ENTRY : undefined),
+    } as unknown as BlueprintRepository;
+
+    const registry = DevicePriceRegistry.fromRepository(repository);
+    expect(registry.require('repo-device')).toEqual(ENTRY);
+    expect(() => registry.require('other-device')).toThrowError(MissingDevicePriceError);
+  });
+});

--- a/src/backend/src/engine/economy/devicePriceRegistry.ts
+++ b/src/backend/src/engine/economy/devicePriceRegistry.ts
@@ -1,0 +1,72 @@
+import type { BlueprintRepository } from '../../../data/blueprintRepository.js';
+import type { DevicePriceEntry } from '../../../data/schemas/index.js';
+import type { PriceCatalog } from './pricing.js';
+
+export interface DevicePriceRequestMetadata {
+  readonly context?: string;
+  readonly blueprintName?: string;
+  readonly quantity?: number;
+}
+
+export class MissingDevicePriceError extends Error {
+  readonly deviceId: string;
+  readonly metadata: DevicePriceRequestMetadata;
+
+  constructor(deviceId: string, metadata: DevicePriceRequestMetadata = {}) {
+    const detail = formatMetadata(metadata);
+    super(`Missing device price entry for blueprint "${deviceId}"${detail}`);
+    this.name = 'MissingDevicePriceError';
+    this.deviceId = deviceId;
+    this.metadata = metadata;
+  }
+}
+
+type DevicePriceLookup = (deviceId: string) => DevicePriceEntry | undefined;
+
+export class DevicePriceRegistry {
+  constructor(private readonly lookup: DevicePriceLookup) {}
+
+  static fromCatalog(catalog: PriceCatalog): DevicePriceRegistry {
+    return new DevicePriceRegistry((deviceId) => catalog.devicePrices.get(deviceId));
+  }
+
+  static fromRepository(repository: BlueprintRepository): DevicePriceRegistry {
+    return new DevicePriceRegistry((deviceId) => repository.getDevicePrice(deviceId));
+  }
+
+  get(deviceId: string): DevicePriceEntry | undefined {
+    return this.lookup(deviceId);
+  }
+
+  require(deviceId: string, metadata: DevicePriceRequestMetadata = {}): DevicePriceEntry {
+    const entry = this.get(deviceId);
+    if (!entry) {
+      throw new MissingDevicePriceError(deviceId, metadata);
+    }
+    return entry;
+  }
+}
+
+const formatMetadata = (metadata: DevicePriceRequestMetadata): string => {
+  const parts: string[] = [];
+
+  if (metadata.context) {
+    parts.push(`context: ${metadata.context}`);
+  }
+
+  if (metadata.blueprintName) {
+    parts.push(`blueprint: ${metadata.blueprintName}`);
+  }
+
+  if (typeof metadata.quantity === 'number') {
+    parts.push(`quantity: ${metadata.quantity}`);
+  }
+
+  if (parts.length === 0) {
+    return '';
+  }
+
+  return ` (${parts.join(', ')})`;
+};
+
+export const formatDevicePriceMetadata = formatMetadata;

--- a/src/backend/src/state/initialization/finance.test.ts
+++ b/src/backend/src/state/initialization/finance.test.ts
@@ -7,6 +7,7 @@ import {
 import type { EconomicsSettings } from '../models.js';
 import { RngService } from '../../lib/rng.js';
 import { createFinanceState } from './finance.js';
+import { MissingDevicePriceError } from '../../engine/economy/devicePriceRegistry.js';
 
 describe('state/initialization/finance', () => {
   it('records initial capital, upfront fees, and device purchases in the ledger', () => {
@@ -45,5 +46,40 @@ describe('state/initialization/finance', () => {
 
     expect(state.cashOnHand).toBeLessThan(economics.initialCapital);
     expect(state.summary.totalExpenses).toBeGreaterThan(0);
+  });
+
+  it('throws a missing price error when installed devices lack price entries', () => {
+    const structure = createStructureBlueprint({ upfrontFee: 5000 });
+    const lamp = createDeviceBlueprint({ kind: 'Lamp', id: 'lamp-missing-price' });
+    const repository = createBlueprintRepositoryStub({
+      devices: [lamp],
+      devicePrices: new Map(),
+    });
+    const economics: EconomicsSettings = {
+      initialCapital: 50_000,
+      itemPriceMultiplier: 1,
+      harvestPriceMultiplier: 1,
+      rentPerSqmStructurePerTick: 0.1,
+      rentPerSqmRoomPerTick: 0.2,
+    };
+    const rng = new RngService('finance-state-missing-price');
+    const idStream = rng.getStream('ids');
+
+    try {
+      createFinanceState(
+        '2024-01-01T00:00:00Z',
+        economics,
+        structure,
+        [lamp],
+        repository,
+        idStream,
+      );
+      expect.fail('Expected createFinanceState to throw when a device price is missing.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(MissingDevicePriceError);
+      expect((error as Error).message).toContain(
+        'Missing device price entry for blueprint "lamp-missing-price"',
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add a DevicePriceRegistry wrapper that surfaces MissingDevicePriceError when device prices are absent
- require device pricing in finance initialization and cost accounting purchase flows to avoid silent fallbacks
- cover the registry and missing-price scenarios with dedicated unit tests

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68cffadf5750832595f269ccddd839b4