### PR TITLE
Fix backend data loader imports to use type-only syntax

### DIFF
--- a/src/backend/src/data/blueprintRepository.ts
+++ b/src/backend/src/data/blueprintRepository.ts
@@ -1,12 +1,7 @@
 import path from 'path';
 import { watchData } from '@runtime/dataWatcher.js';
-import {
-  BlueprintData,
-  DataLoadResult,
-  DataLoadSummary,
-  DataLoaderError,
-  loadBlueprintData,
-} from './dataLoader.js';
+import { DataLoaderError, loadBlueprintData } from './dataLoader.js';
+import type { BlueprintData, DataLoadResult, DataLoadSummary } from './dataLoader.js';
 import type { DevicePriceEntry, StrainPriceEntry } from './schemas/index.js';
 
 export type HotReloadDisposition = 'commit' | 'defer';

--- a/src/backend/src/data/dataLoader.ts
+++ b/src/backend/src/data/dataLoader.ts
@@ -1,21 +1,24 @@
 import { promises as fs, Dirent } from 'fs';
 import path from 'path';
-import { ZodError, ZodType, ZodTypeDef } from 'zod';
+import { ZodError } from 'zod';
+import type { ZodType, ZodTypeDef } from 'zod';
 import {
-  StrainBlueprint,
   strainSchema,
-  DeviceBlueprint,
   deviceSchema,
-  CultivationMethodBlueprint,
   cultivationMethodSchema,
-  RoomPurposeBlueprint,
   roomPurposeSchema,
-  DevicePriceEntry,
   devicePricesSchema,
-  StrainPriceEntry,
   strainPricesSchema,
-  UtilityPrices,
   utilityPricesSchema,
+} from './schemas/index.js';
+import type {
+  StrainBlueprint,
+  DeviceBlueprint,
+  CultivationMethodBlueprint,
+  RoomPurposeBlueprint,
+  DevicePriceEntry,
+  StrainPriceEntry,
+  UtilityPrices,
 } from './schemas/index.js';
 
 export type IssueLevel = 'error' | 'warning';

--- a/src/backend/src/lib/eventBus.ts
+++ b/src/backend/src/lib/eventBus.ts
@@ -1,4 +1,5 @@
-import { Observable, OperatorFunction, Subject, bufferTime, filter as rxFilter, share } from 'rxjs';
+import { Observable, Subject, bufferTime, filter as rxFilter, share } from 'rxjs';
+import type { OperatorFunction } from 'rxjs';
 import type { Level } from 'pino';
 
 import { logger } from '@runtime/logger.js';


### PR DESCRIPTION
## Summary
- separate value and type imports in the data loader so only runtime schemas are brought in at execution time
- update the blueprint repository and event bus modules to rely on type-only imports for interfaces coming from dataLoader and rxjs
- ensure backend dev server starts without Zod type export SyntaxErrors

## Testing
- `pnpm --filter backend dev`

------
https://chatgpt.com/codex/tasks/task_e_68d133a80ad083259040b17d91a4fdd5