### PR TITLE
chore: update data validation workflow to node 23

### DIFF
--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 23
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- update the data validation workflow to install Node.js 23 while retaining pnpm caching configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11655fea88325b80bc368277760b1