### PR TITLE
feat: support configurable default structure height

### DIFF
--- a/src/backend/src/state/initialization/blueprints.ts
+++ b/src/backend/src/state/initialization/blueprints.ts
@@ -12,19 +12,32 @@ interface RawStructureBlueprint {
   footprint: {
     length_m: number;
     width_m: number;
-    height_m: number;
+    height_m?: number;
   };
   rentalCostPerSqmPerMonth: number;
   upfrontFee: number;
 }
 
-const normaliseStructureBlueprint = (blueprint: RawStructureBlueprint): StructureBlueprint => ({
+export const DEFAULT_STRUCTURE_HEIGHT_METERS = 2.5;
+
+export interface LoadStructureBlueprintsOptions {
+  defaultHeightMeters?: number;
+}
+
+const normaliseStructureBlueprint = (
+  blueprint: RawStructureBlueprint,
+  defaultHeightMeters: number,
+): StructureBlueprint => ({
   id: blueprint.id,
   name: blueprint.name,
   footprint: {
     length: blueprint.footprint.length_m,
     width: blueprint.footprint.width_m,
-    height: blueprint.footprint.height_m,
+    height:
+      typeof blueprint.footprint.height_m === 'number' &&
+      Number.isFinite(blueprint.footprint.height_m)
+        ? blueprint.footprint.height_m
+        : defaultHeightMeters,
   },
   rentalCostPerSqmPerMonth: blueprint.rentalCostPerSqmPerMonth,
   upfrontFee: blueprint.upfrontFee,
@@ -32,7 +45,9 @@ const normaliseStructureBlueprint = (blueprint: RawStructureBlueprint): Structur
 
 export const loadStructureBlueprints = async (
   dataDirectory: string,
+  options: LoadStructureBlueprintsOptions = {},
 ): Promise<StructureBlueprint[]> => {
+  const defaultHeightMeters = options.defaultHeightMeters ?? DEFAULT_STRUCTURE_HEIGHT_METERS;
   const directory = path.join(dataDirectory, 'blueprints', 'structures');
   let entries: string[] = [];
   try {
@@ -55,7 +70,7 @@ export const loadStructureBlueprints = async (
     if (!raw) {
       continue;
     }
-    blueprints.push(normaliseStructureBlueprint(raw));
+    blueprints.push(normaliseStructureBlueprint(raw, defaultHeightMeters));
   }
   return blueprints;
 };

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -54,7 +54,7 @@ export interface GameState {
 export interface FootprintBlueprint {
   length: number;
   width: number;
-  height: number;
+  height?: number;
 }
 
 export interface StructureBlueprint {
@@ -66,6 +66,7 @@ export interface StructureBlueprint {
 }
 
 export interface FootprintDimensions extends FootprintBlueprint {
+  height: number;
   area: number;
   volume: number;
 }

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -272,6 +272,7 @@ export const createStateFactoryContext = (
   dataDirectory: options.dataDirectory,
   personnelDirectory: options.personnelDirectory,
   taskDefinitions: options.taskDefinitions,
+  defaultStructureHeightMeters: options.defaultStructureHeightMeters,
 });
 
 export const createDevicePriceMap = (


### PR DESCRIPTION
## Summary
- add a configurable default structure ceiling height when loading structure blueprints
- allow the state factory to supply a default height override and respect explicit blueprint heights
- expand loader and state factory tests to cover default behaviour and overrides

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d0df95bf6c8325b92a103606e87aad