### PR TITLE
feat: centralize physio helpers

### DIFF
--- a/docs/system/simulation-engine.md
+++ b/docs/system/simulation-engine.md
@@ -8,52 +8,58 @@ This document details the engine’s core calculations, tick ordering, and contr
 
 - **Stability** (no drift), **determinism** (seeded RNG), **decoupled rendering**.
 - **Catch-up** without UI stalls; **atomic** state commits per tick.
+
 ### Process
 
 1. **Wall-time accumulation**: keep `accumulatedMs += now - lastNow`.
 2. **Tick threshold**: while `accumulatedMs ≥ tickIntervalMs / gameSpeed`, do:
-    - Run **one full tick** (see _Environment_, _Plant_, _Health_, and _Tasks & Agentic Employees_ below).
-    - `accumulatedMs -= tickIntervalMs / gameSpeed`.
-    - Cap iterations with `maxTicksPerFrame` to prevent long catch-ups.
+   - Run **one full tick** (see _Environment_, _Plant_, _Health_, and _Tasks & Agentic Employees_ below).
+   - `accumulatedMs -= tickIntervalMs / gameSpeed`.
+   - Cap iterations with `maxTicksPerFrame` to prevent long catch-ups.
 3. **Snapshot & events**: publish a read-only snapshot and batched events after each committed tick.
 
 **Notes**
+
 - `gameSpeed` > 0 scales progression without changing equations.
 - In headless runtimes, replace “frame” with the host scheduler; the contract is the same.
 - Determinism: **all stochastic draws** (breeding variance, failure chances, etc.) come from seeded RNG streams.
 
 ---
+
 ## Environment Model (per Zone; well-mixed, delta-based)
 
 Each **Zone** maintains `temperature_C`, `humidity` (0–1), `co2_ppm`, and optionally canopy **PPFD**. The engine aggregates **deltas**; devices contribute their own changes rather than setting absolutes.
+
+See [WB Physiology Reference](./wb-physio.md) for the concrete formulas and unit conventions used in the physio helpers.
 
 ### Tick Order (environment phase)
 
 1. **Start** from last values: `T`, `RH`, `CO2`, (optional `PPFD`).
 2. **Device deltas**
-    - **GrowLight**
-        - Heat gain ∝ `power (kW)` and inefficiency → `+ΔT`.
-        - Light: map `ppf_umol_s` over `coverage_m2` to canopy PPFD.
-        - Optional `dliTarget_mol_m2_day` → duty suggestions (advisory).
-    - **Climate/HVAC**
-        - Cooling/heating: proportional approach to `targetTemperature` within `targetTemperatureRange`.
-        - **Dehumidifier**: `moistureRemoval_Lph` ⇒ `−ΔRH` via moisture balance.
-        - **Exhaust/Fan**: boosts mixing/exchange factor (see normalization).
-    - **CO2Injector**: move `CO2` toward `targetCO2_ppm`, capped by `maxSafeCO2_ppm`.
+   - **GrowLight**
+     - Heat gain ∝ `power (kW)` and inefficiency → `+ΔT`.
+     - Light: map `ppf_umol_s` over `coverage_m2` to canopy PPFD.
+     - Optional `dliTarget_mol_m2_day` → duty suggestions (advisory).
+   - **Climate/HVAC**
+     - Cooling/heating: proportional approach to `targetTemperature` within `targetTemperatureRange`.
+     - **Dehumidifier**: `moistureRemoval_Lph` ⇒ `−ΔRH` via moisture balance.
+     - **Exhaust/Fan**: boosts mixing/exchange factor (see normalization).
+   - **CO2Injector**: move `CO2` toward `targetCO2_ppm`, capped by `maxSafeCO2_ppm`.
 3. **Plant deltas** (coarse canopy physiology)
-    - **Transpiration**: `+ΔRH` (scaled by PPFD, temperature, phenological phase).
-    - **Photosynthesis**: `−ΔCO2` (scaled by PPFD and saturation curve).
+   - **Transpiration**: `+ΔRH` (scaled by PPFD, temperature, phenological phase).
+   - **Photosynthesis**: `−ΔCO2` (scaled by PPFD and saturation curve).
 4. **Normalization toward ambient**
-    - Exponential pull: `Δ = k_mix * (ambient − current)`.
-    - `k_mix` scales with **airflow** (fans/exhaust) and enclosure leakage; higher airflow → faster return to ambient.
+   - Exponential pull: `Δ = k_mix * (ambient − current)`.
+   - `k_mix` scales with **airflow** (fans/exhaust) and enclosure leakage; higher airflow → faster return to ambient.
 5. **Clamp & commit**
-    - Clamp **RH to [0,1]**, safety-clamp `CO2 ≤ maxSafeCO2_ppm`, bound `T` to reasonable limits.
+   - Clamp **RH to [0,1]**, safety-clamp `CO2 ≤ maxSafeCO2_ppm`, bound `T` to reasonable limits.
 6. **Events**
-    - Emit anomalies (e.g., `env.safetyExceeded`) for downstream policy (alarms, auto-shutdowns).
+   - Emit anomalies (e.g., `env.safetyExceeded`) for downstream policy (alarms, auto-shutdowns).
 
 **Why delta-based?** Extensible and composable: new device types add a delta without changing the solver.
 
 ---
+
 ## Plant Growth, Stress, Health (per Planting/Plant)
 
 Plants respond to environment and resources; **stress** reduces **health**; **health** and resources limit **growth** and yield.
@@ -68,69 +74,74 @@ Plants respond to environment and resources; **stress** reduces **health**; **he
 ### Tick Order (plant phase)
 
 1. **Phenology update**  
-    Advance age; evaluate transitions (seedling → vegetative → flowering) by elapsed days and photoperiod policy; emit `plant.stageChanged`.
+   Advance age; evaluate transitions (seedling → vegetative → flowering) by elapsed days and photoperiod policy; emit `plant.stageChanged`.
 2. **Resource requirement**  
-    Convert **NPK (g/m²/day)** → **per-tick, per-plant**:
-    `req_phase = curve[phase]          // g/m²/day`
-	`req_tick_plant = req_phase * (zoneArea / plantCount) * (tickHours / 24)`
-	Water demand analogously from `water.dailyUsePerM2_L`.
+   Convert **NPK (g/m²/day)** → **per-tick, per-plant**:
+   `req_phase = curve[phase]          // g/m²/day`
+   `req_tick_plant = req_phase * (zoneArea / plantCount) * (tickHours / 24)`
+   Water demand analogously from `water.dailyUsePerM2_L`.
 3. **Stress computation (0–1)**  
-    For each driver D ∈ {T, RH/VPD, CO₂, Light, Water, N, P, K} compute a **distance function** from strain optima (e.g., quadratic or Gaussian penalty).  
-    Combine: `stress_raw = Σ w_D * penalty_D`.  
-    Resilience mitigation: `stress = clamp01(stress_raw * (1 − generalResilience))`.
+   For each driver D ∈ {T, RH/VPD, CO₂, Light, Water, N, P, K} compute a **distance function** from strain optima (e.g., quadratic or Gaussian penalty).  
+   Combine: `stress_raw = Σ w_D * penalty_D`.  
+   Resilience mitigation: `stress = clamp01(stress_raw * (1 − generalResilience))`.
 4. **Health update (0–1)**  
-    If `stress > θ_stress`: `health -= α * stress`; otherwise passive recovery `health += β_recovery`.  
-    Additional penalties from **active diseases/pests** and **resource deficits**.
+   If `stress > θ_stress`: `health -= α * stress`; otherwise passive recovery `health += β_recovery`.  
+   Additional penalties from **active diseases/pests** and **resource deficits**.
 5. **Potential growth**
-    - **Light response** (rectangular hyperbola/saturation over PPFD), **temperature response** (Gaussian), **CO₂ factor** (half-saturation).
-    - Apply phase caps and **LUE** to get `potentialGrowth_g_dry_per_tick`.
-    - Apply health & stress: `actualGrowth = potentialGrowth * health * (1 − γ * stress)`.
-    - Accrue `biomassDry_g`; enforce `maxBiomassDry_g` and phase harvest index.
+   - **Light response** (rectangular hyperbola/saturation over PPFD), **temperature response** (Gaussian), **CO₂ factor** (half-saturation).
+   - Apply phase caps and **LUE** to get `potentialGrowth_g_dry_per_tick`.
+   - Apply health & stress: `actualGrowth = potentialGrowth * health * (1 − γ * stress)`.
+   - Accrue `biomassDry_g`; enforce `maxBiomassDry_g` and phase harvest index.
 6. **Quality & harvest window**  
-    Accumulate quality within `harvest.windowDays`; outside this window, quality decays faster.
+   Accumulate quality within `harvest.windowDays`; outside this window, quality decays faster.
 
 **Outputs**: plant metrics (biomass, health, stress), resource consumption, warnings.
 
 ---
+
 ## Health: Pests & Diseases (detect → progress → spread → treat)
 
 Integrates **data-driven** pests/diseases with **operational** treatments.
+
 ### Tick Order (health phase)
 
 1. **Detect**  
-    Visibility rises with time/conditions; **scouting tasks** improve detection; traps add passive checks.  
-    Emit `pest.detected` / `disease.confirmed` on threshold.
+   Visibility rises with time/conditions; **scouting tasks** improve detection; traps add passive checks.  
+   Emit `pest.detected` / `disease.confirmed` on threshold.
 2. **Progress**  
-    Advance **severity/infection** using blueprint daily increments (scaled to ticks) × environmental risk × phase multipliers.  
-    Apply **damage** to plant processes (growth, transpiration, mortality risk) per blueprint.
-   3. **Spread**  
-    Stochastic spread within zone and to neighbors; modulated by **airflow (mixing)**, **sanitation**, and **tool transmission**.  
-    Quarantine/locks reduce adjacency graph edges.
-4. **Treat**  
-    Apply active **treatments** from `configs/treatment_options.json`: efficacy multipliers to infection/degeneration/recovery.  
-    Enforce **cooldowns**, **reentryIntervalTicks**, **preHarvestIntervalTicks**; set **safety constraints** that block task claiming.
-   5. **Emit events**  
-    `health.spread`, `treatment.applied`, `outbreak.contained`, `treatment.failed`.
+   Advance **severity/infection** using blueprint daily increments (scaled to ticks) × environmental risk × phase multipliers.  
+   Apply **damage** to plant processes (growth, transpiration, mortality risk) per blueprint. 3. **Spread**  
+   Stochastic spread within zone and to neighbors; modulated by **airflow (mixing)**, **sanitation**, and **tool transmission**.  
+   Quarantine/locks reduce adjacency graph edges.
+3. **Treat**  
+   Apply active **treatments** from `configs/treatment_options.json`: efficacy multipliers to infection/degeneration/recovery.  
+   Enforce **cooldowns**, **reentryIntervalTicks**, **preHarvestIntervalTicks**; set **safety constraints** that block task claiming. 5. **Emit events**  
+   `health.spread`, `treatment.applied`, `outbreak.contained`, `treatment.failed`.
 
 ---
+
 ## Tasks & Agentic Employees (utility-based; overtime-aware)
 
 ### Task generation (per tick)
 
 Scan world state → create **Task** objects (see DD §Tasks) from `task_definitions.json`.  
 Compute `durationTicks` via `costBasis`:
+
 - `perAction` fixed
 - `perPlant × plantCount`
 - `perSquareMeter × area`
+
 ### Claiming (pull model with utility)
 
 **Idle** employees compute a **utility** for visible tasks:  
 `U = w1*priority + w2*skillMatch + w3*roleAffinity + w4*urgency − w5*distance − w6*fatigue + w7*morale + w8*toolAvailability ± traitMods`  
 Highest utility claims; use **backoff** to avoid thrash; **aging** to prevent starvation.  
 Honor **safety constraints** (e.g., no entry before `reentryIntervalTicks`).
+
 ### Execution & completion
 
 While Working: increment `progressTicks` each tick; when `progressTicks ≥ durationTicks`, resolve effects (repair, harvest, clean…), emit `task.completed`.
+
 ### Overtime (energy-linked)
 
 Energy `0..100` decreases per working tick. Employees **finish the current task** even if **energy < 0**.  
@@ -139,34 +150,38 @@ At completion: convert negative energy to **overtime hours** (ticks).
 
 - `payout`: pay `overtimeMultiplier × hourlyWage` immediately; employee rests normally.
 - `timeOff`: credit overtime to `leaveHours`; next OffDuty extends accordingly.  
-    Emit `hr.overtimeAccrued`, `hr.overtimePaid` / `hr.timeOffScheduled`.
+   Emit `hr.overtimeAccrued`, `hr.overtimePaid` / `hr.timeOffScheduled`.
 
 ---
+
 ## Economics (currency-neutral)
 
 **Event-based** and **per-tick** accounting; figures are currency-neutral (UI chooses symbol).
+
 - **CapEx**: device purchases (`capitalCost`), structure setup; log & deduct immediately.
 - **OpEx (per tick)**:
-    - **Maintenance**: `baseMaintenanceCostPerTick` (+ aging via `costIncreasePer1000Ticks`).
-    - **Energy**: sum `(device.power_kW × tickHours × electricityCostPerKWh)` for active devices.
-    - **Water/Nutrients**: from zone demand using **g/m²/day** curves → per-tick spend via `waterCostPerM3`, `nutrientsCostPerKg`.
-    - **Rent**: structure fixed costs or `area_m2 × rentalRate`, normalized to ticks.
-    - **Labor**: daily sweep (every 24 ticks) or continuous accrual; overtime per policy.
+  - **Maintenance**: `baseMaintenanceCostPerTick` (+ aging via `costIncreasePer1000Ticks`).
+  - **Energy**: sum `(device.power_kW × tickHours × electricityCostPerKWh)` for active devices.
+  - **Water/Nutrients**: from zone demand using **g/m²/day** curves → per-tick spend via `waterCostPerM3`, `nutrientsCostPerKg`.
+  - **Rent**: structure fixed costs or `area_m2 × rentalRate`, normalized to ticks.
+  - **Labor**: daily sweep (every 24 ticks) or continuous accrual; overtime per policy.
 - **Revenue**: `harvestBasePricePerGram × quality × market modifiers` on sales.
 - **Reports**: emit `finance.tick` summaries; categorize by device/structure/zone.
 
 ---
+
 ## Persistence, Validation, and Hot-Reload
 
 - **Persistence**: serialize full authoritative state + RNG streams; loading restores determinism.
 - **Validation** on data load & hot-reload:
-    - Types/ranges; **IDs are UUID** (`id`) in all blueprints; cross-refs by `id`.
-    - Strain **`lineage.parents`** must be UUIDs; empty/missing ⇒ **ur-plant**.
-    - Devices must honor **`allowedRoomPurposes`**.
-    - Treatment options must carry **`reentryIntervalTicks` / `preHarvestIntervalTicks`** (or convert from human-readable inputs).
+  - Types/ranges; **IDs are UUID** (`id`) in all blueprints; cross-refs by `id`.
+  - Strain **`lineage.parents`** must be UUIDs; empty/missing ⇒ **ur-plant**.
+  - Devices must honor **`allowedRoomPurposes`**.
+  - Treatment options must carry **`reentryIntervalTicks` / `preHarvestIntervalTicks`** (or convert from human-readable inputs).
 - **Hot-reload**: validate → stage → swap at a tick boundary; emit `data.reloaded` with a diff summary.
 
 ---
+
 ## Determinism & RNG Streams
 
 - A **global seed** initializes named streams: `"breeding"`, `"environment.noise"`, `"device.failure"`, `"task.random"`, etc.
@@ -174,6 +189,7 @@ At completion: convert negative energy to **overtime hours** (ticks).
 - Store stream positions in snapshots to guarantee **exact replay**.
 
 ---
+
 ## Error Handling & Safety
 
 - **Hard clamps**: RH `[0,1]`, `CO2 ≤ maxSafeCO2_ppm`, reasonable temperature bounds, non-negative inventories.
@@ -181,6 +197,7 @@ At completion: convert negative energy to **overtime hours** (ticks).
 - **Task invalidation**: if a referenced object disappears (sold device, culled planting), cancel with `task.abandoned`.
 
 ---
+
 ## Future Enhancements (compatible with current contracts)
 
 - **Event-driven task creation**: replace polling with device/plant events (e.g., `device.maintenanceRequired`) to cut scan cost.

--- a/docs/system/wb-physio.md
+++ b/docs/system/wb-physio.md
@@ -1,0 +1,62 @@
+# Weed Breed Physiology Reference
+
+This note documents the simplified canopy physiology formulas implemented in `src/physio`. All
+functions are deterministic, pure utilities that operate on **SI units** (unless noted) and are used by
+the simulation engine to derive environment deltas and plant growth responses.
+
+## Temperature Mixing (`temp.ts`)
+
+- **Function:** `approachTemperature(currentC, targetC, ratePerHour, hours)`
+- **Units:** °C, h⁻¹, hours
+- **Formula:** `Tₜ = Tₐ + (T₀ − Tₐ) · exp(−k · Δt)`
+- **Use:** Zone normalization toward ambient temperature based on passive leakage and airflow.
+- **Also provides:** `gaussianResponse(value, mean, sigma)` (unitless) for thermal stress curves.
+
+## Relative Humidity Mixing (`rh.ts`)
+
+- **Function:** `approachRelativeHumidity(current, target, ratePerHour, hours)`
+- **Units:** fraction (0–1), h⁻¹, hours
+- **Formula:** Same exponential approach as temperature, clamped to `[0, 1]`.
+- **Use:** Pulls zone humidity toward ambient after device and plant deltas.
+
+## CO₂ Dynamics (`co2.ts`)
+
+- **Functions:**
+  - `approachCo2(currentPpm, targetPpm, ratePerHour, hours)` — exponential approach in ppm.
+  - `co2HalfSaturationResponse(concentrationPpm, halfSaturationPpm)` — rectangular hyperbola response.
+- **Use:** Normalization toward ambient and photosynthetic CO₂ response in the growth model.
+
+## Photosynthetic Photons (`ppfd.ts`)
+
+- **Functions:**
+  - `ppfdToMoles(ppfd, durationHours)` — converts PPFD (µmol·m⁻²·s⁻¹) over a tick to mol·m⁻².
+  - `lightSaturationResponse(ppfd, halfSaturation, maxResponse?)` — light saturation curve.
+- **Use:** Converting canopy PPFD into absorbed photon dose and the corresponding light response factor.
+
+## Vapour Pressure Deficit (`vpd.ts`)
+
+- **Functions:**
+  - `saturationVaporPressure(temperatureC)` — Magnus approximation (kPa).
+  - `actualVaporPressure(temperatureC, relativeHumidity)` — saturation × RH (kPa).
+  - `vaporPressureDeficit(temperatureC, relativeHumidity)` — difference in kPa.
+- **Use:** Zone VPD telemetry and VPD-driven stress in the growth model.
+
+## Transpiration (`transpiration.ts`)
+
+- **Function:** `estimateTranspirationLiters({ vpdKPa, canopyAreaM2, leafAreaIndex, durationHours, stomatalFactor })`
+- **Units:** kPa, m², dimensionless LAI, hours; returns litres per tick.
+- **Formula:**
+  - Effective canopy conductance: `g_c = g₀ · clamp(LAI / 3, 0.3, 2)` with `g₀ = 0.008 mol·m⁻²·s⁻¹·kPa⁻¹`.
+  - Flux: `E = g_c · VPD · f_stomatal` (mol·m⁻²·s⁻¹).
+  - Tick volume: `litres = E · area · Δt · 3600 · 0.018` (0.018 L per mol of water).
+- **Use:** Provides a coarse transpiration estimate per plant for telemetry and future water budget coupling.
+
+## Integration Points
+
+- `ZoneEnvironmentService.normalize` uses the mixing helpers to pull temperature, humidity and CO₂
+  toward ambient conditions every tick and recomputes VPD via `vaporPressureDeficit`.
+- `updatePlantGrowth` consumes the PPFD, temperature, CO₂, VPD and transpiration helpers to derive
+  growth responses, stress metrics, photon absorption and transpiration outputs.
+
+Refer to the accompanying unit tests in `src/backend/src/engine/physio/__tests__/formulas.test.ts`
+for golden master values that validate these calculations.

--- a/src/backend/src/engine/physio/__tests__/formulas.test.ts
+++ b/src/backend/src/engine/physio/__tests__/formulas.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  actualVaporPressure,
+  saturationVaporPressure,
+  vaporPressureDeficit,
+} from '../../../../../physio/vpd.js';
+import { lightSaturationResponse, ppfdToMoles } from '../../../../../physio/ppfd.js';
+import { approachTemperature } from '../../../../../physio/temp.js';
+import { approachRelativeHumidity } from '../../../../../physio/rh.js';
+import { approachCo2, co2HalfSaturationResponse } from '../../../../../physio/co2.js';
+import { estimateTranspirationLiters } from '../../../../../physio/transpiration.js';
+
+const EPSILON = 1e-6;
+
+describe('physio formulas', () => {
+  it('computes vapor pressure deficit with consistent saturation pressure', () => {
+    const saturation = saturationVaporPressure(25);
+    const actual = actualVaporPressure(25, 0.6);
+    const vpd = vaporPressureDeficit(25, 0.6);
+
+    expect(Math.abs(saturation - 3.1677777175068473)).toBeLessThan(EPSILON);
+    expect(Math.abs(actual - 1.9006666305041082)).toBeLessThan(EPSILON);
+    expect(Math.abs(vpd - 1.2671110870027391)).toBeLessThan(EPSILON);
+  });
+
+  it('integrates PPFD and applies saturation response', () => {
+    const mol = ppfdToMoles(500, 1);
+    const response = lightSaturationResponse(600, 300);
+
+    expect(Math.abs(mol - 1.8)).toBeLessThan(EPSILON);
+    expect(Math.abs(response - 0.6666666667)).toBeLessThan(1e-9);
+  });
+
+  it('approaches ambient conditions for temperature, humidity, and CO2', () => {
+    const mixedTemperature = approachTemperature(28, 22, 0.2, 0.5);
+    const mixedHumidity = approachRelativeHumidity(0.35, 0.6, 0.1, 1);
+    const mixedCo2 = approachCo2(950, 420, 0.3, 0.25);
+
+    expect(Math.abs(mixedTemperature - 27.429024508215758)).toBeLessThan(1e-9);
+    expect(Math.abs(mixedHumidity - 0.3737906454910101)).toBeLessThan(1e-9);
+    expect(Math.abs(mixedCo2 - 911.704047754133)).toBeLessThan(1e-9);
+  });
+
+  it('computes CO2 half-saturation response', () => {
+    const response = co2HalfSaturationResponse(1000, 600);
+    expect(Math.abs(response - 0.625)).toBeLessThan(EPSILON);
+  });
+
+  it('estimates transpiration from canopy conductance', () => {
+    const liters = estimateTranspirationLiters({
+      vpdKPa: 1.2,
+      canopyAreaM2: 0.4,
+      leafAreaIndex: 3,
+      durationHours: 0.25,
+      stomatalFactor: 0.75,
+    });
+    expect(Math.abs(liters - 0.046655999999999996)).toBeLessThan(1e-9);
+  });
+});

--- a/src/backend/src/engine/plants/growthModel.test.ts
+++ b/src/backend/src/engine/plants/growthModel.test.ts
@@ -147,6 +147,8 @@ describe('updatePlantGrowth', () => {
 
     expect(darkResult.biomassDelta).toBeLessThan(brightResult.biomassDelta);
     expect(brightResult.biomassDelta).toBeGreaterThan(0);
+    expect(darkResult.transpirationLiters).toBeLessThan(brightResult.transpirationLiters);
+    expect(brightResult.transpirationLiters).toBeGreaterThan(0);
   });
 
   it('reduces growth when temperature deviates from the optimal band', () => {
@@ -258,6 +260,7 @@ describe('updatePlantGrowth', () => {
     expect(limited.metrics.water.stress).toBeGreaterThan(ample.metrics.water.stress);
     expect(limited.biomassDelta).toBeLessThan(ample.biomassDelta);
     expect(limited.plant.health).toBeLessThan(ample.plant.health);
+    expect(limited.transpirationLiters).toBeLessThan(ample.transpirationLiters);
   });
 });
 

--- a/src/physio/co2.ts
+++ b/src/physio/co2.ts
@@ -1,0 +1,46 @@
+import { exponentialApproach } from './temp.js';
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+/**
+ * Mixes CO₂ concentration towards an ambient reference using an exponential approach.
+ *
+ * @param current - Current CO₂ concentration in parts per million (ppm).
+ * @param target - Ambient CO₂ concentration in ppm.
+ * @param ratePerHour - Mixing rate constant in h⁻¹.
+ * @param hours - Simulation time step in hours.
+ * @returns Updated CO₂ concentration in ppm.
+ */
+export const approachCo2 = (
+  current: number,
+  target: number,
+  ratePerHour: number,
+  hours: number,
+): number => {
+  const mixed = exponentialApproach(current, target, ratePerHour, hours);
+  return Math.max(mixed, 0);
+};
+
+/**
+ * Computes a half-saturation response for CO₂ assimilation.
+ *
+ * @param concentrationPpm - CO₂ concentration in parts per million (ppm).
+ * @param halfSaturationPpm - Half-saturation constant in ppm.
+ * @returns Response multiplier in the range [0, 1].
+ */
+export const co2HalfSaturationResponse = (
+  concentrationPpm: number,
+  halfSaturationPpm: number,
+): number => {
+  if (concentrationPpm <= 0) {
+    return 0;
+  }
+  const half = Math.max(halfSaturationPpm, 1);
+  const response = concentrationPpm / (concentrationPpm + half);
+  return clamp(response, 0, 1);
+};

--- a/src/physio/index.ts
+++ b/src/physio/index.ts
@@ -1,0 +1,6 @@
+export * from './vpd.js';
+export * from './temp.js';
+export * from './rh.js';
+export * from './co2.js';
+export * from './ppfd.js';
+export * from './transpiration.js';

--- a/src/physio/ppfd.ts
+++ b/src/physio/ppfd.ts
@@ -1,0 +1,43 @@
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const SECONDS_PER_HOUR = 3600;
+const MICROMOL_TO_MOL = 1e-6;
+
+/**
+ * Rectangular hyperbola response of photosynthesis to PPFD (µmol·m⁻²·s⁻¹).
+ *
+ * @param ppfd - Incident photosynthetic photon flux density in µmol·m⁻²·s⁻¹.
+ * @param halfSaturation - Half-saturation constant (µmol·m⁻²·s⁻¹).
+ * @param maxResponse - Optional maximum response multiplier (default 1).
+ * @returns Response multiplier in the range [0, maxResponse].
+ */
+export const lightSaturationResponse = (
+  ppfd: number,
+  halfSaturation: number,
+  maxResponse = 1,
+): number => {
+  if (ppfd <= 0) {
+    return 0;
+  }
+  const half = Math.max(halfSaturation, 1);
+  const response = ppfd / (ppfd + half);
+  return clamp(response * maxResponse, 0, maxResponse);
+};
+
+/**
+ * Integrates PPFD over a time step and converts it to mol·m⁻².
+ *
+ * @param ppfd - Photosynthetic photon flux density in µmol·m⁻²·s⁻¹.
+ * @param durationHours - Duration of the time step in hours.
+ * @returns Photon dose in mol·m⁻² for the given time step.
+ */
+export const ppfdToMoles = (ppfd: number, durationHours: number): number => {
+  const photons = Math.max(ppfd, 0);
+  const hours = Math.max(durationHours, 0);
+  return photons * MICROMOL_TO_MOL * hours * SECONDS_PER_HOUR;
+};

--- a/src/physio/rh.ts
+++ b/src/physio/rh.ts
@@ -1,0 +1,20 @@
+import { clamp01, exponentialApproach } from './temp.js';
+
+/**
+ * Mixes relative humidity towards an ambient reference.
+ *
+ * @param current - Current relative humidity (fraction 0–1).
+ * @param target - Ambient relative humidity (fraction 0–1).
+ * @param ratePerHour - Mixing rate constant in h⁻¹.
+ * @param hours - Simulation time step in hours.
+ * @returns Updated relative humidity (fraction 0–1).
+ */
+export const approachRelativeHumidity = (
+  current: number,
+  target: number,
+  ratePerHour: number,
+  hours: number,
+): number => {
+  const mixed = exponentialApproach(current, target, ratePerHour, hours);
+  return clamp01(mixed);
+};

--- a/src/physio/temp.ts
+++ b/src/physio/temp.ts
@@ -1,0 +1,69 @@
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const MIN_SIGMA = 0.05;
+
+/**
+ * Exponential relaxation towards a target value.
+ *
+ * @param current - Current value in the same units as the target.
+ * @param target - Target value to approach.
+ * @param ratePerHour - Mixing rate constant in h⁻¹.
+ * @param hours - Simulation time step in hours.
+ * @returns Relaxed value in the same units as `current` and `target`.
+ */
+export const exponentialApproach = (
+  current: number,
+  target: number,
+  ratePerHour: number,
+  hours: number,
+): number => {
+  const rate = Math.max(ratePerHour, 0);
+  const stepHours = Math.max(hours, 0);
+  if (rate === 0 || stepHours === 0) {
+    return current;
+  }
+  const decay = Math.exp(-rate * stepHours);
+  return target + (current - target) * decay;
+};
+
+/**
+ * Mixes air temperature towards an ambient reference using an exponential approach.
+ *
+ * @param currentC - Current air temperature in degrees Celsius.
+ * @param targetC - Ambient or target air temperature in degrees Celsius.
+ * @param ratePerHour - Mixing rate constant in h⁻¹.
+ * @param hours - Simulation time step in hours.
+ * @returns Updated air temperature in degrees Celsius.
+ */
+export const approachTemperature = (
+  currentC: number,
+  targetC: number,
+  ratePerHour: number,
+  hours: number,
+): number => {
+  return exponentialApproach(currentC, targetC, ratePerHour, hours);
+};
+
+/**
+ * Gaussian response curve bounded to [0, 1].
+ *
+ * @param value - Input value (°C for temperature-driven responses).
+ * @param mean - Optimal value (°C).
+ * @param sigma - Spread (standard deviation) in the same units as the input.
+ * @returns Response multiplier in the range [0, 1].
+ */
+export const gaussianResponse = (value: number, mean: number, sigma: number): number => {
+  if (!Number.isFinite(value) || !Number.isFinite(mean)) {
+    return 0;
+  }
+  const spread = Math.max(Math.abs(sigma), MIN_SIGMA);
+  const exponent = -0.5 * ((value - mean) / spread) ** 2;
+  return clamp(Math.exp(exponent), 0, 1);
+};
+
+export const clamp01 = (value: number): number => clamp(value, 0, 1);

--- a/src/physio/transpiration.ts
+++ b/src/physio/transpiration.ts
@@ -1,0 +1,52 @@
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const BASE_CANOPY_CONDUCTANCE = 0.008; // mol·m⁻²·s⁻¹·kPa⁻¹
+const WATER_MOLAR_VOLUME_LITERS = 0.018; // L per mol of water
+const SECONDS_PER_HOUR = 3600;
+
+export interface TranspirationInput {
+  /** Vapour pressure deficit in kilopascals (kPa). */
+  vpdKPa: number;
+  /** Effective canopy area exposed to air in square metres (m²). */
+  canopyAreaM2: number;
+  /** Leaf area index (dimensionless, m² leaf area per m² ground). */
+  leafAreaIndex: number;
+  /** Duration of the time step in hours. */
+  durationHours: number;
+  /** Optional stomatal opening factor (0–1) capturing stress modulation. */
+  stomatalFactor?: number;
+}
+
+/**
+ * Estimates plant transpiration over a time step using a canopy conductance model.
+ *
+ * The formulation is a simplified Penman–Monteith proxy:
+ *   `E = g_c * VPD * f_stomatal`
+ * where `g_c` scales with the leaf area index. The resulting flux is converted from
+ * mol·m⁻²·s⁻¹ to litres over the given canopy area and time step.
+ */
+export const estimateTranspirationLiters = ({
+  vpdKPa,
+  canopyAreaM2,
+  leafAreaIndex,
+  durationHours,
+  stomatalFactor,
+}: TranspirationInput): number => {
+  const vpd = Math.max(vpdKPa, 0);
+  const area = Math.max(canopyAreaM2, 0);
+  const hours = Math.max(durationHours, 0);
+  if (vpd === 0 || area === 0 || hours === 0) {
+    return 0;
+  }
+  const laiFactor = clamp(leafAreaIndex / 3, 0.3, 2);
+  const stomatal = clamp(stomatalFactor ?? 1, 0, 1);
+  const conductance = BASE_CANOPY_CONDUCTANCE * laiFactor;
+  const fluxMolPerM2S = conductance * vpd * stomatal;
+  const mol = fluxMolPerM2S * area * hours * SECONDS_PER_HOUR;
+  return mol * WATER_MOLAR_VOLUME_LITERS;
+};

--- a/src/physio/vpd.ts
+++ b/src/physio/vpd.ts
@@ -1,0 +1,49 @@
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const SATURATION_CONSTANT_A = 17.27;
+const SATURATION_CONSTANT_B = 237.3;
+const SATURATION_PRESSURE_COEFFICIENT = 0.6108;
+
+/**
+ * Computes the saturation vapour pressure of air at a given temperature.
+ *
+ * @param temperatureC - Air temperature in degrees Celsius.
+ * @returns Saturation vapour pressure in kilopascals (kPa).
+ */
+export const saturationVaporPressure = (temperatureC: number): number => {
+  const temperature = clamp(temperatureC, -50, 60);
+  const exponent = (SATURATION_CONSTANT_A * temperature) / (temperature + SATURATION_CONSTANT_B);
+  return SATURATION_PRESSURE_COEFFICIENT * Math.exp(exponent);
+};
+
+/**
+ * Computes the actual vapour pressure given temperature and relative humidity.
+ *
+ * @param temperatureC - Air temperature in degrees Celsius.
+ * @param relativeHumidity - Relative humidity as a fraction (0–1).
+ * @returns Actual vapour pressure in kilopascals (kPa).
+ */
+export const actualVaporPressure = (temperatureC: number, relativeHumidity: number): number => {
+  const humidity = clamp(relativeHumidity, 0, 1);
+  return saturationVaporPressure(temperatureC) * humidity;
+};
+
+/**
+ * Calculates the vapour pressure deficit (VPD) using the simplified Magnus equation.
+ *
+ * @param temperatureC - Air temperature in degrees Celsius.
+ * @param relativeHumidity - Relative humidity as a fraction (0–1).
+ * @returns Vapour pressure deficit in kilopascals (kPa).
+ */
+export const vaporPressureDeficit = (temperatureC: number, relativeHumidity: number): number => {
+  const saturation = saturationVaporPressure(temperatureC);
+  const actual = actualVaporPressure(temperatureC, relativeHumidity);
+  return Math.max(saturation - actual, 0);
+};
+
+export const computeVpd = vaporPressureDeficit;


### PR DESCRIPTION
## Summary
- add a shared physio module suite for VPD, PPFD, CO₂, temperature, humidity, and transpiration helpers
- refactor zone environment normalization and the plant growth model to consume the physio helpers and expose transpiration
- add targeted physio golden-master tests and document the formulas with links from the simulation engine guide

## Testing
- `pnpm --filter @weebbreed/backend test`


------
https://chatgpt.com/codex/tasks/task_e_68d0d0fefed0832592a2f1c3b8c2aa15