### PR TITLE
refactor: use path aliases for shared modules

### DIFF
--- a/src/backend/src/bench.ts
+++ b/src/backend/src/bench.ts
@@ -12,7 +12,7 @@ import type { SimulationPhaseContext } from './sim/loop.js';
 import { createPhenologyConfig } from './engine/plants/phenology.js';
 import type { PhenologyState } from './engine/plants/phenology.js';
 import { updatePlantGrowth } from './engine/plants/growthModel.js';
-import { createBlueprintRepositoryStub, createStateFactoryContext } from './testing/fixtures.js';
+import { createBlueprintRepositoryStub, createStateFactoryContext } from '@/testing/fixtures.js';
 import { logger } from '@runtime/logger.js';
 
 const benchLogger = logger.child({ component: 'bench' });

--- a/src/backend/src/engine/environment/deviceDegradation.test.ts
+++ b/src/backend/src/engine/environment/deviceDegradation.test.ts
@@ -8,7 +8,7 @@ import type {
   ZoneResourceState,
 } from '@/state/models.js';
 import { resolveRoomPurposeId } from '../roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 
 const LAMBDA = 1e-5;

--- a/src/backend/src/engine/environment/zoneEnvironment.test.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { ZoneEnvironmentService } from './zoneEnvironment.js';
 import { resolveRoomPurposeId } from '../roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type {
   DeviceInstanceState,

--- a/src/backend/src/engine/environment/zoneEnvironment.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.ts
@@ -6,10 +6,10 @@ import {
 } from './climateController.js';
 import type { GameState, RoomState, StructureState, ZoneState } from '@/state/models.js';
 import type { SimulationPhaseContext } from '@/sim/loop.js';
-import { approachTemperature } from '../../../../physio/temp.js';
-import { approachRelativeHumidity } from '../../../../physio/rh.js';
-import { approachCo2 } from '../../../../physio/co2.js';
-import { computeVpd } from '../../../../physio/vpd.js';
+import { approachTemperature } from '@/physio/temp.js';
+import { approachRelativeHumidity } from '@/physio/rh.js';
+import { approachCo2 } from '@/physio/co2.js';
+import { computeVpd } from '@/physio/vpd.js';
 import { getZoneGeometry, type ZoneGeometry } from '@/state/geometry.js';
 
 export interface AmbientEnvironment {

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -3,7 +3,7 @@ import { PlantHealthEngine } from './healthEngine.js';
 import type { DiseaseBalancingConfig, PestBalancingConfig, TreatmentOption } from './models.js';
 import { createEventCollector, type SimulationEvent } from '@/lib/eventBus.js';
 import { resolveRoomPurposeId } from '../roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type {
   DiseaseState,

--- a/src/backend/src/engine/physio/__tests__/formulas.test.ts
+++ b/src/backend/src/engine/physio/__tests__/formulas.test.ts
@@ -3,12 +3,12 @@ import {
   actualVaporPressure,
   saturationVaporPressure,
   vaporPressureDeficit,
-} from '../../../../../physio/vpd.js';
-import { lightSaturationResponse, ppfdToMoles } from '../../../../../physio/ppfd.js';
-import { approachTemperature } from '../../../../../physio/temp.js';
-import { approachRelativeHumidity } from '../../../../../physio/rh.js';
-import { approachCo2, co2HalfSaturationResponse } from '../../../../../physio/co2.js';
-import { estimateTranspirationLiters } from '../../../../../physio/transpiration.js';
+} from '@/physio/vpd.js';
+import { lightSaturationResponse, ppfdToMoles } from '@/physio/ppfd.js';
+import { approachTemperature } from '@/physio/temp.js';
+import { approachRelativeHumidity } from '@/physio/rh.js';
+import { approachCo2, co2HalfSaturationResponse } from '@/physio/co2.js';
+import { estimateTranspirationLiters } from '@/physio/transpiration.js';
 
 const EPSILON = 1e-6;
 

--- a/src/backend/src/engine/plants/growthModel.ts
+++ b/src/backend/src/engine/plants/growthModel.ts
@@ -14,11 +14,11 @@ import {
   type ResourceDemandResult,
   type ResourceSupply,
 } from './resourceDemand.js';
-import { lightSaturationResponse, ppfdToMoles } from '../../../../physio/ppfd.js';
-import { gaussianResponse } from '../../../../physio/temp.js';
-import { co2HalfSaturationResponse } from '../../../../physio/co2.js';
-import { vaporPressureDeficit } from '../../../../physio/vpd.js';
-import { estimateTranspirationLiters } from '../../../../physio/transpiration.js';
+import { lightSaturationResponse, ppfdToMoles } from '@/physio/ppfd.js';
+import { gaussianResponse } from '@/physio/temp.js';
+import { co2HalfSaturationResponse } from '@/physio/co2.js';
+import { vaporPressureDeficit } from '@/physio/vpd.js';
+import { estimateTranspirationLiters } from '@/physio/transpiration.js';
 
 const clamp = (value: number, min: number, max: number): number => {
   return Math.min(Math.max(value, min), max);

--- a/src/backend/src/engine/roomPurposes.test.ts
+++ b/src/backend/src/engine/roomPurposes.test.ts
@@ -6,7 +6,7 @@ import {
   resolveRoomPurposeId,
 } from './roomPurposes/index.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
-import { loadTestRoomPurposes } from '../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 
 let repository: BlueprintRepository;
 

--- a/src/backend/src/engine/workforce/workforceEngine.test.ts
+++ b/src/backend/src/engine/workforce/workforceEngine.test.ts
@@ -13,7 +13,7 @@ import type {
 import { addDeviceToZone } from '@/state/devices.js';
 import { WorkforceEngine } from './workforceEngine.js';
 import { resolveRoomPurposeId } from '../roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 
 let growRoomPurposeId: string;

--- a/src/backend/src/engine/workforce/workforceIntegration.test.ts
+++ b/src/backend/src/engine/workforce/workforceIntegration.test.ts
@@ -10,7 +10,7 @@ import type {
 } from '@/state/models.js';
 import { WorkforceEngine } from './workforceEngine.js';
 import { resolveRoomPurposeId } from '../roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 
 let growRoomPurposeId: string;

--- a/src/backend/src/persistence/schemas.test.ts
+++ b/src/backend/src/persistence/schemas.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SAVEGAME_KIND, saveGameEnvelopeSchema } from './schemas.js';
 import { createInitialState } from '../stateFactory.js';
-import { createStateFactoryContext } from '../testing/fixtures.js';
+import { createStateFactoryContext } from '@/testing/fixtures.js';
 
 describe('saveGameEnvelopeSchema', () => {
   it('accepts a well-formed save game envelope', async () => {

--- a/src/backend/src/sim/integrationScenarios.test.ts
+++ b/src/backend/src/sim/integrationScenarios.test.ts
@@ -12,7 +12,7 @@ import {
   createStrainBlueprint,
   createStrainPriceMap,
   createStructureBlueprint,
-} from '../testing/fixtures.js';
+} from '@/testing/fixtures.js';
 import { createPhenologyConfig } from '@/engine/plants/phenology.js';
 import type { PhenologyState } from '@/engine/plants/phenology.js';
 import { updatePlantGrowth } from '@/engine/plants/growthModel.js';

--- a/src/backend/src/sim/loop.golden.test.ts
+++ b/src/backend/src/sim/loop.golden.test.ts
@@ -14,7 +14,7 @@ import {
   createStateFactoryContext,
   createStrainBlueprint,
   createStrainPriceMap,
-} from '../testing/fixtures.js';
+} from '@/testing/fixtures.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type { GameState, ZoneState } from '@/state/models.js';
 import { createPhenologyConfig } from '@/engine/plants/phenology.js';

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { EventBus } from '@/lib/eventBus.js';
 import { resolveRoomPurposeId } from '@/engine/roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type {
   DeviceInstanceState,

--- a/src/backend/src/state/initialization/blueprints.test.ts
+++ b/src/backend/src/state/initialization/blueprints.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { createDeviceBlueprint, createStructureBlueprint } from '../../testing/fixtures.js';
+import { createDeviceBlueprint, createStructureBlueprint } from '@/testing/fixtures.js';
 import { RngService, RNG_STREAM_IDS } from '@/lib/rng.js';
 import {
   chooseDeviceBlueprints,

--- a/src/backend/src/state/initialization/finance.test.ts
+++ b/src/backend/src/state/initialization/finance.test.ts
@@ -3,7 +3,7 @@ import {
   createBlueprintRepositoryStub,
   createDeviceBlueprint,
   createStructureBlueprint,
-} from '../../testing/fixtures.js';
+} from '@/testing/fixtures.js';
 import type { EconomicsSettings } from '../models.js';
 import { RngService, RNG_STREAM_IDS } from '@/lib/rng.js';
 import { createFinanceState } from './finance.js';

--- a/src/backend/src/state/initialization/tasks.test.ts
+++ b/src/backend/src/state/initialization/tasks.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { RngService, RNG_STREAM_IDS } from '@/lib/rng.js';
 import { resolveRoomPurposeId } from '@/engine/roomPurposes/index.js';
-import { loadTestRoomPurposes } from '../../testing/loadTestRoomPurposes.js';
+import { loadTestRoomPurposes } from '@/testing/loadTestRoomPurposes.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type {
   StructureState,

--- a/src/backend/src/stateFactory.test.ts
+++ b/src/backend/src/stateFactory.test.ts
@@ -10,7 +10,7 @@ import {
   createStrainBlueprint,
   createStrainPriceMap,
   createStructureBlueprint,
-} from './testing/fixtures.js';
+} from '@/testing/fixtures.js';
 import * as blueprintModule from './state/initialization/blueprints.js';
 
 afterEach(() => {

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
+      "@/physio/*": ["../physio/*"],
       "@/*": ["src/*"],
       "@runtime/*": ["../runtime/*"]
     },

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -13,11 +13,27 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-      '@runtime': path.resolve(__dirname, '../runtime'),
-      rxjs: path.resolve(__dirname, 'node_modules/rxjs'),
-      pino: path.resolve(__dirname, 'src/testing/pinoStub.ts'),
-    },
+    alias: [
+      {
+        find: '@/physio',
+        replacement: path.resolve(__dirname, '../physio'),
+      },
+      {
+        find: '@',
+        replacement: path.resolve(__dirname, 'src'),
+      },
+      {
+        find: '@runtime',
+        replacement: path.resolve(__dirname, '../runtime'),
+      },
+      {
+        find: 'rxjs',
+        replacement: path.resolve(__dirname, 'node_modules/rxjs'),
+      },
+      {
+        find: 'pino',
+        replacement: path.resolve(__dirname, 'src/testing/pinoStub.ts'),
+      },
+    ],
   },
 });

--- a/src/frontend/src/components/EventLog.tsx
+++ b/src/frontend/src/components/EventLog.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
 import { useAppStore } from '../store';
-import type { SimulationEvent } from '../types/simulation';
+import type { SimulationEvent } from '@/types/simulation';
 import styles from './EventLog.module.css';
 
 const formatTimestamp = (timestamp?: number) => {

--- a/src/frontend/src/components/ModalRoot.tsx
+++ b/src/frontend/src/components/ModalRoot.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import type { ModalDescriptor } from '../store';
-import type { FacadeIntentCommand } from '../types/simulation';
+import type { FacadeIntentCommand } from '@/types/simulation';
 import styles from './ModalRoot.module.css';
 
 type SubmitHandler = (event: FormEvent<HTMLFormElement>) => void;

--- a/src/frontend/src/components/PersonnelView.tsx
+++ b/src/frontend/src/components/PersonnelView.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 import { useAppStore } from '../store';
-import type { SimulationEvent } from '../types/simulation';
+import type { SimulationEvent } from '@/types/simulation';
 import styles from './PersonnelView.module.css';
 
 const buildEventKey = (event: SimulationEvent, fallbackIndex: number) => {

--- a/src/frontend/src/components/WorldExplorer.tsx
+++ b/src/frontend/src/components/WorldExplorer.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
-import type { DeviceSnapshot, PlantSnapshot, ZoneSnapshot } from '../types/simulation';
+import type { DeviceSnapshot, PlantSnapshot, ZoneSnapshot } from '@/types/simulation';
 import { BreedingStationPlaceholder } from './world-explorer/BreedingStationPlaceholder';
 import { RoomGrid, type RoomSummary } from './world-explorer/RoomGrid';
 import { StructureGrid, type StructureSummary } from './world-explorer/StructureGrid';

--- a/src/frontend/src/components/world-explorer/RoomGrid.test.tsx
+++ b/src/frontend/src/components/world-explorer/RoomGrid.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { RoomSnapshot } from '../../types/simulation';
+import type { RoomSnapshot } from '@/types/simulation';
 import { RoomGrid, type RoomSummary } from './RoomGrid';
 
 vi.mock('react-i18next', () => ({

--- a/src/frontend/src/components/world-explorer/RoomGrid.tsx
+++ b/src/frontend/src/components/world-explorer/RoomGrid.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { RoomSnapshot } from '../../types/simulation';
+import type { RoomSnapshot } from '@/types/simulation';
 import styles from './HierarchyGrid.module.css';
 
 export interface RoomSummary {

--- a/src/frontend/src/components/world-explorer/StructureGrid.tsx
+++ b/src/frontend/src/components/world-explorer/StructureGrid.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { StructureSnapshot } from '../../types/simulation';
+import type { StructureSnapshot } from '@/types/simulation';
 import styles from './HierarchyGrid.module.css';
 
 export interface StructureSummary {
@@ -116,9 +116,10 @@ export const StructureGrid = ({
                     <span className={styles.cardSubtitle}>
                       {t('labels.structureFootprint', {
                         defaultValue: '{{value}} m² footprint',
-                        value: structure.footprint?.area?.toLocaleString(undefined, {
-                          maximumFractionDigits: 1,
-                        }) ?? '—',
+                        value:
+                          structure.footprint?.area?.toLocaleString(undefined, {
+                            maximumFractionDigits: 1,
+                          }) ?? '—',
                       })}
                     </span>
                   </div>
@@ -137,7 +138,13 @@ export const StructureGrid = ({
                       type="button"
                       className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                       onClick={() => {
-                        if (window.confirm(t('labels.confirmDeleteStructure', { defaultValue: 'Delete this structure?' }))) {
+                        if (
+                          window.confirm(
+                            t('labels.confirmDeleteStructure', {
+                              defaultValue: 'Delete this structure?',
+                            }),
+                          )
+                        ) {
                           onDelete(structure.id);
                         }
                       }}

--- a/src/frontend/src/components/world-explorer/ZoneDetailView.tsx
+++ b/src/frontend/src/components/world-explorer/ZoneDetailView.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { DeviceSnapshot, PlantSnapshot, PlantingGroupSnapshot, ZoneSnapshot } from '../../types/simulation';
+import type {
+  DeviceSnapshot,
+  PlantSnapshot,
+  PlantingGroupSnapshot,
+  ZoneSnapshot,
+} from '@/types/simulation';
 import styles from './ZoneDetailView.module.css';
 
 interface DerivedPlantGroup {
@@ -60,10 +65,7 @@ const resolveGroupStatus = (devices: DeviceSnapshot[]): 'on' | 'off' | 'mixed' |
   return 'mixed';
 };
 
-const toDeviceGroups = (
-  zone: ZoneSnapshot,
-  devices: DeviceSnapshot[],
-): DeviceGroupModel[] => {
+const toDeviceGroups = (zone: ZoneSnapshot, devices: DeviceSnapshot[]): DeviceGroupModel[] => {
   if (Array.isArray(zone.deviceGroups) && zone.deviceGroups.length) {
     const byId = new Map(devices.map((device) => [device.id, device] as const));
     return zone.deviceGroups.map((group) => {
@@ -117,7 +119,9 @@ const toDerivedPlantGroups = (
       const resolvedPlants = groupPlants.length ? groupPlants : fallback;
       return {
         id: group.id,
-        name: group.name ?? t('labels.strainName', { defaultValue: 'Strain {{id}}', id: group.strainId }),
+        name:
+          group.name ??
+          t('labels.strainName', { defaultValue: 'Strain {{id}}', id: group.strainId }),
         strainId: group.strainId,
         stage: group.stage,
         plants: resolvedPlants,
@@ -218,7 +222,8 @@ export const ZoneDetailView = ({
     setExpandedGroups([]);
   }, [zone.id, zone.name]);
 
-  const lightingCoverage = zone.lighting?.coverageRatio ?? zone.environment.ppfd / (ENVIRONMENT_RANGES.ppfd.max || 900);
+  const lightingCoverage =
+    zone.lighting?.coverageRatio ?? zone.environment.ppfd / (ENVIRONMENT_RANGES.ppfd.max || 900);
   const lightingClass = lightingCoverage >= 1 ? styles.lightingOk : styles.lightingInsufficient;
 
   const commitRename = () => {
@@ -326,7 +331,11 @@ export const ZoneDetailView = ({
                 type="button"
                 className={`${styles.zoneAction} ${styles.zoneActionDanger}`}
                 onClick={() => {
-                  if (window.confirm(t('labels.confirmDeleteZone', { defaultValue: 'Delete this zone?' }))) {
+                  if (
+                    window.confirm(
+                      t('labels.confirmDeleteZone', { defaultValue: 'Delete this zone?' }),
+                    )
+                  ) {
                     onDelete();
                   }
                 }}
@@ -364,19 +373,27 @@ export const ZoneDetailView = ({
             <div className={styles.metricGrid}>
               <div className={styles.metricRow}>
                 <span>{t('labels.water')}</span>
-                <span className={styles.metricValue}>{zone.resources.waterLiters.toFixed(1)} L</span>
+                <span className={styles.metricValue}>
+                  {zone.resources.waterLiters.toFixed(1)} L
+                </span>
               </div>
               <div className={styles.metricRow}>
                 <span>{t('labels.nutrientSolution')}</span>
-                <span className={styles.metricValue}>{zone.resources.nutrientSolutionLiters.toFixed(1)} L</span>
+                <span className={styles.metricValue}>
+                  {zone.resources.nutrientSolutionLiters.toFixed(1)} L
+                </span>
               </div>
               <div className={styles.metricRow}>
                 <span>{t('labels.nutrientStrength')}</span>
-                <span className={styles.metricValue}>{zone.resources.nutrientStrength.toFixed(2)}</span>
+                <span className={styles.metricValue}>
+                  {zone.resources.nutrientStrength.toFixed(2)}
+                </span>
               </div>
               <div className={styles.metricRow}>
                 <span>{t('labels.substrateHealth')}</span>
-                <span className={styles.metricValue}>{(zone.resources.substrateHealth * 100).toFixed(1)}%</span>
+                <span className={styles.metricValue}>
+                  {(zone.resources.substrateHealth * 100).toFixed(1)}%
+                </span>
               </div>
             </div>
             <div className={styles.suppliesFooter}>
@@ -482,9 +499,14 @@ export const ZoneDetailView = ({
           <section className={styles.card}>
             <header className={styles.cardHeader}>
               <div>
-                <h4 className={styles.cardTitle}>{t('labels.plantingGroups', { defaultValue: 'Planting groups' })}</h4>
+                <h4 className={styles.cardTitle}>
+                  {t('labels.plantingGroups', { defaultValue: 'Planting groups' })}
+                </h4>
                 <p className={styles.cardSubtitle}>
-                  {t('labels.groupCount', { defaultValue: '{{count}} groups', count: plantGroups.length })}
+                  {t('labels.groupCount', {
+                    defaultValue: '{{count}} groups',
+                    count: plantGroups.length,
+                  })}
                 </p>
               </div>
               <button type="button" className={styles.harvestButton} onClick={handleHarvestAll}>
@@ -548,15 +570,16 @@ export const ZoneDetailView = ({
                           {group.plants.map((plant) => (
                             <div key={plant.id} className={styles.plantRow}>
                               <span>
-                                {plant.id}{' '}
-                                {plant.stage ? `• ${plant.stage}` : ''}
+                                {plant.id} {plant.stage ? `• ${plant.stage}` : ''}
                               </span>
                               <div className={styles.plantActions}>
                                 <button
                                   type="button"
                                   className={styles.zoneAction}
                                   onClick={() => onHarvestPlant(plant.id)}
-                                  aria-label={t('labels.harvestPlant', { defaultValue: 'Harvest plant' })}
+                                  aria-label={t('labels.harvestPlant', {
+                                    defaultValue: 'Harvest plant',
+                                  })}
                                 >
                                   <span className="material-symbols-outlined" aria-hidden>
                                     content_cut
@@ -582,7 +605,9 @@ export const ZoneDetailView = ({
 
           <section className={styles.card}>
             <header className={styles.cardHeader}>
-              <h4 className={styles.cardTitle}>{t('labels.plantingPlan', { defaultValue: 'Planting plan' })}</h4>
+              <h4 className={styles.cardTitle}>
+                {t('labels.plantingPlan', { defaultValue: 'Planting plan' })}
+              </h4>
             </header>
             {zone.plantingPlan ? (
               <div className={styles.metricGrid}>
@@ -604,13 +629,21 @@ export const ZoneDetailView = ({
                   <span>{t('labels.autoReplantToggle', { defaultValue: 'Auto replant' })}</span>
                 </label>
                 <div className={styles.deviceActions}>
-                  <button type="button" className={styles.deviceActionButton} onClick={onOpenAutomationPlanModal}>
+                  <button
+                    type="button"
+                    className={styles.deviceActionButton}
+                    onClick={onOpenAutomationPlanModal}
+                  >
                     <span className="material-symbols-outlined" aria-hidden>
                       edit
                     </span>
                     {t('labels.editPlan', { defaultValue: 'Edit plan' })}
                   </button>
-                  <button type="button" className={styles.deviceActionButton} onClick={() => onTogglePlan(false)}>
+                  <button
+                    type="button"
+                    className={styles.deviceActionButton}
+                    onClick={() => onTogglePlan(false)}
+                  >
                     <span className="material-symbols-outlined" aria-hidden>
                       delete
                     </span>
@@ -620,8 +653,14 @@ export const ZoneDetailView = ({
               </div>
             ) : (
               <div className={styles.metricGrid}>
-                <p className={styles.emptyState}>{t('labels.noPlantingPlan', { defaultValue: 'No plan configured.' })}</p>
-                <button type="button" className={styles.planAction} onClick={onOpenAutomationPlanModal}>
+                <p className={styles.emptyState}>
+                  {t('labels.noPlantingPlan', { defaultValue: 'No plan configured.' })}
+                </p>
+                <button
+                  type="button"
+                  className={styles.planAction}
+                  onClick={onOpenAutomationPlanModal}
+                >
                   <span className="material-symbols-outlined" aria-hidden>
                     add_circle
                   </span>
@@ -634,9 +673,14 @@ export const ZoneDetailView = ({
           <section className={styles.card}>
             <header className={styles.cardHeader}>
               <div>
-                <h4 className={styles.cardTitle}>{t('labels.deviceGroups', { defaultValue: 'Device groups' })}</h4>
+                <h4 className={styles.cardTitle}>
+                  {t('labels.deviceGroups', { defaultValue: 'Device groups' })}
+                </h4>
                 <p className={styles.cardSubtitle}>
-                  {t('labels.deviceCount', { defaultValue: '{{count}} devices', count: devices.length })}
+                  {t('labels.deviceCount', {
+                    defaultValue: '{{count}} devices',
+                    count: devices.length,
+                  })}
                 </p>
               </div>
               <button type="button" className={styles.planAction} onClick={onOpenDeviceModal}>
@@ -672,7 +716,9 @@ export const ZoneDetailView = ({
                             type="button"
                             className={styles.zoneAction}
                             onClick={() => onToggleDeviceGroup(group.kind, !isEnabled)}
-                            title={t('tooltips.toggleDeviceGroup', { defaultValue: 'Toggle group power' })}
+                            title={t('tooltips.toggleDeviceGroup', {
+                              defaultValue: 'Toggle group power',
+                            })}
                           >
                             <span className="material-symbols-outlined" aria-hidden>
                               power_settings_new
@@ -690,7 +736,9 @@ export const ZoneDetailView = ({
                               </span>
                             </button>
                           ) : null}
-                          {onScheduleDeviceGroup && (group.supportsScheduling || group.kind.toLowerCase().includes('light')) ? (
+                          {onScheduleDeviceGroup &&
+                          (group.supportsScheduling ||
+                            group.kind.toLowerCase().includes('light')) ? (
                             <button
                               type="button"
                               className={styles.zoneAction}

--- a/src/frontend/src/components/world-explorer/ZoneGrid.tsx
+++ b/src/frontend/src/components/world-explorer/ZoneGrid.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { ZoneSnapshot, PlantSnapshot } from '../../types/simulation';
+import type { ZoneSnapshot, PlantSnapshot } from '@/types/simulation';
 import styles from './HierarchyGrid.module.css';
 
 export interface ZoneSummary {
@@ -102,7 +102,10 @@ export const ZoneGrid = ({
             const isActive = selectedZoneId === zone.id;
             const harvestable = harvestReadyCount(plants);
             return (
-              <article key={zone.id} className={`${styles.card} ${isActive ? styles.cardActive : ''}`.trim()}>
+              <article
+                key={zone.id}
+                className={`${styles.card} ${isActive ? styles.cardActive : ''}`.trim()}
+              >
                 <header className={styles.cardHeader}>
                   <div className={styles.cardTitleGroup}>
                     {isEditing ? (
@@ -137,7 +140,9 @@ export const ZoneGrid = ({
                       <span>
                         {t('labels.zoneMethod', {
                           defaultValue: 'Method: {{value}}',
-                          value: zone.cultivationMethodId ?? t('labels.unknown', { defaultValue: 'Unknown' }),
+                          value:
+                            zone.cultivationMethodId ??
+                            t('labels.unknown', { defaultValue: 'Unknown' }),
                         })}
                       </span>
                     </span>
@@ -168,7 +173,11 @@ export const ZoneGrid = ({
                       type="button"
                       className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                       onClick={() => {
-                        if (window.confirm(t('labels.confirmDeleteZone', { defaultValue: 'Delete this zone?' }))) {
+                        if (
+                          window.confirm(
+                            t('labels.confirmDeleteZone', { defaultValue: 'Delete this zone?' }),
+                          )
+                        ) {
                           onDelete(zone.id);
                         }
                       }}
@@ -191,7 +200,9 @@ export const ZoneGrid = ({
                   </div>
                   <div className={styles.metricRow}>
                     <dt>{t('labels.ppfd')}</dt>
-                    <dd className={styles.metricValue}>{zone.environment.ppfd.toFixed(0)} µmol·m⁻²·s⁻¹</dd>
+                    <dd className={styles.metricValue}>
+                      {zone.environment.ppfd.toFixed(0)} µmol·m⁻²·s⁻¹
+                    </dd>
                   </div>
                 </dl>
               </article>

--- a/src/frontend/src/hooks/useSimulationBridge.ts
+++ b/src/frontend/src/hooks/useSimulationBridge.ts
@@ -8,7 +8,7 @@ import type {
   SimulationTickEvent,
   SimulationUpdateEntry,
   SimulationUpdateMessage,
-} from '../types/simulation';
+} from '@/types/simulation';
 import { useAppStore } from '../store';
 import type { ConnectionStatus } from '../store';
 import type { FinanceTickEntry } from '../store/types';

--- a/src/frontend/src/store/slices/simulationSlice.ts
+++ b/src/frontend/src/store/slices/simulationSlice.ts
@@ -9,7 +9,7 @@ import type {
   SimulationSnapshot,
   SimulationUpdateEntry,
   ZoneSnapshot,
-} from '../../types/simulation';
+} from '@/types/simulation';
 import type {
   AppStoreState,
   FinanceTickEntry,

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -4,6 +4,7 @@ import type {
   FinanceSummarySnapshot,
   PlantSnapshot,
   PersonnelSnapshot,
+  RoomSnapshot,
   SimulationConfigUpdate,
   SimulationControlCommand,
   SimulationEvent,
@@ -12,9 +13,8 @@ import type {
   SimulationTimeStatus,
   SimulationUpdateEntry,
   StructureSnapshot,
-  RoomSnapshot,
   ZoneSnapshot,
-} from '../types/simulation';
+} from '@/types/simulation';
 
 export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
 


### PR DESCRIPTION
## Summary
- add a backend `@/physio` alias and update Vitest resolution so simulation code can load shared physio utilities without deep relative paths
- switch backend modules and tests to import physio helpers and testing fixtures via `@/physio/*` and `@/testing/*`
- update frontend store and world explorer components to consume simulation types through the `@/types/simulation` alias

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck *(fails: backend package already contains numerous strict type errors surfaced by tsc)*

------
https://chatgpt.com/codex/tasks/task_e_68d12142b0b0832589e29ce755a36d66