### PR TITLE
Scale pricing multipliers to normalized quality inputs

### DIFF
--- a/docs/_currentjobs/13-strainprices-and-market.md
+++ b/docs/_currentjobs/13-strainprices-and-market.md
@@ -13,4 +13,5 @@ Nutze `strainPrices.json` (seedPrice, harvestPricePerGram). Implementiere `quali
 
 1. Registry `StrainPriceRegistry` + Validierung.
 2. Einfaches Qualitätsmodell (0.7–1.2) dokumentieren.
+   - Qualitätssignal kommt normalisiert (`0–1`) aus Health/Stress; ca. `0.6` entspricht neutraler Preisqualität (`×1.0`).
 3. Abverkaufslogik im Accounting integrieren.

--- a/src/backend/src/engine/economy/pricing.test.ts
+++ b/src/backend/src/engine/economy/pricing.test.ts
@@ -25,10 +25,10 @@ const createCatalog = (): PriceCatalog => ({
   },
 });
 
-const createEconomics = (): EconomicsSettings => ({
+const createEconomics = (harvestPriceMultiplier = 1.05): EconomicsSettings => ({
   initialCapital: 0,
   itemPriceMultiplier: 1,
-  harvestPriceMultiplier: 1.05,
+  harvestPriceMultiplier,
   rentPerSqmStructurePerTick: 0,
   rentPerSqmRoomPerTick: 0,
 });
@@ -43,7 +43,7 @@ describe('PricingService', () => {
     const marketStream = expectedRng.getStream(RNG_STREAM_IDS.market);
     const economics = createEconomics();
 
-    const sale1 = service.calculateHarvestSale('strain-a', 1200, 82, economics);
+    const sale1 = service.calculateHarvestSale('strain-a', 1200, 0.82, economics);
     const expectedIndex1 =
       MARKET_INDEX_MIN + (MARKET_INDEX_MAX - MARKET_INDEX_MIN) * marketStream.nextFloat();
     const economicsMultiplier = economics.harvestPriceMultiplier ?? 1;
@@ -57,7 +57,7 @@ describe('PricingService', () => {
       6,
     );
 
-    const sale2 = service.calculateHarvestSale('strain-a', 600, 95, economics);
+    const sale2 = service.calculateHarvestSale('strain-a', 600, 0.95, economics);
     const expectedIndex2 =
       MARKET_INDEX_MIN + (MARKET_INDEX_MAX - MARKET_INDEX_MIN) * marketStream.nextFloat();
 
@@ -76,7 +76,7 @@ describe('PricingService', () => {
     const service = new PricingService(catalog);
     const economics = createEconomics();
 
-    const sale = service.calculateHarvestSale('strain-a', 500, 75, economics);
+    const sale = service.calculateHarvestSale('strain-a', 500, 0.75, economics);
 
     expect(sale.marketIndex).toBe(1);
     expect(sale.appliedMultiplier).toBeCloseTo(economics.harvestPriceMultiplier ?? 1, 6);
@@ -84,5 +84,51 @@ describe('PricingService', () => {
       sale.grams * sale.adjustedPricePerGram * sale.appliedMultiplier,
       6,
     );
+  });
+  it('maps normalized quality onto the expected multiplier window', () => {
+    const catalog = createCatalog();
+    const service = new PricingService(catalog);
+    const basePrice = catalog.strainPrices.get('strain-a')?.harvestPricePerGram ?? 0;
+
+    const qualities = [0, 0.3, 0.6, 0.85, 1];
+    const multipliers = qualities.map((quality) => {
+      const sale = service.calculateHarvestSale('strain-a', 1000, quality, createEconomics(1));
+      const qualityMultiplier = sale.adjustedPricePerGram / basePrice;
+      expect(qualityMultiplier).toBeGreaterThanOrEqual(0.7);
+      expect(qualityMultiplier).toBeLessThanOrEqual(1.2);
+      return qualityMultiplier;
+    });
+
+    expect(multipliers[0]).toBeCloseTo(0.7, 6);
+    expect(multipliers[2]).toBeCloseTo(1, 6);
+    expect(multipliers[4]).toBeCloseTo(1.2, 6);
+
+    for (let i = 1; i < multipliers.length; i += 1) {
+      expect(multipliers[i]).toBeGreaterThanOrEqual(multipliers[i - 1]);
+    }
+  });
+
+  it('reflects revenue sensitivity to quality changes at neutral economics', () => {
+    const catalog = createCatalog();
+    const service = new PricingService(catalog);
+    const economics = createEconomics(1);
+    const grams = 800;
+
+    const poorQualitySale = service.calculateHarvestSale('strain-a', grams, 0.2, economics);
+    const baselineQualitySale = service.calculateHarvestSale('strain-a', grams, 0.6, economics);
+    const greatQualitySale = service.calculateHarvestSale('strain-a', grams, 0.9, economics);
+
+    const basePrice = catalog.strainPrices.get('strain-a')?.harvestPricePerGram ?? 0;
+    const poorMultiplier = poorQualitySale.adjustedPricePerGram / basePrice;
+    const baselineMultiplier = baselineQualitySale.adjustedPricePerGram / basePrice;
+    const greatMultiplier = greatQualitySale.adjustedPricePerGram / basePrice;
+
+    expect(poorMultiplier).toBeLessThan(baselineMultiplier);
+    expect(baselineMultiplier).toBeLessThan(greatMultiplier);
+    expect(poorMultiplier).toBeGreaterThanOrEqual(0.7);
+    expect(greatMultiplier).toBeLessThanOrEqual(1.2);
+
+    expect(poorQualitySale.totalRevenue).toBeLessThan(baselineQualitySale.totalRevenue);
+    expect(baselineQualitySale.totalRevenue).toBeLessThan(greatQualitySale.totalRevenue);
   });
 });


### PR DESCRIPTION
## Summary
- map the normalized (0–1) quality signal onto the 0.7–1.2 harvest price multiplier window with a health/stress curve
- expand pricing service tests to cover the new quality scale and revenue sensitivity to quality changes
- document the accepted quality range for strain pricing jobs

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d0e5f54f548325bc133196b6407068