### PR TITLE
refactor(frontend): use path aliases for shared modules

### DIFF
--- a/src/frontend/src/components/Dashboard.tsx
+++ b/src/frontend/src/components/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SimulationBridgeHandle } from '../hooks/useSimulationBridge';
-import { useAppStore } from '../store';
-import type { NavigationView } from '../store';
+import type { SimulationBridgeHandle } from '@/hooks/useSimulationBridge';
+import { useAppStore } from '@/store';
+import type { NavigationView } from '@/store';
 import {
   selectAlertCount,
   selectCapital,
@@ -13,8 +13,8 @@ import {
   selectLastTickEvent,
   selectRecentEvents,
   selectTargetTickRate,
-} from '../store/selectors';
-import { formatInGameTime } from '../store/utils/time';
+} from '@/store/selectors';
+import { formatInGameTime } from '@/store/utils/time';
 import styles from './Dashboard.module.css';
 
 const SPEED_OPTIONS = [0.5, 1, 2, 5, 10];

--- a/src/frontend/src/components/EventLog.tsx
+++ b/src/frontend/src/components/EventLog.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import type { SimulationEvent } from '@/types/simulation';
 import styles from './EventLog.module.css';
 

--- a/src/frontend/src/components/FinanceView.tsx
+++ b/src/frontend/src/components/FinanceView.tsx
@@ -11,7 +11,7 @@ import {
   Area,
   AreaChart,
 } from 'recharts';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import styles from './FinanceView.module.css';
 
 export const FinanceView = () => {

--- a/src/frontend/src/components/ModalRoot.tsx
+++ b/src/frontend/src/components/ModalRoot.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../store';
-import type { ModalDescriptor } from '../store';
+import { useAppStore } from '@/store';
+import type { ModalDescriptor } from '@/store';
 import type { FacadeIntentCommand } from '@/types/simulation';
 import styles from './ModalRoot.module.css';
 

--- a/src/frontend/src/components/NavigationTabs.tsx
+++ b/src/frontend/src/components/NavigationTabs.tsx
@@ -1,11 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../store';
-import {
-  selectSelectedRoom,
-  selectSelectedStructure,
-  selectSelectedZone,
-} from '../store/selectors';
+import { useAppStore } from '@/store';
+import { selectSelectedRoom, selectSelectedStructure, selectSelectedZone } from '@/store/selectors';
 import styles from './NavigationTabs.module.css';
 
 interface BreadcrumbSegment {

--- a/src/frontend/src/components/PersonnelView.tsx
+++ b/src/frontend/src/components/PersonnelView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import type { SimulationEvent } from '@/types/simulation';
 import styles from './PersonnelView.module.css';
 

--- a/src/frontend/src/components/SimulationControls.tsx
+++ b/src/frontend/src/components/SimulationControls.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SimulationBridgeHandle } from '../hooks/useSimulationBridge';
-import { useAppStore } from '../store';
+import type { SimulationBridgeHandle } from '@/hooks/useSimulationBridge';
+import { useAppStore } from '@/store';
 import styles from './SimulationControls.module.css';
 
 interface SimulationControlsProps {

--- a/src/frontend/src/components/SimulationOverview.tsx
+++ b/src/frontend/src/components/SimulationOverview.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import styles from './SimulationOverview.module.css';
 
 export const SimulationOverview = () => {

--- a/src/frontend/src/components/TelemetryCharts.tsx
+++ b/src/frontend/src/components/TelemetryCharts.tsx
@@ -10,9 +10,9 @@ import {
   YAxis,
 } from 'recharts';
 import { useTranslation } from 'react-i18next';
-import { useThrottledValue } from '../hooks/useThrottledValue';
-import { useAppStore } from '../store';
-import type { SimulationTimelineEntry } from '../store';
+import { useThrottledValue } from '@/hooks/useThrottledValue';
+import { useAppStore } from '@/store';
+import type { SimulationTimelineEntry } from '@/store';
 import styles from './TelemetryCharts.module.css';
 
 const MAX_POINTS = 120;

--- a/src/frontend/src/components/TelemetryTable.tsx
+++ b/src/frontend/src/components/TelemetryTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import styles from './TelemetryTable.module.css';
 
 interface TelemetryRow {

--- a/src/frontend/src/components/WorldExplorer.tsx
+++ b/src/frontend/src/components/WorldExplorer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../store';
+import { useAppStore } from '@/store';
 import type { DeviceSnapshot, PlantSnapshot, ZoneSnapshot } from '@/types/simulation';
 import { BreedingStationPlaceholder } from './world-explorer/BreedingStationPlaceholder';
 import { RoomGrid, type RoomSummary } from './world-explorer/RoomGrid';

--- a/src/frontend/src/hooks/useSimulationBridge.ts
+++ b/src/frontend/src/hooks/useSimulationBridge.ts
@@ -9,9 +9,9 @@ import type {
   SimulationUpdateEntry,
   SimulationUpdateMessage,
 } from '@/types/simulation';
-import { useAppStore } from '../store';
-import type { ConnectionStatus } from '../store';
-import type { FinanceTickEntry } from '../store/types';
+import { useAppStore } from '@/store';
+import type { ConnectionStatus } from '@/store';
+import type { FinanceTickEntry } from '@/store/types';
 
 type AnyHandler = (...args: unknown[]) => void;
 


### PR DESCRIPTION
## Summary
- replace relative store and hook imports in frontend components with the configured `@/` aliases to match the existing TypeScript path mapping

## Testing
- ESLINT_USE_FLAT_CONFIG=false pnpm --filter @weebbreed/frontend lint
- pnpm --filter @weebbreed/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d1308989308325880f01adecf47b97