### PR TITLE
Add audit and lint jobs to data validation workflow

### DIFF
--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -11,23 +11,51 @@ jobs:
     name: Validate blueprint data
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - &checkout
+        name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - &setup-pnpm
+        name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
           version: 10.17.0
 
-      - name: Setup Node.js
+      - &setup-node
+        name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 23
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install dependencies
+      - &install
+        name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Validate blueprint data
         run: pnpm validate:data
+
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *setup-pnpm
+      - *setup-node
+      - *install
+
+      - name: Run security audit
+        run: pnpm audit:run
+
+  lint:
+    name: Lint workspace
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *setup-pnpm
+      - *setup-node
+      - *install
+
+      - name: Run lint checks
+        run: pnpm lint

--- a/docs/addendum/data-validation.md
+++ b/docs/addendum/data-validation.md
@@ -42,6 +42,12 @@ appear as untracked changes.
 
 ## Continuous Integration
 
-The `Data Validation` workflow (`.github/workflows/data-validation.yml`) executes
-`pnpm validate:data` on every push and pull request. This ensures blueprint
-changes are validated alongside application code before merging.
+The `Data Validation` workflow (`.github/workflows/data-validation.yml`) now
+executes three independent jobs on every push and pull request:
+
+- `pnpm validate:data` to gate blueprint updates.
+- `pnpm audit:run` to surface dependency vulnerabilities via the audit runner.
+- `pnpm lint` to keep workspace lint rules enforced in the same gate.
+
+Each job installs dependencies with the pinned pnpm and Node.js versions so a
+failure in any command marks the workflow as failed.


### PR DESCRIPTION
## Summary
- extend the Data Validation workflow with dedicated audit and lint jobs that reuse the pnpm setup
- document the additional CI coverage in the data validation addendum

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d1171c33348325a8772aeec79b59d9