### PR TITLE
feat(frontend): scaffold dashboard components

### DIFF
--- a/src/frontend/src/components/Card.tsx
+++ b/src/frontend/src/components/Card.tsx
@@ -1,0 +1,62 @@
+import { HTMLAttributes, ReactNode } from 'react';
+
+type CardProps = {
+  title?: string;
+  subtitle?: string;
+  metadata?: Array<{ label: string; value: string }>;
+  footer?: ReactNode;
+  interactive?: boolean;
+  children?: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+const Card = ({
+  title,
+  subtitle,
+  metadata,
+  footer,
+  interactive = false,
+  children,
+  className,
+  ...rest
+}: CardProps) => {
+  const containerClass = [
+    'flex h-full flex-col gap-3 rounded-lg border border-border/50 bg-surfaceAlt/70 p-4 shadow-soft transition',
+    interactive
+      ? 'hover:-translate-y-0.5 hover:border-accent hover:shadow-strong focus-within:border-accent'
+      : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClass} {...rest}>
+      {(title || subtitle) && (
+        <header className="space-y-1">
+          {title ? <h3 className="text-lg font-semibold text-text-primary">{title}</h3> : null}
+          {subtitle ? <p className="text-sm text-text-secondary">{subtitle}</p> : null}
+        </header>
+      )}
+      {metadata && metadata.length > 0 ? (
+        <dl className="grid grid-cols-1 gap-3 text-xs text-text-muted sm:grid-cols-2">
+          {metadata.map((entry) => (
+            <div
+              key={entry.label}
+              className="space-y-1 rounded-md border border-border/40 bg-surfaceAlt/60 p-3"
+            >
+              <dt className="uppercase tracking-wide">{entry.label}</dt>
+              <dd className="text-sm font-medium text-text-primary">{entry.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      {children ? <div className="flex-1 text-sm text-text-secondary">{children}</div> : null}
+      {footer ? (
+        <footer className="border-t border-border/40 pt-3 text-sm text-text-muted">{footer}</footer>
+      ) : null}
+    </div>
+  );
+};
+
+export type { CardProps };
+export default Card;

--- a/src/frontend/src/components/DashboardControls.tsx
+++ b/src/frontend/src/components/DashboardControls.tsx
@@ -1,0 +1,159 @@
+import { ChangeEvent, ReactNode } from 'react';
+
+type SimulationRunState = 'running' | 'paused' | 'fastForward';
+
+type DashboardControlsProps = {
+  state: SimulationRunState;
+  onPlay: () => void;
+  onPause: () => void;
+  onStep: () => void;
+  onFastForward?: () => void;
+  tickLengthMinutes: number;
+  minTickLength?: number;
+  maxTickLength?: number;
+  onTickLengthChange?: (value: number) => void;
+  setpointControls?: ReactNode;
+  footer?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+};
+
+const stateLabel: Record<SimulationRunState, string> = {
+  running: 'Simulation running',
+  paused: 'Simulation paused',
+  fastForward: 'Fast forward active',
+};
+
+const DashboardControls = ({
+  state,
+  onPlay,
+  onPause,
+  onStep,
+  onFastForward,
+  tickLengthMinutes,
+  minTickLength = 1,
+  maxTickLength = 10,
+  onTickLengthChange,
+  setpointControls,
+  footer,
+  disabled = false,
+  className,
+}: DashboardControlsProps) => {
+  const containerClass = [
+    'space-y-6 rounded-lg border border-border/60 bg-surfaceAlt/80 p-6 shadow-soft',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleTickLengthChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!onTickLengthChange) {
+      return;
+    }
+
+    onTickLengthChange(Number(event.target.value));
+  };
+
+  const renderButton = (
+    label: string,
+    onClick: () => void,
+    options?: {
+      icon?: ReactNode;
+      intent?: 'primary' | 'secondary';
+      isActive?: boolean;
+      isDisabled?: boolean;
+    },
+  ) => {
+    const icon = options?.icon;
+    const intent = options?.intent ?? 'secondary';
+    const isActive = options?.isActive;
+    const isDisabled = disabled || options?.isDisabled;
+
+    const baseClass =
+      'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2';
+    const intentClass =
+      intent === 'primary'
+        ? 'border border-accent/70 bg-accent/90 text-surface shadow-strong hover:bg-accent focus-visible:outline-accent'
+        : 'border border-border/70 bg-surfaceAlt text-text-secondary hover:border-accent/60 hover:text-text-primary focus-visible:outline-accent';
+
+    const activeClass = isActive ? 'border-accent text-accent shadow-soft' : '';
+
+    return (
+      <button
+        type="button"
+        className={[baseClass, intentClass, activeClass].filter(Boolean).join(' ')}
+        onClick={onClick}
+        disabled={isDisabled}
+      >
+        {icon}
+        <span>{label}</span>
+      </button>
+    );
+  };
+
+  return (
+    <section className={containerClass} aria-label="Simulation controls">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-sm font-medium uppercase tracking-wide text-text-muted">
+            {stateLabel[state]}
+          </p>
+          <div className="flex flex-wrap gap-3">
+            {renderButton('Play', onPlay, {
+              icon: <span aria-hidden="true">▶</span>,
+              intent: 'primary',
+              isDisabled: state === 'running',
+            })}
+            {renderButton('Pause', onPause, {
+              icon: <span aria-hidden="true">⏸</span>,
+              isActive: state === 'paused',
+            })}
+            {renderButton('Step', onStep, {
+              icon: <span aria-hidden="true">⏭</span>,
+            })}
+            {onFastForward
+              ? renderButton('Fast forward', onFastForward, {
+                  icon: <span aria-hidden="true">⏩</span>,
+                  isActive: state === 'fastForward',
+                })
+              : null}
+          </div>
+        </div>
+        <div className="flex flex-1 flex-col gap-3">
+          <label className="flex flex-col gap-2 text-sm text-text-secondary">
+            <span className="font-medium text-text-primary">Tick length</span>
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={minTickLength}
+                max={maxTickLength}
+                step={1}
+                value={tickLengthMinutes}
+                onChange={handleTickLengthChange}
+                disabled={disabled || !onTickLengthChange}
+                className="h-2 w-full cursor-pointer appearance-none rounded-full bg-border/60 accent-accent/70"
+              />
+              <span className="w-20 text-right font-mono text-sm text-text-muted">
+                {tickLengthMinutes.toFixed(0)}m
+              </span>
+            </div>
+            <span className="text-xs text-text-muted">
+              {minTickLength}–{maxTickLength} minutes per simulation tick.
+            </span>
+          </label>
+        </div>
+      </div>
+      {setpointControls ? (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {setpointControls}
+        </div>
+      ) : null}
+      {footer ? (
+        <div className="border-t border-border/50 pt-4 text-sm text-text-muted">{footer}</div>
+      ) : null}
+    </section>
+  );
+};
+
+export type { DashboardControlsProps, SimulationRunState };
+export default DashboardControls;

--- a/src/frontend/src/components/DashboardHeader.tsx
+++ b/src/frontend/src/components/DashboardHeader.tsx
@@ -1,0 +1,105 @@
+import { ReactNode } from 'react';
+
+type DashboardHeaderStatusTone = 'default' | 'positive' | 'warning' | 'danger';
+
+type DashboardHeaderStatus = {
+  label: string;
+  tone?: DashboardHeaderStatusTone;
+  icon?: ReactNode;
+  tooltip?: string;
+};
+
+type HeaderMeta = {
+  label: string;
+  value: string;
+};
+
+type DashboardHeaderProps = {
+  title: string;
+  subtitle?: string;
+  status?: DashboardHeaderStatus;
+  actions?: ReactNode;
+  children?: ReactNode;
+  meta?: HeaderMeta[];
+  className?: string;
+};
+
+const toneClassName: Record<DashboardHeaderStatusTone, string> = {
+  default:
+    'border border-border/60 bg-surfaceAlt/70 text-text-secondary shadow-soft hover:border-border-strong',
+  positive: 'border border-positive/40 bg-positive/10 text-positive',
+  warning: 'border border-warning/40 bg-warning/10 text-warning',
+  danger: 'border border-danger/40 bg-danger/10 text-danger',
+};
+
+const DashboardHeader = ({
+  title,
+  subtitle,
+  status,
+  actions,
+  children,
+  meta,
+  className,
+}: DashboardHeaderProps) => {
+  const containerClass = [
+    'rounded-lg bg-surfaceElevated/80 px-6 py-6 shadow-soft backdrop-blur-md md:px-8',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <header className={containerClass}>
+      <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-2xl font-semibold tracking-tight text-text-primary md:text-3xl">
+              {title}
+            </h1>
+            {status ? (
+              <span
+                className={[
+                  'inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium transition-colors',
+                  toneClassName[status.tone ?? 'default'],
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                title={status.tooltip}
+              >
+                {status.icon}
+                <span>{status.label}</span>
+              </span>
+            ) : null}
+          </div>
+          {subtitle ? (
+            <p className="max-w-3xl text-base text-text-secondary md:text-lg">{subtitle}</p>
+          ) : null}
+          {meta && meta.length > 0 ? (
+            <dl className="grid grid-cols-1 gap-4 text-sm text-text-muted sm:grid-cols-2 lg:grid-cols-3">
+              {meta.map((entry) => (
+                <div
+                  key={entry.label}
+                  className="space-y-1 rounded-md border border-border/40 bg-surfaceAlt/50 p-3"
+                >
+                  <dt className="text-xs uppercase tracking-wide text-text-muted/80">
+                    {entry.label}
+                  </dt>
+                  <dd className="text-base font-medium text-text-primary">{entry.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+        </div>
+        {actions ? (
+          <div className="flex w-full items-center justify-start gap-3 md:w-auto md:justify-end">
+            {actions}
+          </div>
+        ) : null}
+      </div>
+      {children ? <div className="mt-6">{children}</div> : null}
+    </header>
+  );
+};
+
+export type { DashboardHeaderProps, DashboardHeaderStatus, DashboardHeaderStatusTone };
+export default DashboardHeader;

--- a/src/frontend/src/components/MetricsBar.tsx
+++ b/src/frontend/src/components/MetricsBar.tsx
@@ -1,0 +1,123 @@
+import { ReactNode } from 'react';
+
+type MetricTrend = 'up' | 'down' | 'steady';
+
+type MetricDefinition = {
+  id: string;
+  label: string;
+  value: number | string;
+  unit?: string;
+  change?: number | string;
+  changeLabel?: string;
+  trend?: MetricTrend;
+  hint?: string;
+  icon?: ReactNode;
+};
+
+type MetricsBarProps = {
+  metrics: MetricDefinition[];
+  onMetricClick?: (metric: MetricDefinition) => void;
+  layout?: 'comfortable' | 'compact';
+  className?: string;
+};
+
+const trendClassName: Record<MetricTrend, string> = {
+  up: 'text-positive',
+  down: 'text-danger',
+  steady: 'text-text-muted',
+};
+
+const MetricsBar = ({
+  metrics,
+  onMetricClick,
+  layout = 'comfortable',
+  className,
+}: MetricsBarProps) => {
+  const gridClassName = [
+    'grid grid-cols-1',
+    layout === 'compact'
+      ? 'gap-3 sm:grid-cols-2 xl:grid-cols-4'
+      : 'gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <section className={gridClassName}>
+      {metrics.map((metric) => {
+        const valueText =
+          typeof metric.value === 'number' ? metric.value.toLocaleString() : metric.value;
+        const changeText =
+          typeof metric.change === 'number'
+            ? `${metric.change > 0 ? '+' : ''}${metric.change.toFixed(2)}${metric.changeLabel ?? ''}`
+            : metric.change;
+        const showChange = changeText !== undefined && changeText !== null && changeText !== '';
+        const Component = onMetricClick ? 'button' : 'div';
+        const interactive = Boolean(onMetricClick);
+
+        return (
+          <Component
+            key={metric.id}
+            type={interactive ? 'button' : undefined}
+            onClick={interactive ? () => onMetricClick(metric) : undefined}
+            className={[
+              'group flex flex-col gap-2 rounded-lg border border-border/50 bg-surfaceAlt/60 p-4 text-left shadow-soft transition-all',
+              interactive
+                ? 'hover:-translate-y-0.5 hover:border-accent hover:shadow-strong focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
+                : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            title={metric.hint}
+          >
+            <div className="flex items-center justify-between gap-3 text-sm text-text-muted">
+              <span className="font-medium uppercase tracking-wide">{metric.label}</span>
+              {metric.icon ? (
+                <span className="text-lg text-text-secondary">{metric.icon}</span>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-baseline gap-2">
+              <span className="text-2xl font-semibold text-text-primary">{valueText}</span>
+              {metric.unit ? (
+                <span className="text-sm font-medium text-text-muted">{metric.unit}</span>
+              ) : null}
+            </div>
+            {showChange ? (
+              <div className="flex items-center gap-2 text-sm">
+                <span
+                  className={[
+                    'font-medium',
+                    metric.trend ? trendClassName[metric.trend] : 'text-text-secondary',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
+                  {changeText}
+                </span>
+                {metric.trend === 'up' ? (
+                  <span aria-hidden="true" className="text-positive">
+                    ▲
+                  </span>
+                ) : null}
+                {metric.trend === 'down' ? (
+                  <span aria-hidden="true" className="text-danger">
+                    ▼
+                  </span>
+                ) : null}
+                {metric.trend === 'steady' ? (
+                  <span aria-hidden="true" className="text-text-muted">
+                    ▬
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </Component>
+        );
+      })}
+    </section>
+  );
+};
+
+export type { MetricDefinition, MetricsBarProps, MetricTrend };
+export default MetricsBar;

--- a/src/frontend/src/components/Modal.tsx
+++ b/src/frontend/src/components/Modal.tsx
@@ -1,0 +1,130 @@
+import { ReactNode, useEffect } from 'react';
+
+type ModalAction = {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary' | 'danger';
+  disabled?: boolean;
+};
+
+type ModalProps = {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  onClose: () => void;
+  children?: ReactNode;
+  actions?: ModalAction[];
+  size?: 'sm' | 'md' | 'lg';
+  closeOnOverlay?: boolean;
+  className?: string;
+};
+
+const actionClassName: Record<NonNullable<ModalAction['variant']>, string> = {
+  primary:
+    'inline-flex items-center justify-center rounded-md border border-accent/80 bg-accent/90 px-4 py-2 text-sm font-medium text-surface shadow-strong transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+  secondary:
+    'inline-flex items-center justify-center rounded-md border border-border/60 bg-surfaceAlt px-4 py-2 text-sm font-medium text-text-secondary transition hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+  danger:
+    'inline-flex items-center justify-center rounded-md border border-danger/60 bg-danger/20 px-4 py-2 text-sm font-medium text-danger transition hover:bg-danger/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger',
+};
+
+const sizeClassName = {
+  sm: 'max-w-md',
+  md: 'max-w-2xl',
+  lg: 'max-w-4xl',
+};
+
+const Modal = ({
+  isOpen,
+  title,
+  description,
+  onClose,
+  children,
+  actions,
+  size = 'md',
+  closeOnOverlay = true,
+  className,
+}: ModalProps) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const dialogClass = [
+    'relative z-10 w-full rounded-lg border border-border/40 bg-surfaceElevated p-6 text-text-secondary shadow-strong backdrop-blur-lg',
+    sizeClassName[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleOverlayClick = () => {
+    if (closeOnOverlay) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-6">
+      <div
+        className="absolute inset-0 bg-overlay"
+        aria-hidden="true"
+        onClick={handleOverlayClick}
+      />
+      <div role="dialog" aria-modal="true" aria-labelledby="modal-title" className={dialogClass}>
+        <header className="mb-4 flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h2 id="modal-title" className="text-xl font-semibold text-text-primary">
+              {title}
+            </h2>
+            {description ? <p className="text-sm text-text-secondary">{description}</p> : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/40 text-lg text-text-muted transition hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            aria-label="Close dialog"
+          >
+            ×
+          </button>
+        </header>
+        <div className="space-y-4 text-sm text-text-secondary">{children}</div>
+        {actions && actions.length > 0 ? (
+          <div className="mt-6 flex flex-wrap justify-end gap-3">
+            {actions.map((action) => {
+              const variant = action.variant ?? 'secondary';
+              return (
+                <button
+                  key={action.label}
+                  type="button"
+                  onClick={action.onClick}
+                  className={actionClassName[variant]}
+                  disabled={action.disabled}
+                >
+                  {action.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export type { ModalAction, ModalProps };
+export default Modal;

--- a/src/frontend/src/components/Navigation.tsx
+++ b/src/frontend/src/components/Navigation.tsx
@@ -1,0 +1,74 @@
+import { ReactNode } from 'react';
+
+type NavigationLayout = 'horizontal' | 'vertical';
+
+type NavigationItem = {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  badge?: string | number;
+  disabled?: boolean;
+  tooltip?: string;
+};
+
+type NavigationProps = {
+  items: NavigationItem[];
+  activeItemId?: string;
+  onSelect?: (id: string) => void;
+  layout?: NavigationLayout;
+  className?: string;
+};
+
+const Navigation = ({
+  items,
+  activeItemId,
+  onSelect,
+  layout = 'horizontal',
+  className,
+}: NavigationProps) => {
+  const containerClass = [
+    layout === 'vertical'
+      ? 'flex flex-col gap-2 rounded-lg border border-border/60 bg-surfaceAlt/70 p-2 shadow-soft'
+      : 'flex flex-wrap items-center gap-2 rounded-full border border-border/60 bg-surfaceAlt/60 p-2 shadow-soft',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <nav className={containerClass} aria-label="Dashboard navigation">
+      {items.map((item) => {
+        const isActive = item.id === activeItemId;
+        const baseClass =
+          'group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+        const activeClass = isActive
+          ? 'bg-accent/20 text-text-primary shadow-soft'
+          : 'text-text-muted hover:bg-surfaceAlt/90 hover:text-text-primary';
+        const disabledClass = item.disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer';
+
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => (item.disabled ? undefined : onSelect?.(item.id))}
+            className={[baseClass, activeClass, disabledClass].filter(Boolean).join(' ')}
+            title={item.tooltip}
+            aria-pressed={isActive}
+            aria-disabled={item.disabled}
+          >
+            {item.icon ? <span className="text-base text-text-secondary">{item.icon}</span> : null}
+            <span>{item.label}</span>
+            {item.badge !== undefined ? (
+              <span className="ml-2 inline-flex min-w-[1.5rem] items-center justify-center rounded-full border border-border/60 bg-surfaceElevated px-2 py-0.5 text-xs font-semibold text-text-secondary">
+                {item.badge}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </nav>
+  );
+};
+
+export type { NavigationItem, NavigationLayout, NavigationProps };
+export default Navigation;

--- a/src/frontend/src/components/Panel.tsx
+++ b/src/frontend/src/components/Panel.tsx
@@ -1,0 +1,71 @@
+import { ReactNode } from 'react';
+
+type PanelPadding = 'none' | 'sm' | 'md' | 'lg';
+type PanelVariant = 'default' | 'ghost' | 'elevated';
+
+type PanelProps = {
+  title?: string;
+  description?: string;
+  action?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  padding?: PanelPadding;
+  variant?: PanelVariant;
+  className?: string;
+};
+
+const paddingClassName: Record<PanelPadding, string> = {
+  none: 'p-0',
+  sm: 'p-4',
+  md: 'p-6',
+  lg: 'p-8',
+};
+
+const variantClassName: Record<PanelVariant, string> = {
+  default: 'border border-border/60 bg-surfaceAlt/70 shadow-soft',
+  ghost: 'border border-transparent bg-transparent',
+  elevated: 'border border-border/40 bg-surfaceElevated shadow-strong backdrop-blur-md',
+};
+
+const Panel = ({
+  title,
+  description,
+  action,
+  footer,
+  children,
+  padding = 'md',
+  variant = 'default',
+  className,
+}: PanelProps) => {
+  const containerClass = [
+    'rounded-lg',
+    paddingClassName[padding],
+    variantClassName[variant],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <section className={containerClass}>
+      {(title || description || action) && (
+        <header className="mb-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-1">
+            {title ? <h2 className="text-lg font-semibold text-text-primary">{title}</h2> : null}
+            {description ? <p className="text-sm text-text-secondary">{description}</p> : null}
+          </div>
+          {action ? <div className="flex items-center gap-2">{action}</div> : null}
+        </header>
+      )}
+      <div className="space-y-4 text-sm text-text-secondary">{children}</div>
+      {footer ? (
+        <footer className="mt-6 border-t border-border/40 pt-4 text-sm text-text-muted">
+          {footer}
+        </footer>
+      ) : null}
+    </section>
+  );
+};
+
+export type { PanelPadding, PanelProps, PanelVariant };
+export default Panel;

--- a/src/frontend/src/components/Tabs.tsx
+++ b/src/frontend/src/components/Tabs.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from 'react';
+
+type TabItem = {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  badge?: string | number;
+  disabled?: boolean;
+};
+
+type TabsProps = {
+  tabs: TabItem[];
+  activeTab: string;
+  onTabChange: (id: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  className?: string;
+};
+
+const Tabs = ({
+  tabs,
+  activeTab,
+  onTabChange,
+  orientation = 'horizontal',
+  className,
+}: TabsProps) => {
+  const containerClass = [
+    orientation === 'vertical'
+      ? 'flex flex-col gap-2 rounded-lg border border-border/60 bg-surfaceAlt/70 p-2 shadow-soft'
+      : 'flex flex-wrap gap-2 rounded-full border border-border/60 bg-surfaceAlt/60 p-2 shadow-soft',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClass} role="tablist" aria-orientation={orientation}>
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTab;
+        const baseClass =
+          'group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+        const activeClass = isActive
+          ? 'bg-accent/20 text-text-primary shadow-soft'
+          : 'text-text-muted hover:bg-surfaceAlt/90 hover:text-text-primary';
+        const disabledClass = tab.disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer';
+
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`${tab.id}-panel`}
+            className={[baseClass, activeClass, disabledClass].filter(Boolean).join(' ')}
+            onClick={() => (tab.disabled ? undefined : onTabChange(tab.id))}
+            disabled={tab.disabled}
+          >
+            {tab.icon ? <span className="text-base text-text-secondary">{tab.icon}</span> : null}
+            <span>{tab.label}</span>
+            {tab.badge !== undefined ? (
+              <span className="ml-2 inline-flex min-w-[1.5rem] items-center justify-center rounded-full border border-border/60 bg-surfaceElevated px-2 py-0.5 text-xs font-semibold text-text-secondary">
+                {tab.badge}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export type { TabItem, TabsProps };
+export default Tabs;

--- a/src/frontend/src/components/TimeDisplay.tsx
+++ b/src/frontend/src/components/TimeDisplay.tsx
@@ -1,0 +1,108 @@
+import { ReactNode } from 'react';
+
+type SimulationStatus = 'live' | 'paused' | 'fastForward';
+
+type TimeDisplayMeta = {
+  label: string;
+  value: string;
+};
+
+type TimeDisplayProps = {
+  tick: number;
+  simulationTimeLabel: string;
+  realTimeLabel?: string;
+  status?: SimulationStatus;
+  tickLengthMinutes?: number;
+  meta?: TimeDisplayMeta[];
+  onSync?: () => void;
+  syncLabel?: string;
+  prefix?: ReactNode;
+  className?: string;
+};
+
+const statusClassName: Record<SimulationStatus, string> = {
+  live: 'bg-positive/90',
+  paused: 'bg-text-muted',
+  fastForward: 'bg-accent',
+};
+
+const statusLabel: Record<SimulationStatus, string> = {
+  live: 'Live',
+  paused: 'Paused',
+  fastForward: 'Fast forward',
+};
+
+const TimeDisplay = ({
+  tick,
+  simulationTimeLabel,
+  realTimeLabel,
+  status = 'live',
+  tickLengthMinutes,
+  meta,
+  onSync,
+  syncLabel = 'Jump to live',
+  prefix,
+  className,
+}: TimeDisplayProps) => {
+  const containerClass = [
+    'flex flex-col gap-4 rounded-lg border border-border/60 bg-surfaceAlt/60 p-4 text-sm text-text-secondary shadow-soft md:flex-row md:items-center md:justify-between md:text-base',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const statusIndicator = status ? statusClassName[status] : statusClassName.live;
+
+  return (
+    <section className={containerClass}>
+      <div className="flex flex-1 items-center gap-4">
+        <span
+          className={['inline-flex h-3 w-3 rounded-full', statusIndicator].join(' ')}
+          aria-label={statusLabel[status]}
+        />
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {prefix ? <span className="text-text-muted">{prefix}</span> : null}
+            <span className="font-semibold uppercase tracking-wide text-text-muted">
+              Tick #{tick}
+            </span>
+            {tickLengthMinutes !== undefined ? (
+              <span className="rounded-full border border-border/50 px-2 py-0.5 text-xs font-medium text-text-muted">
+                {tickLengthMinutes} min/tick
+              </span>
+            ) : null}
+          </div>
+          <p className="text-lg font-medium text-text-primary md:text-xl">{simulationTimeLabel}</p>
+          {realTimeLabel ? (
+            <p className="text-xs text-text-muted md:text-sm">Real time: {realTimeLabel}</p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex flex-col items-start gap-4 md:items-end">
+        {meta && meta.length > 0 ? (
+          <dl className="grid grid-cols-1 gap-3 text-left text-xs text-text-muted sm:grid-cols-2">
+            {meta.map((entry) => (
+              <div key={entry.label} className="space-y-1">
+                <dt className="uppercase tracking-wide text-text-muted/80">{entry.label}</dt>
+                <dd className="text-sm font-medium text-text-primary">{entry.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+        {onSync ? (
+          <button
+            type="button"
+            onClick={onSync}
+            className="inline-flex items-center gap-2 rounded-md border border-accent/60 px-3 py-1.5 text-xs font-medium text-accent transition hover:border-accent hover:bg-accent/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <span aria-hidden="true">⟳</span>
+            {syncLabel}
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export type { SimulationStatus, TimeDisplayMeta, TimeDisplayProps };
+export default TimeDisplay;

--- a/src/frontend/src/components/ToggleSwitch.tsx
+++ b/src/frontend/src/components/ToggleSwitch.tsx
@@ -1,0 +1,101 @@
+import { KeyboardEvent, ReactNode } from 'react';
+
+type ToggleSize = 'sm' | 'md';
+
+type ToggleSwitchProps = {
+  id?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: ReactNode;
+  description?: ReactNode;
+  disabled?: boolean;
+  size?: ToggleSize;
+  className?: string;
+};
+
+const sizeClassName: Record<ToggleSize, { track: string; thumb: string }> = {
+  sm: {
+    track: 'h-5 w-9',
+    thumb: 'h-4 w-4 translate-x-0.5 data-[state=on]:translate-x-[1.55rem]',
+  },
+  md: {
+    track: 'h-6 w-11',
+    thumb: 'h-5 w-5 translate-x-1 data-[state=on]:translate-x-[1.65rem]',
+  },
+};
+
+const ToggleSwitch = ({
+  id,
+  checked,
+  onChange,
+  label,
+  description,
+  disabled = false,
+  size = 'md',
+  className,
+}: ToggleSwitchProps) => {
+  const containerClass = [
+    'flex items-center gap-3 rounded-md border border-transparent px-2 py-2 transition',
+    disabled ? 'opacity-60' : 'hover:border-accent/60',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const { track, thumb } = sizeClassName[size];
+
+  const handleToggle = () => {
+    if (!disabled) {
+      onChange(!checked);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleToggle();
+    }
+  };
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-label={typeof label === 'string' ? label : undefined}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        data-state={checked ? 'on' : 'off'}
+        className={[
+          'relative inline-flex shrink-0 cursor-pointer items-center rounded-full border border-border/60 bg-surfaceAlt transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+          checked ? 'border-accent bg-accent/70' : 'hover:border-accent/50',
+          disabled ? 'cursor-not-allowed' : '',
+          track,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <span
+          className={[
+            'pointer-events-none inline-block rounded-full bg-surface shadow-soft transition-transform duration-200 ease-in-out',
+            thumb,
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        />
+      </button>
+      {(label || description) && (
+        <label htmlFor={id} className="flex flex-col text-left">
+          {label ? <span className="text-sm font-medium text-text-primary">{label}</span> : null}
+          {description ? <span className="text-xs text-text-muted">{description}</span> : null}
+        </label>
+      )}
+    </div>
+  );
+};
+
+export type { ToggleSize, ToggleSwitchProps };
+export default ToggleSwitch;


### PR DESCRIPTION
## Summary
- scaffold dashboard primitives (header, metrics bar, time display, controls) with props for simulation telemetry
- add navigation, panel, card, modal, tabs, and toggle switch components aligned with existing tailwind design tokens

## Testing
- pnpm --filter frontend lint *(fails: missing eslint rule import/no-named-as-default-member because eslint-plugin-import is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d143a59700832587c224ab0f90794a