### PR TITLE
Track payroll expenses in accounting

### DIFF
--- a/src/backend/src/engine/economy/costAccounting.ts
+++ b/src/backend/src/engine/economy/costAccounting.ts
@@ -55,6 +55,7 @@ export interface TickAccumulator {
   capex: number;
   opex: number;
   maintenance: number;
+  payroll: number;
   utilities: UtilityCostBreakdown;
   maintenanceDetails: MaintenanceExpenseRecord[];
 }
@@ -86,6 +87,7 @@ const DEFAULT_DESCRIPTION = {
   utilities: 'Utility consumption',
   maintenance: 'Device maintenance',
   devicePurchase: 'Device purchase',
+  payroll: 'Employee payroll',
 };
 
 export class CostAccountingService {
@@ -102,6 +104,7 @@ export class CostAccountingService {
       capex: 0,
       opex: 0,
       maintenance: 0,
+      payroll: 0,
       utilities: createEmptyUtilityBreakdown(),
       maintenanceDetails: [],
     };
@@ -197,6 +200,47 @@ export class CostAccountingService {
     return record;
   }
 
+  applyPayroll(
+    state: GameState,
+    tick: number,
+    timestamp: string,
+    accumulator: TickAccumulator,
+    events: EventCollector,
+  ): number | undefined {
+    const employees = state.personnel.employees ?? [];
+    if (employees.length === 0) {
+      return undefined;
+    }
+
+    const totalPayroll = employees.reduce((sum, employee) => {
+      const salary = Number.isFinite(employee.salaryPerTick) ? employee.salaryPerTick : 0;
+      return sum + Math.max(0, salary);
+    }, 0);
+
+    if (totalPayroll <= MULTIPLIER_TOLERANCE) {
+      return undefined;
+    }
+
+    this.recordExpense(
+      state,
+      totalPayroll,
+      'payroll',
+      DEFAULT_DESCRIPTION.payroll,
+      tick,
+      timestamp,
+      accumulator,
+      events,
+      'opex',
+      {
+        employeeCount: employees.length,
+        payroll: totalPayroll,
+        averageSalaryPerTick: employees.length > 0 ? totalPayroll / employees.length : 0,
+      },
+    );
+
+    return totalPayroll;
+  }
+
   recordDevicePurchase(
     state: GameState,
     blueprintId: string,
@@ -259,6 +303,7 @@ export class CostAccountingService {
     summary.totalRevenue += accumulator.revenue;
     summary.totalExpenses += accumulator.expenses;
     summary.totalMaintenance += accumulator.maintenance;
+    summary.totalPayroll += accumulator.payroll;
     summary.lastTickRevenue = accumulator.revenue;
     summary.lastTickExpenses = accumulator.expenses;
     summary.netIncome = summary.totalRevenue - summary.totalExpenses;
@@ -275,6 +320,7 @@ export class CostAccountingService {
         opex: accumulator.opex,
         utilities: accumulator.utilities,
         maintenance: accumulator.maintenanceDetails,
+        payroll: accumulator.payroll,
       },
       tick,
       'info',
@@ -467,6 +513,7 @@ export class CostAccountingService {
 
     accumulator.expenses += amount;
     accumulator.maintenance += category === 'maintenance' ? amount : 0;
+    accumulator.payroll += category === 'payroll' ? amount : 0;
     if (detailKind === 'capex') {
       accumulator.capex += amount;
     } else {

--- a/src/backend/src/sim/loop.ts
+++ b/src/backend/src/sim/loop.ts
@@ -458,6 +458,14 @@ export class SimulationLoop {
       );
     }
 
+    this.costAccountingService.applyPayroll(
+      context.state,
+      context.tick,
+      timestamp,
+      runtime.accumulator,
+      context.events,
+    );
+
     this.costAccountingService.finalizeTick(
       context.state,
       runtime.accumulator,


### PR DESCRIPTION
## Summary
- track payroll totals in the cost accounting accumulator and summary, and add an `applyPayroll` helper that deducts salaries while emitting payroll opex events
- invoke payroll processing from the simulation loop accounting phase so each tick records payroll before finalization
- cover payroll cash flow with new unit and integration tests that assert ledger entries, summary totals, and emitted events

## Testing
- pnpm --filter @weebbreed/backend exec vitest run costAccounting
- pnpm --filter @weebbreed/backend exec vitest run loop.accounting


------
https://chatgpt.com/codex/tasks/task_e_68d0f1f2ad848325b8b238f4ad70d865