### PR TITLE
Add shared seedrandom RNG streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "validate:data": "tsx tools/validate-data.ts",
     "prepare": "husky"
   },
+  "dependencies": {
+    "seedrandom": "^3.0.5"
+  },
   "devDependencies": {
     "@types/node": "^20.19.17",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      seedrandom:
+        specifier: ^3.0.5
+        version: 3.0.5
     devDependencies:
       '@types/node':
         specifier: ^20.19.17
@@ -2452,6 +2456,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5400,6 +5407,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  seedrandom@3.0.5: {}
 
   semver@6.3.1: {}
 

--- a/src/backend/src/engine/economy/pricing.test.ts
+++ b/src/backend/src/engine/economy/pricing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { PricingService, type PriceCatalog } from './pricing.js';
-import { RngService } from '../../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../../lib/rng.js';
 import type { EconomicsSettings } from '../../state/models.js';
 
 const MARKET_INDEX_MIN = 0.85;
@@ -40,7 +40,7 @@ describe('PricingService', () => {
     const rng = new RngService(seed);
     const service = new PricingService(catalog, rng);
     const expectedRng = new RngService(seed);
-    const marketStream = expectedRng.getStream('market');
+    const marketStream = expectedRng.getStream(RNG_STREAM_IDS.market);
     const economics = createEconomics();
 
     const sale1 = service.calculateHarvestSale('strain-a', 1200, 82, economics);

--- a/src/backend/src/engine/economy/pricing.ts
+++ b/src/backend/src/engine/economy/pricing.ts
@@ -4,6 +4,7 @@ import type {
   UtilityPrices,
 } from '../../../data/schemas/index.js';
 import type { EconomicsSettings } from '../../state/models.js';
+import { RNG_STREAM_IDS } from '../../lib/rng.js';
 import type { RngService } from '../../lib/rng.js';
 
 export interface PriceCatalog {
@@ -46,7 +47,7 @@ const LOW_QUALITY_KINK_MULTIPLIER = 0.85;
 
 const MARKET_INDEX_MIN = 0.85;
 const MARKET_INDEX_MAX = 1.15;
-const DEFAULT_MARKET_STREAM_ID = 'market';
+const DEFAULT_MARKET_STREAM_ID = RNG_STREAM_IDS.market;
 
 const computeQualityFactor = (quality: number): number => {
   const q = clamp(quality, 0, 100);

--- a/src/backend/src/persistence/saveGame.test.ts
+++ b/src/backend/src/persistence/saveGame.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RngService } from '../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../lib/rng.js';
 import type { GameState } from '../state/models.js';
 import {
   DEFAULT_SAVEGAME_VERSION,
@@ -83,7 +83,7 @@ describe('saveGame persistence', () => {
   it('round-trips a game state with rng offsets intact', () => {
     const state = createMinimalState();
     const rng = new RngService(state.metadata.seed);
-    const stream = rng.getStream('sim.test');
+    const stream = rng.getStream(RNG_STREAM_IDS.simulationTest);
     stream.next();
     stream.nextBoolean();
 
@@ -93,14 +93,14 @@ describe('saveGame persistence', () => {
     });
 
     expect(serialized.header.kind).toBe(SAVEGAME_KIND);
-    expect(serialized.rng.streams['sim.test']).toBe(2);
+    expect(serialized.rng.streams[RNG_STREAM_IDS.simulationTest]).toBe(2);
 
     const plain = JSON.parse(JSON.stringify(serialized));
     const result = deserializeGameState(plain);
 
     expect(result.state).toEqual(state);
     expect(result.rng.serialize()).toEqual(serialized.rng);
-    expect(result.rng.getStream('sim.test').getOffset()).toBe(2);
+    expect(result.rng.getStream(RNG_STREAM_IDS.simulationTest).getOffset()).toBe(2);
   });
 
   it('migrates legacy save envelopes without headers', () => {

--- a/src/backend/src/state/initialization/blueprints.test.ts
+++ b/src/backend/src/state/initialization/blueprints.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { createDeviceBlueprint, createStructureBlueprint } from '../../testing/fixtures.js';
-import { RngService } from '../../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../../lib/rng.js';
 import {
   chooseDeviceBlueprints,
   isDeviceCompatibleWithRoomPurpose,
@@ -17,7 +17,11 @@ describe('state/initialization/blueprints', () => {
     const preferred = { id: 'preferred', name: 'Preferred' };
     const options = [{ id: 'a', name: 'Alpha' }, preferred, { id: 'b', name: 'Beta' }];
 
-    const chosen = selectBlueprint(options, rng.getStream('options'), preferred.id);
+    const chosen = selectBlueprint(
+      options,
+      rng.getStream(RNG_STREAM_IDS.blueprintOptions),
+      preferred.id,
+    );
 
     expect(chosen).toBe(preferred);
   });
@@ -31,7 +35,7 @@ describe('state/initialization/blueprints', () => {
 
     const selected = chooseDeviceBlueprints(
       [lamp, climate, dehumidifier, misc],
-      rng.getStream('devices'),
+      rng.getStream(RNG_STREAM_IDS.devices),
       'growroom',
     );
     const kinds = selected.map((device) => device.kind);
@@ -88,7 +92,7 @@ describe('state/initialization/blueprints', () => {
 
     const selected = chooseDeviceBlueprints(
       [growLamp, breakRoomFan],
-      rng.getStream('devices'),
+      rng.getStream(RNG_STREAM_IDS.devices),
       'breakroom',
     );
 
@@ -110,7 +114,7 @@ describe('state/initialization/blueprints', () => {
 
     const selected = chooseDeviceBlueprints(
       [wildcardDevice],
-      rng.getStream('devices'),
+      rng.getStream(RNG_STREAM_IDS.devices),
       'breakroom',
     );
 

--- a/src/backend/src/state/initialization/finance.test.ts
+++ b/src/backend/src/state/initialization/finance.test.ts
@@ -5,7 +5,7 @@ import {
   createStructureBlueprint,
 } from '../../testing/fixtures.js';
 import type { EconomicsSettings } from '../models.js';
-import { RngService } from '../../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../../lib/rng.js';
 import { createFinanceState } from './finance.js';
 import { MissingDevicePriceError } from '../../engine/economy/devicePriceRegistry.js';
 
@@ -28,7 +28,7 @@ describe('state/initialization/finance', () => {
       rentPerSqmRoomPerTick: 0.3,
     };
     const rng = new RngService('finance-state');
-    const idStream = rng.getStream('ids');
+    const idStream = rng.getStream(RNG_STREAM_IDS.ids);
 
     const state = createFinanceState(
       '2024-01-01T00:00:00Z',
@@ -63,7 +63,7 @@ describe('state/initialization/finance', () => {
       rentPerSqmRoomPerTick: 0.2,
     };
     const rng = new RngService('finance-state-missing-price');
-    const idStream = rng.getStream('ids');
+    const idStream = rng.getStream(RNG_STREAM_IDS.ids);
 
     try {
       createFinanceState(

--- a/src/backend/src/state/initialization/personnel.test.ts
+++ b/src/backend/src/state/initialization/personnel.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { RngService } from '../../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../../lib/rng.js';
 import { createPersonnel, loadPersonnelDirectory } from './personnel.js';
 
 describe('state/initialization/personnel', () => {
@@ -37,7 +37,7 @@ describe('state/initialization/personnel', () => {
 
   it('creates personnel with role-based shift preferences and morale averages', () => {
     const rng = new RngService('personnel-roster');
-    const idStream = rng.getStream('ids');
+    const idStream = rng.getStream(RNG_STREAM_IDS.ids);
     const directory = {
       firstNames: ['Morgan', 'Drew', 'Sasha'],
       lastNames: ['Nguyen', 'Lopez'],

--- a/src/backend/src/state/initialization/personnel.ts
+++ b/src/backend/src/state/initialization/personnel.ts
@@ -7,7 +7,7 @@ import type {
   EmployeeSkills,
   EmployeeShiftAssignment,
 } from '../models.js';
-import { RngService, RngStream } from '../../lib/rng.js';
+import { RngService, RngStream, RNG_STREAM_IDS } from '../../lib/rng.js';
 import { generateId, readJsonFile } from './common.js';
 
 const DEFAULT_SALARY_BY_ROLE: Record<EmployeeRole, number> = {
@@ -117,9 +117,9 @@ export const createPersonnel = (
   const firstNames = directory?.firstNames ?? [];
   const lastNames = directory?.lastNames ?? [];
   const traits = directory?.traits ?? [];
-  const nameStream = rng.getStream('personnel-names');
-  const traitStream = rng.getStream('personnel-traits');
-  const moraleStream = rng.getStream('personnel-morale');
+  const nameStream = rng.getStream(RNG_STREAM_IDS.personnelNames);
+  const traitStream = rng.getStream(RNG_STREAM_IDS.personnelTraits);
+  const moraleStream = rng.getStream(RNG_STREAM_IDS.personnelMorale);
   const employees: EmployeeState[] = [];
   const shiftCounts = new Map<string, number>();
   let shiftCursor = 0;

--- a/src/backend/src/state/initialization/tasks.test.ts
+++ b/src/backend/src/state/initialization/tasks.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { RngService } from '../../lib/rng.js';
+import { RngService, RNG_STREAM_IDS } from '../../lib/rng.js';
 import { resolveRoomPurposeId } from '../../engine/roomPurposes/index.js';
 import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '../../../data/blueprintRepository.js';
@@ -56,7 +56,7 @@ describe('state/initialization/tasks', () => {
 
   it('creates seed tasks with metadata populated from structure context', () => {
     const rng = new RngService('task-seeding');
-    const idStream = rng.getStream('ids');
+    const idStream = rng.getStream(RNG_STREAM_IDS.ids);
 
     const environment: ZoneEnvironmentState = {
       temperature: 24,

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -28,7 +28,7 @@ import {
   ZoneMetricState,
   ZoneResourceState,
 } from './state/models.js';
-import { RngService, RngStream } from './lib/rng.js';
+import { RngService, RngStream, RNG_STREAM_IDS } from './lib/rng.js';
 import { generateId } from './state/initialization/common.js';
 import {
   chooseDeviceBlueprints,
@@ -247,7 +247,7 @@ const buildStructureState = (
   const totalArea = footprint.area;
   const growRoomArea = totalArea * 0.65;
   const supportRoomArea = Math.max(0, totalArea - growRoomArea);
-  const plantStream = rng.getStream('plants');
+  const plantStream = rng.getStream(RNG_STREAM_IDS.plants);
   const zoneId = generateId(idStream, 'zone');
   const deviceInstances = createDeviceInstances(
     deviceBlueprints,
@@ -370,7 +370,7 @@ export const createInitialState = async (
   const economics = DIFFICULTY_ECONOMICS[difficulty];
   const tickLengthMinutes = options.tickLengthMinutes ?? DEFAULT_TICK_LENGTH_MINUTES;
   const createdAt = new Date().toISOString();
-  const idStream = context.rng.getStream('ids');
+  const idStream = context.rng.getStream(RNG_STREAM_IDS.ids);
 
   const structureBlueprints =
     context.structureBlueprints ??
@@ -379,7 +379,7 @@ export const createInitialState = async (
     throw new Error('No structure blueprints available to create initial state.');
   }
 
-  const structureSelectionStream = context.rng.getStream('structures');
+  const structureSelectionStream = context.rng.getStream(RNG_STREAM_IDS.structures);
   const structureBlueprint = selectBlueprint(
     structureBlueprints,
     structureSelectionStream,
@@ -392,7 +392,7 @@ export const createInitialState = async (
   }
   const strain = selectBlueprint(
     strains,
-    context.rng.getStream('strains'),
+    context.rng.getStream(RNG_STREAM_IDS.strains),
     options.preferredStrainId,
   );
 
@@ -402,7 +402,7 @@ export const createInitialState = async (
   }
   const method = selectBlueprint(
     cultivationMethods,
-    context.rng.getStream('methods'),
+    context.rng.getStream(RNG_STREAM_IDS.methods),
     options.preferredCultivationMethodId,
   );
 
@@ -413,7 +413,7 @@ export const createInitialState = async (
   }
   const deviceBlueprints = chooseDeviceBlueprints(
     devices,
-    context.rng.getStream('devices'),
+    context.rng.getStream(RNG_STREAM_IDS.devices),
     growRoomPurpose.kind,
   );
 

--- a/src/runtime/rng.ts
+++ b/src/runtime/rng.ts
@@ -1,0 +1,53 @@
+import seedrandom, { type PRNG } from 'seedrandom';
+
+export type SeededRngStream = PRNG;
+
+export const RNG_STREAM_IDS = {
+  pests: 'pests',
+  events: 'events',
+  loot: 'loot',
+  market: 'market',
+  placement: 'placement',
+  plants: 'plants',
+  ids: 'ids',
+  structures: 'structures',
+  strains: 'strains',
+  methods: 'methods',
+  devices: 'devices',
+  blueprintOptions: 'options',
+  personnelNames: 'personnel-names',
+  personnelTraits: 'personnel-traits',
+  personnelMorale: 'personnel-morale',
+  simulationTest: 'sim.test',
+} as const;
+
+export type RngStreamKey = keyof typeof RNG_STREAM_IDS;
+export type RngStreamId = (typeof RNG_STREAM_IDS)[RngStreamKey];
+
+const registeredStreamIds = new Set<string>(Object.values(RNG_STREAM_IDS));
+
+export const registerRngStreamIds = (...streamIds: string[]): void => {
+  for (const streamId of streamIds) {
+    if (!streamId) {
+      continue;
+    }
+    registeredStreamIds.add(streamId);
+  }
+};
+
+export const getRegisteredRngStreamIds = (): readonly string[] => {
+  return Array.from(registeredStreamIds.values()).sort();
+};
+
+const composeStreamSeed = (seed: string, streamId: string): string => `${seed}::${streamId}`;
+
+export const createSeededStreamGenerator = (seed: string, streamId: string): SeededRngStream => {
+  registerRngStreamIds(streamId);
+  return seedrandom(composeStreamSeed(seed, streamId), { state: true });
+};
+
+export type SeededStreamFactory = (streamId: string) => SeededRngStream;
+
+export const createSeededStreamFactory = (seed: string): SeededStreamFactory => {
+  return (streamId: string) => createSeededStreamGenerator(seed, streamId);
+};


### PR DESCRIPTION
## Summary
- add the seedrandom dependency and expose a runtime RNG helper with canonical stream ids
- refactor the backend RNG service to delegate to the shared helper and re-export the registry
- update pricing, state initialization, and tests to use the shared stream identifiers for deterministic streams

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d0a3cfa0b48325b282e5d0c96942a8