### PR TITLE
docs: add changelog and refresh ts toolchain adr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Introduced the changelog to capture noteworthy changes for upcoming releases.
+
+### Changed
+- Updated ADR 0001 to reflect the accepted CommonJS-first TypeScript toolchain decision and documentation touchpoints.
+

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ workspace documentation. Start with the product vision and system references in
 [`docs/vision_scope.md`](docs/vision_scope.md), the data dictionary in
 [`docs/DD.md`](docs/DD.md), and additional deep dives under `docs/system/`.
 
+### Project History & Decisions
+
+- Track notable workspace changes in [`CHANGELOG.md`](CHANGELOG.md) following the
+  Keep a Changelog convention with Semantic Versioning.
+- Accepted architecture decisions are recorded in `docs/system/adr/`. The
+  TypeScript toolchain direction lives in
+  [`docs/system/adr/0001-typescript-toolchain.md`](docs/system/adr/0001-typescript-toolchain.md).
+
 ## Continuous Verification
 
 Our automation pipeline keeps data, security, and code quality aligned with the
@@ -47,7 +55,8 @@ Our automation pipeline keeps data, security, and code quality aligned with the
    - `pnpm lint`
 
 Refer to the docs for simulation tuning, schema updates, and naming conventions
-before changing blueprints or code.
+before changing blueprints or code. Review the changelog and ADRs when planning
+tooling or architecture updates to stay aligned with previous decisions.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add an initial Keep a Changelog file to capture upcoming release notes
- refresh ADR 0001 to lock in the CommonJS-first TypeScript toolchain decision and doc references
- link the changelog and ADR hub from the workspace README for easier discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d11a4dafe08325b717a7ec480fb96f