### PR TITLE
Run pnpm check in data validation workflow

### DIFF
--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  validate:
-    name: Validate blueprint data
+  quality-gate:
+    name: Run pnpm check
     runs-on: ubuntu-latest
     steps:
       - &checkout
@@ -33,8 +33,8 @@ jobs:
         name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Validate blueprint data
-        run: pnpm validate:data
+      - name: Run aggregated quality checks
+        run: pnpm check
 
   audit:
     name: Audit dependencies
@@ -48,14 +48,3 @@ jobs:
       - name: Run security audit
         run: pnpm audit:run
 
-  lint:
-    name: Lint workspace
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *setup-pnpm
-      - *setup-node
-      - *install
-
-      - name: Run lint checks
-        run: pnpm lint


### PR DESCRIPTION
## Summary
- run the aggregated `pnpm check` script in the data validation workflow to cover lint, format, tests, and schema validation
- drop the redundant lint job while keeping the dependency audit job intact

## Testing
- pnpm check *(fails: existing backend typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d12e7dfa708325a48fe95495879464