### PR TITLE
Add dashboard view layer for overview, zone detail, personnel, finance

### DIFF
--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -1,9 +1,8 @@
-/* eslint-disable import/no-named-as-default-member */
 import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
-import tseslint from 'typescript-eslint';
+import * as tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {

--- a/src/frontend/src/views/DashboardOverview.tsx
+++ b/src/frontend/src/views/DashboardOverview.tsx
@@ -1,0 +1,188 @@
+import Card from '@/components/Card';
+import DashboardHeader from '@/components/DashboardHeader';
+import MetricsBar from '@/components/MetricsBar';
+import Panel from '@/components/Panel';
+import {
+  selectAlertCount,
+  selectCapital,
+  selectCurrentTick,
+  selectCumulativeYield,
+  selectTimeStatus,
+  useAppStore,
+} from '@/store';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+const decimalFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+});
+
+const percentageFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumFractionDigits: 0,
+});
+
+const DashboardOverview = () => {
+  const timeStatus = useAppStore(selectTimeStatus);
+  const currentTick = useAppStore(selectCurrentTick);
+  const cashOnHand = useAppStore(selectCapital);
+  const cumulativeYield = useAppStore(selectCumulativeYield);
+  const alertCount = useAppStore(selectAlertCount);
+  const structures = useAppStore((state) => Object.values(state.structures));
+  const rooms = useAppStore((state) => Object.values(state.rooms));
+  const zones = useAppStore((state) => Object.values(state.zones));
+  const plants = useAppStore((state) => Object.values(state.plants));
+
+  const headerStatus =
+    timeStatus === undefined
+      ? undefined
+      : {
+          label: timeStatus.paused ? 'Paused' : timeStatus.speed > 1 ? 'Fast forward' : 'Running',
+          tone: timeStatus.paused ? 'warning' : 'positive',
+          tooltip: timeStatus.paused
+            ? 'Simulation is currently paused'
+            : `Tick rate: ${timeStatus.targetTickRate.toFixed(0)}x (speed ${timeStatus.speed.toFixed(2)})`,
+        };
+
+  const overviewMetrics = [
+    {
+      id: 'tick',
+      label: 'Current tick',
+      value: currentTick,
+    },
+    {
+      id: 'capital',
+      label: 'Cash on hand',
+      value: currencyFormatter.format(cashOnHand),
+    },
+    {
+      id: 'yield',
+      label: 'Cumulative dry yield',
+      value: `${decimalFormatter.format(cumulativeYield)} g`,
+    },
+    {
+      id: 'alerts',
+      label: 'Active alerts',
+      value: alertCount,
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <DashboardHeader
+        title="Facility overview"
+        subtitle="High-level snapshot of structures, rooms, and grow zones across the simulation."
+        status={headerStatus}
+        meta={[
+          { label: 'Structures', value: structures.length.toLocaleString() },
+          { label: 'Rooms', value: rooms.length.toLocaleString() },
+          { label: 'Zones', value: zones.length.toLocaleString() },
+          { label: 'Plants', value: plants.length.toLocaleString() },
+        ]}
+      />
+
+      <MetricsBar metrics={overviewMetrics} layout="compact" />
+
+      <Panel
+        title="Zones"
+        description="Live environment readings, resource levels, and stress indicators for each active zone."
+        padding="lg"
+        variant="elevated"
+      >
+        {zones.length === 0 ? (
+          <p className="text-sm text-text-muted">
+            No zones available yet. Create a zone to start monitoring.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+            {zones.map((zone) => {
+              const stressLevel = Math.max(0, Math.min(zone.metrics.stressLevel ?? 0, 1));
+              const lightingCoverage = zone.lighting?.coverageRatio;
+              const plantingPlan = zone.plantingPlan;
+
+              return (
+                <Card
+                  key={zone.id}
+                  title={zone.name}
+                  subtitle={`${zone.structureName} • ${zone.roomName}`}
+                  metadata={[
+                    { label: 'Area', value: `${decimalFormatter.format(zone.area)} m²` },
+                    { label: 'Volume', value: `${decimalFormatter.format(zone.volume)} m³` },
+                    { label: 'Plants', value: zone.plants.length.toLocaleString() },
+                    {
+                      label: 'Lighting coverage',
+                      value:
+                        lightingCoverage !== undefined
+                          ? percentageFormatter.format(Math.max(0, Math.min(lightingCoverage, 1)))
+                          : '—',
+                    },
+                  ]}
+                  footer={`Last update: tick ${zone.metrics.lastUpdatedTick.toLocaleString()}`}
+                >
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">Temperature</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {zone.environment.temperature.toFixed(1)} °C
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">Humidity</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {(zone.environment.relativeHumidity * 100).toFixed(0)}%
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">CO₂</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {zone.environment.co2.toLocaleString()} ppm
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">PPFD</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {zone.environment.ppfd.toFixed(0)} μmol·m⁻²·s⁻¹
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">VPD proxy</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {zone.environment.vpd.toFixed(2)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-text-muted">Plan</p>
+                      <p className="text-base font-medium text-text-primary">
+                        {plantingPlan
+                          ? `${plantingPlan.count} × ${plantingPlan.strainId}`
+                          : 'Manual'}
+                      </p>
+                    </div>
+                    <div className="col-span-2 space-y-2">
+                      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                        <span>Stress level</span>
+                        <span>{percentageFormatter.format(stressLevel)}</span>
+                      </div>
+                      <div className="h-2 w-full rounded-full bg-border/30">
+                        <div
+                          className="h-2 rounded-full bg-warning"
+                          style={{ width: `${Math.round(stressLevel * 100)}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </Panel>
+    </div>
+  );
+};
+
+export default DashboardOverview;

--- a/src/frontend/src/views/FinancesView.tsx
+++ b/src/frontend/src/views/FinancesView.tsx
@@ -1,0 +1,276 @@
+import { useMemo } from 'react';
+import DashboardHeader from '@/components/DashboardHeader';
+import MetricsBar from '@/components/MetricsBar';
+import Panel from '@/components/Panel';
+import { selectFinanceSummary, useAppStore } from '@/store';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+const formatCurrency = (value: number | undefined) => currencyFormatter.format(value ?? 0);
+
+const FinancesView = () => {
+  const financeSummary = useAppStore(selectFinanceSummary);
+  const financeHistory = useAppStore((state) => state.financeHistory);
+
+  const chartData = useMemo(() => {
+    return financeHistory.slice(-24).map((entry) => ({
+      tick: entry.tick,
+      ts: entry.ts,
+      revenue: entry.revenue,
+      expenses: entry.expenses,
+      netIncome: entry.netIncome,
+      capex: entry.capex,
+      opex: entry.opex,
+      maintenance: entry.maintenanceTotal,
+      utilitiesTotal: entry.utilities.totalCost,
+      utilitiesEnergy: entry.utilities.energy,
+      utilitiesWater: entry.utilities.water,
+      utilitiesNutrients: entry.utilities.nutrients,
+    }));
+  }, [financeHistory]);
+
+  const hasHistory = chartData.length > 0;
+  const recentEntries = useMemo(() => financeHistory.slice(-10).reverse(), [financeHistory]);
+  const latestEntry = financeHistory.at(-1);
+
+  const summaryMetrics = [
+    {
+      id: 'cash',
+      label: 'Cash on hand',
+      value: formatCurrency(financeSummary?.cashOnHand),
+    },
+    {
+      id: 'net-income',
+      label: 'Net income',
+      value: formatCurrency(financeSummary?.netIncome),
+      trend: financeSummary && financeSummary.netIncome >= 0 ? 'up' : 'down',
+    },
+    {
+      id: 'total-revenue',
+      label: 'Total revenue',
+      value: formatCurrency(financeSummary?.totalRevenue),
+    },
+    {
+      id: 'total-expenses',
+      label: 'Total expenses',
+      value: formatCurrency(financeSummary?.totalExpenses),
+    },
+  ];
+
+  const headerStatus = financeSummary
+    ? {
+        label: financeSummary.netIncome >= 0 ? 'Profitable' : 'Operating at loss',
+        tone: financeSummary.netIncome >= 0 ? 'positive' : 'warning',
+        tooltip:
+          financeSummary.netIncome >= 0
+            ? 'Cumulative net income remains positive.'
+            : 'Expenses exceed revenue; monitor costs closely.',
+      }
+    : undefined;
+
+  const tooltipFormatter = (value: number | string) =>
+    typeof value === 'number' ? formatCurrency(value) : value;
+  const labelFormatter = (tick: number) => `Tick ${tick.toLocaleString()}`;
+
+  return (
+    <div className="space-y-8">
+      <DashboardHeader
+        title="Finances"
+        subtitle="Track revenue, expenses, and resource costs to keep the grow operation solvent."
+        status={headerStatus}
+        meta={[
+          { label: 'Last revenue', value: formatCurrency(financeSummary?.lastTickRevenue) },
+          { label: 'Last expenses', value: formatCurrency(financeSummary?.lastTickExpenses) },
+        ]}
+      />
+
+      <MetricsBar metrics={summaryMetrics} layout="compact" />
+
+      <div className="grid gap-6 xl:grid-cols-[2fr,1fr]">
+        <Panel title="Revenue vs expenses" padding="lg" variant="elevated">
+          {hasHistory ? (
+            <ResponsiveContainer width="100%" height={280}>
+              <AreaChart data={chartData} margin={{ top: 10, right: 20, bottom: 0, left: -10 }}>
+                <CartesianGrid strokeDasharray="4 4" stroke="rgba(148, 163, 184, 0.2)" />
+                <XAxis dataKey="tick" tickLine={false} axisLine={false} />
+                <YAxis
+                  tickFormatter={(value) =>
+                    formatCurrency(typeof value === 'number' ? value : Number(value))
+                  }
+                  width={80}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
+                <Legend />
+                <Area
+                  type="monotone"
+                  dataKey="revenue"
+                  name="Revenue"
+                  stroke="#16a34a"
+                  fill="#16a34a22"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="expenses"
+                  name="Expenses"
+                  stroke="#ef4444"
+                  fill="#ef444422"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="netIncome"
+                  name="Net income"
+                  stroke="#6366f1"
+                  fill="#6366f122"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <p className="text-sm text-text-muted">
+              Financial history will appear after the first tick completes.
+            </p>
+          )}
+        </Panel>
+
+        <div className="space-y-6">
+          <Panel title="Cost breakdown" padding="lg" variant="elevated">
+            {hasHistory ? (
+              <ResponsiveContainer width="100%" height={240}>
+                <BarChart data={chartData} margin={{ top: 10, right: 20, bottom: 0, left: -10 }}>
+                  <CartesianGrid strokeDasharray="4 4" stroke="rgba(148, 163, 184, 0.2)" />
+                  <XAxis dataKey="tick" tickLine={false} axisLine={false} />
+                  <YAxis
+                    tickFormatter={(value) =>
+                      formatCurrency(typeof value === 'number' ? value : Number(value))
+                    }
+                    width={80}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
+                  <Legend />
+                  <Bar dataKey="capex" name="CapEx" stackId="costs" fill="#f97316" />
+                  <Bar dataKey="opex" name="OpEx" stackId="costs" fill="#14b8a6" />
+                  <Bar dataKey="maintenance" name="Maintenance" stackId="costs" fill="#facc15" />
+                  <Bar dataKey="utilitiesTotal" name="Utilities" stackId="costs" fill="#38bdf8" />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-sm text-text-muted">
+                Cost categories will populate as the simulation runs.
+              </p>
+            )}
+          </Panel>
+
+          <Panel title="Latest tick" padding="lg" variant="elevated">
+            {latestEntry ? (
+              <dl className="grid grid-cols-2 gap-4 text-sm text-text-secondary">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Tick</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {latestEntry.tick.toLocaleString()}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Net income</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {formatCurrency(latestEntry.netIncome)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Revenue</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {formatCurrency(latestEntry.revenue)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Expenses</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {formatCurrency(latestEntry.expenses)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Utilities</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {formatCurrency(latestEntry.utilities.totalCost)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-text-muted">Maintenance</dt>
+                  <dd className="text-base font-medium text-text-primary">
+                    {formatCurrency(latestEntry.maintenanceTotal)}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="text-sm text-text-muted">Awaiting first financial snapshot.</p>
+            )}
+          </Panel>
+        </div>
+      </div>
+
+      <Panel
+        title="Recent financial ticks"
+        description="Revenue, expenses, and cost drivers over the last 10 ticks."
+        padding="lg"
+        variant="elevated"
+      >
+        {recentEntries.length === 0 ? (
+          <p className="text-sm text-text-muted">No historical data recorded yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border/50 text-sm">
+              <thead className="bg-surfaceAlt/70 text-xs uppercase tracking-wide text-text-muted">
+                <tr>
+                  <th className="px-3 py-2 text-left">Tick</th>
+                  <th className="px-3 py-2 text-left">Revenue</th>
+                  <th className="px-3 py-2 text-left">Expenses</th>
+                  <th className="px-3 py-2 text-left">Net income</th>
+                  <th className="px-3 py-2 text-left">CapEx</th>
+                  <th className="px-3 py-2 text-left">OpEx</th>
+                  <th className="px-3 py-2 text-left">Utilities</th>
+                  <th className="px-3 py-2 text-left">Maintenance</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/40 text-text-secondary">
+                {recentEntries.map((entry) => (
+                  <tr key={`${entry.tick}-${entry.ts}`}>
+                    <td className="px-3 py-2 font-mono text-xs text-text-muted">
+                      {entry.tick.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">{formatCurrency(entry.revenue)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.expenses)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.netIncome)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.capex)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.opex)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.utilities.totalCost)}</td>
+                    <td className="px-3 py-2">{formatCurrency(entry.maintenanceTotal)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+    </div>
+  );
+};
+
+export default FinancesView;

--- a/src/frontend/src/views/PersonnelView.tsx
+++ b/src/frontend/src/views/PersonnelView.tsx
@@ -1,0 +1,263 @@
+import Card from '@/components/Card';
+import DashboardHeader from '@/components/DashboardHeader';
+import MetricsBar from '@/components/MetricsBar';
+import Panel from '@/components/Panel';
+import { useAppStore } from '@/store';
+
+const percentageFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumFractionDigits: 0,
+});
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+const clampRatio = (value: number | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(value, 1));
+};
+
+const resolveBarTone = (value: number) => {
+  if (value >= 0.8) {
+    return 'bg-positive';
+  }
+  if (value >= 0.6) {
+    return 'bg-accent';
+  }
+  if (value >= 0.4) {
+    return 'bg-warning';
+  }
+  return 'bg-danger';
+};
+
+const PersonnelView = () => {
+  const personnel = useAppStore((state) => state.personnel);
+  const hrEvents = useAppStore((state) => state.hrEvents.slice(-12).reverse());
+
+  if (!personnel) {
+    return (
+      <Panel
+        title="Personnel overview"
+        description="Staffing data will appear once the simulation streams HR snapshots."
+        padding="lg"
+        variant="elevated"
+      >
+        <p className="text-sm text-text-muted">No personnel data available yet.</p>
+      </Panel>
+    );
+  }
+
+  const employees = personnel.employees ?? [];
+  const applicants = personnel.applicants ?? [];
+  const overallMorale = clampRatio(personnel.overallMorale);
+  const averageEnergy = employees.length
+    ? clampRatio(
+        employees.reduce((sum, employee) => sum + clampRatio(employee.energy), 0) /
+          employees.length,
+      )
+    : 0;
+  const averageMorale = employees.length
+    ? clampRatio(
+        employees.reduce((sum, employee) => sum + clampRatio(employee.morale), 0) /
+          employees.length,
+      )
+    : 0;
+
+  const summaryMetrics = [
+    {
+      id: 'overall-morale',
+      label: 'Overall morale',
+      value: percentageFormatter.format(overallMorale),
+    },
+    {
+      id: 'employee-count',
+      label: 'Employees',
+      value: employees.length,
+    },
+    {
+      id: 'applicants',
+      label: 'Applicants',
+      value: applicants.length,
+    },
+    {
+      id: 'avg-energy',
+      label: 'Average energy',
+      value: percentageFormatter.format(averageEnergy),
+      change: percentageFormatter.format(averageMorale),
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <DashboardHeader
+        title="Personnel"
+        subtitle="Monitor team morale, workload, and hiring pipeline to keep the facility operating smoothly."
+        status={{
+          label: overallMorale >= 0.6 ? 'Stable team' : 'Needs attention',
+          tone: overallMorale >= 0.6 ? 'positive' : 'warning',
+          tooltip:
+            overallMorale >= 0.6
+              ? 'Morale is within healthy range.'
+              : 'Investigate morale dips with HR events.',
+        }}
+        meta={[
+          { label: 'Employees', value: employees.length.toLocaleString() },
+          { label: 'Applicants', value: applicants.length.toLocaleString() },
+          { label: 'Avg morale', value: percentageFormatter.format(averageMorale) },
+        ]}
+      />
+
+      <MetricsBar metrics={summaryMetrics} layout="compact" />
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Panel
+          title="Team roster"
+          description="Morale and energy trends per employee."
+          padding="lg"
+          variant="elevated"
+        >
+          {employees.length === 0 ? (
+            <p className="text-sm text-text-muted">No employees hired yet.</p>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {employees.map((employee) => {
+                const morale = clampRatio(employee.morale);
+                const energy = clampRatio(employee.energy);
+                const moraleTone = resolveBarTone(morale);
+                const energyTone = resolveBarTone(energy);
+
+                return (
+                  <Card
+                    key={employee.id}
+                    title={employee.name}
+                    subtitle={employee.role}
+                    metadata={[
+                      {
+                        label: 'Salary / tick',
+                        value: `${currencyFormatter.format(employee.salaryPerTick)} / tick`,
+                      },
+                      {
+                        label: 'Max minutes / tick',
+                        value: employee.maxMinutesPerTick.toLocaleString(),
+                      },
+                      {
+                        label: 'Status',
+                        value: employee.status,
+                      },
+                      {
+                        label: 'Assignment',
+                        value: employee.assignedStructureId ?? 'Unassigned',
+                      },
+                    ]}
+                  >
+                    <div className="space-y-3">
+                      <div>
+                        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                          <span>Morale</span>
+                          <span>{percentageFormatter.format(morale)}</span>
+                        </div>
+                        <div className="mt-1 h-2 w-full rounded-full bg-border/30">
+                          <div
+                            className={`h-2 rounded-full ${moraleTone}`}
+                            style={{ width: `${Math.round(morale * 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                          <span>Energy</span>
+                          <span>{percentageFormatter.format(energy)}</span>
+                        </div>
+                        <div className="mt-1 h-2 w-full rounded-full bg-border/30">
+                          <div
+                            className={`h-2 rounded-full ${energyTone}`}
+                            style={{ width: `${Math.round(energy * 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </Panel>
+
+        <div className="space-y-6">
+          <Panel
+            title="Applicants"
+            description="Candidates waiting in the hiring pipeline."
+            padding="lg"
+            variant="elevated"
+          >
+            {applicants.length === 0 ? (
+              <p className="text-sm text-text-muted">No open applications at the moment.</p>
+            ) : (
+              <ul className="space-y-4 text-sm text-text-secondary">
+                {applicants.map((applicant) => (
+                  <li
+                    key={applicant.id}
+                    className="rounded-md border border-border/40 bg-surfaceAlt/60 p-3"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-text-primary">{applicant.name}</p>
+                        <p className="text-xs uppercase tracking-wide text-text-muted">
+                          {applicant.desiredRole}
+                        </p>
+                      </div>
+                      <span className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                        {currencyFormatter.format(applicant.expectedSalary)} / tick
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Panel>
+
+          <Panel
+            title="HR events"
+            description="Latest staffing-related alerts from the simulation."
+            padding="lg"
+            variant="elevated"
+          >
+            {hrEvents.length === 0 ? (
+              <p className="text-sm text-text-muted">No HR events recorded.</p>
+            ) : (
+              <ul className="space-y-3 text-sm text-text-secondary">
+                {hrEvents.map((event, index) => (
+                  <li
+                    key={`${event.type}-${event.ts ?? event.tick ?? index}`}
+                    className="rounded-md border border-border/40 bg-surfaceAlt/50 p-3"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="font-semibold text-text-primary">
+                        {event.type.replace('hr.', '')}
+                      </p>
+                      {event.tick !== undefined ? (
+                        <span className="font-mono text-xs text-text-muted">
+                          Tick {event.tick.toLocaleString()}
+                        </span>
+                      ) : null}
+                    </div>
+                    {event.message ? (
+                      <p className="mt-2 text-sm text-text-secondary">{event.message}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Panel>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PersonnelView;

--- a/src/frontend/src/views/ZoneDetail.tsx
+++ b/src/frontend/src/views/ZoneDetail.tsx
@@ -1,0 +1,486 @@
+import Card from '@/components/Card';
+import DashboardHeader from '@/components/DashboardHeader';
+import MetricsBar from '@/components/MetricsBar';
+import Panel from '@/components/Panel';
+import { selectCurrentTick, selectSelectedZone, useAppStore } from '@/store';
+
+const percentageFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumFractionDigits: 0,
+});
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+});
+
+const ZoneDetail = () => {
+  const zone = useAppStore(selectSelectedZone);
+  const currentTick = useAppStore(selectCurrentTick);
+  const timeline = useAppStore((state) => state.timeline);
+
+  if (!zone) {
+    return (
+      <Panel
+        title="Zone detail"
+        description="Select a zone from the overview to inspect environment telemetry, resources, and automation."
+        padding="lg"
+        variant="elevated"
+      >
+        <p className="text-sm text-text-muted">
+          No zone is currently selected. Choose a zone to view its live status and configuration
+          details.
+        </p>
+      </Panel>
+    );
+  }
+
+  const stressLevel = Math.max(0, Math.min(zone.metrics.stressLevel ?? 0, 1));
+  const substrateHealth = Math.max(0, Math.min(zone.resources.substrateHealth ?? 0, 1));
+  const reservoirLevel = Math.max(0, Math.min(zone.resources.reservoirLevel ?? 0, 1));
+  const nutrientStrength = Math.max(0, Math.min(zone.resources.nutrientStrength ?? 0, 1));
+  const zoneTimeline = timeline
+    .filter((entry) => entry.zoneId === zone.id)
+    .slice(-12)
+    .reverse();
+
+  const environmentMetrics = [
+    {
+      id: 'temperature',
+      label: 'Temperature',
+      value: `${zone.environment.temperature.toFixed(1)} °C`,
+    },
+    {
+      id: 'humidity',
+      label: 'Humidity',
+      value: `${(zone.environment.relativeHumidity * 100).toFixed(0)}%`,
+    },
+    {
+      id: 'co2',
+      label: 'CO₂',
+      value: `${zone.environment.co2.toLocaleString()} ppm`,
+    },
+    {
+      id: 'ppfd',
+      label: 'PPFD',
+      value: `${zone.environment.ppfd.toFixed(0)} μmol·m⁻²·s⁻¹`,
+    },
+    {
+      id: 'vpd',
+      label: 'VPD proxy',
+      value: zone.environment.vpd.toFixed(2),
+    },
+    {
+      id: 'stress',
+      label: 'Stress level',
+      value: percentageFormatter.format(stressLevel),
+    },
+  ];
+
+  const headerStatus =
+    zone.health.diseases > 0 || zone.health.pests > 0
+      ? {
+          label: 'Attention required',
+          tone: 'warning' as const,
+          tooltip: 'Active disease or pest pressure detected in this zone.',
+        }
+      : {
+          label: 'Healthy',
+          tone: 'positive' as const,
+          tooltip: 'No outstanding health alerts for this zone.',
+        };
+
+  const plantingGroups = zone.plantingGroups ?? [];
+  const displayedPlants = zone.plants.slice(0, 6);
+
+  return (
+    <div className="space-y-8">
+      <DashboardHeader
+        title={zone.name}
+        subtitle={`Detailed telemetry for tick ${currentTick.toLocaleString()} with historical averages per zone.`}
+        status={headerStatus}
+        meta={[
+          { label: 'Structure', value: zone.structureName },
+          { label: 'Room', value: zone.roomName },
+          { label: 'Area', value: `${numberFormatter.format(zone.area)} m²` },
+          { label: 'Volume', value: `${numberFormatter.format(zone.volume)} m³` },
+        ]}
+      >
+        <MetricsBar metrics={environmentMetrics} layout="compact" />
+      </DashboardHeader>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-6">
+          <Panel title="Environment detail" padding="lg" variant="elevated">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+                  Instantaneous
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm text-text-secondary">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">Temperature</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.environment.temperature.toFixed(1)} °C
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">Humidity</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {(zone.environment.relativeHumidity * 100).toFixed(0)}%
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">CO₂</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.environment.co2.toLocaleString()} ppm
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">PPFD</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.environment.ppfd.toFixed(0)} μmol·m⁻²·s⁻¹
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">VPD proxy</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.environment.vpd.toFixed(2)}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+                  Rolling averages
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm text-text-secondary">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">
+                      Avg temperature
+                    </dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.metrics.averageTemperature.toFixed(1)} °C
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">
+                      Avg humidity
+                    </dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {(zone.metrics.averageHumidity * 100).toFixed(0)}%
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">Avg CO₂</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.metrics.averageCo2.toLocaleString()} ppm
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-text-muted">Avg PPFD</dt>
+                    <dd className="text-base font-medium text-text-primary">
+                      {zone.metrics.averagePpfd.toFixed(0)} μmol·m⁻²·s⁻¹
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          </Panel>
+
+          <Panel title="Plant inventory" padding="lg" variant="elevated">
+            {plantingGroups.length > 0 ? (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+                  Planting groups
+                </h3>
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {plantingGroups.map((group) => (
+                    <Card
+                      key={group.id}
+                      title={group.name ?? group.strainId}
+                      subtitle={group.stage ? `Stage: ${group.stage}` : undefined}
+                      metadata={[
+                        { label: 'Strain', value: group.strainId },
+                        {
+                          label: 'Plants',
+                          value:
+                            group.plantIds && group.plantIds.length > 0
+                              ? group.plantIds.length.toLocaleString()
+                              : '—',
+                        },
+                        {
+                          label: 'Harvest ready',
+                          value:
+                            group.harvestReadyCount !== undefined
+                              ? group.harvestReadyCount.toLocaleString()
+                              : '—',
+                        },
+                      ]}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+                Sample plants
+              </h3>
+              {displayedPlants.length === 0 ? (
+                <p className="text-sm text-text-muted">No active plants in this zone.</p>
+              ) : (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {displayedPlants.map((plant) => (
+                    <Card
+                      key={plant.id}
+                      title={plant.id}
+                      subtitle={`Strain ${plant.strainId}`}
+                      metadata={[
+                        { label: 'Stage', value: plant.stage },
+                        {
+                          label: 'Health',
+                          value: percentageFormatter.format(Math.max(0, Math.min(plant.health, 1))),
+                        },
+                        {
+                          label: 'Stress',
+                          value: percentageFormatter.format(Math.max(0, Math.min(plant.stress, 1))),
+                        },
+                        {
+                          label: 'Dry mass',
+                          value: `${numberFormatter.format(plant.biomassDryGrams)} g`,
+                        },
+                      ]}
+                    />
+                  ))}
+                </div>
+              )}
+              {zone.plants.length > displayedPlants.length ? (
+                <p className="text-xs text-text-muted">
+                  {zone.plants.length - displayedPlants.length} additional plants tracked in this
+                  zone.
+                </p>
+              ) : null}
+            </div>
+          </Panel>
+
+          <Panel title="Recent telemetry" padding="lg" variant="elevated">
+            {zoneTimeline.length === 0 ? (
+              <p className="text-sm text-text-muted">
+                No telemetry has been recorded for this zone yet.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-border/50 text-sm">
+                  <thead className="bg-surfaceAlt/70 text-xs uppercase tracking-wide text-text-muted">
+                    <tr>
+                      <th className="px-3 py-2 text-left">Tick</th>
+                      <th className="px-3 py-2 text-left">Temperature</th>
+                      <th className="px-3 py-2 text-left">Humidity</th>
+                      <th className="px-3 py-2 text-left">CO₂</th>
+                      <th className="px-3 py-2 text-left">PPFD</th>
+                      <th className="px-3 py-2 text-left">VPD</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/40 text-text-secondary">
+                    {zoneTimeline.map((entry) => (
+                      <tr key={`${entry.tick}-${entry.ts}`}>
+                        <td className="px-3 py-2 font-mono text-xs text-text-muted">
+                          {entry.tick.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2">
+                          {entry.temperature !== undefined
+                            ? `${entry.temperature.toFixed(1)} °C`
+                            : '—'}
+                        </td>
+                        <td className="px-3 py-2">
+                          {entry.humidity !== undefined
+                            ? `${(entry.humidity * 100).toFixed(0)}%`
+                            : '—'}
+                        </td>
+                        <td className="px-3 py-2">
+                          {entry.co2 !== undefined ? entry.co2.toLocaleString() : '—'}
+                        </td>
+                        <td className="px-3 py-2">
+                          {entry.ppfd !== undefined ? entry.ppfd.toFixed(0) : '—'}
+                        </td>
+                        <td className="px-3 py-2">
+                          {entry.vpd !== undefined ? entry.vpd.toFixed(2) : '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </Panel>
+        </div>
+
+        <div className="space-y-6">
+          <Panel title="Resources & automation" padding="lg" variant="elevated">
+            <dl className="space-y-4 text-sm text-text-secondary">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                  <dt>Water reserve</dt>
+                  <dd>{`${numberFormatter.format(zone.resources.waterLiters)} L`}</dd>
+                </div>
+                <div className="h-2 w-full rounded-full bg-border/30">
+                  <div
+                    className="h-2 rounded-full bg-accent"
+                    style={{ width: `${Math.round(reservoirLevel * 100)}%` }}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                  <dt>Nutrient solution</dt>
+                  <dd>{`${numberFormatter.format(zone.resources.nutrientSolutionLiters)} L`}</dd>
+                </div>
+                <div className="h-2 w-full rounded-full bg-border/30">
+                  <div
+                    className="h-2 rounded-full bg-positive"
+                    style={{ width: `${Math.round(nutrientStrength * 100)}%` }}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+                  <dt>Substrate health</dt>
+                  <dd>{percentageFormatter.format(substrateHealth)}</dd>
+                </div>
+                <div className="h-2 w-full rounded-full bg-border/30">
+                  <div
+                    className="h-2 rounded-full bg-positive/80"
+                    style={{ width: `${Math.round(substrateHealth * 100)}%` }}
+                  />
+                </div>
+              </div>
+            </dl>
+            {zone.supplyStatus ? (
+              <div className="mt-6 space-y-3 text-xs text-text-muted">
+                <p className="font-semibold uppercase tracking-wide text-text-secondary">
+                  Daily consumption
+                </p>
+                <div className="grid grid-cols-2 gap-3 text-sm text-text-secondary">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-text-muted">Water</p>
+                    <p className="font-medium text-text-primary">
+                      {zone.supplyStatus.dailyWaterConsumptionLiters?.toFixed(1) ?? '—'} L
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-text-muted">Nutrients</p>
+                    <p className="font-medium text-text-primary">
+                      {zone.supplyStatus.dailyNutrientConsumptionLiters?.toFixed(1) ?? '—'} L
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </Panel>
+
+          <Panel title="Device overview" padding="lg" variant="elevated">
+            {zone.devices.length === 0 ? (
+              <p className="text-sm text-text-muted">No devices assigned to this zone.</p>
+            ) : (
+              <ul className="space-y-4 text-sm text-text-secondary">
+                {zone.devices.map((device) => (
+                  <li
+                    key={device.id}
+                    className="rounded-md border border-border/40 bg-surfaceAlt/60 p-3"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-text-primary">{device.name}</p>
+                        <p className="text-xs uppercase tracking-wide text-text-muted">
+                          {device.kind}
+                        </p>
+                      </div>
+                      <span className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                        {device.status}
+                      </span>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
+                      <div>
+                        <p className="text-text-muted">Blueprint</p>
+                        <p className="font-medium text-text-secondary">{device.blueprintId}</p>
+                      </div>
+                      <div>
+                        <p className="text-text-muted">Efficiency</p>
+                        <p className="font-medium text-text-secondary">
+                          {percentageFormatter.format(Math.max(0, Math.min(device.efficiency, 1)))}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-text-muted">Runtime hours</p>
+                        <p className="font-medium text-text-secondary">
+                          {numberFormatter.format(device.runtimeHours)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-text-muted">Condition</p>
+                        <p className="font-medium text-text-secondary">
+                          {percentageFormatter.format(
+                            Math.max(0, Math.min(device.maintenance.condition ?? 0, 1)),
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Panel>
+
+          <Panel title="Health & restrictions" padding="lg" variant="elevated">
+            <dl className="grid grid-cols-2 gap-4 text-sm text-text-secondary">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-text-muted">Diseases</dt>
+                <dd className="text-base font-medium text-text-primary">{zone.health.diseases}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-text-muted">Pests</dt>
+                <dd className="text-base font-medium text-text-primary">{zone.health.pests}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-text-muted">
+                  Pending treatments
+                </dt>
+                <dd className="text-base font-medium text-text-primary">
+                  {zone.health.pendingTreatments}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-text-muted">
+                  Applied treatments
+                </dt>
+                <dd className="text-base font-medium text-text-primary">
+                  {zone.health.appliedTreatments}
+                </dd>
+              </div>
+            </dl>
+            <div className="mt-4 space-y-2 text-xs text-text-muted">
+              {zone.health.reentryRestrictedUntilTick ? (
+                <p>
+                  Re-entry restricted until tick{' '}
+                  {zone.health.reentryRestrictedUntilTick.toLocaleString()}.
+                </p>
+              ) : null}
+              {zone.health.preHarvestRestrictedUntilTick ? (
+                <p>
+                  Pre-harvest restricted until tick{' '}
+                  {zone.health.preHarvestRestrictedUntilTick.toLocaleString()}.
+                </p>
+              ) : null}
+              {!zone.health.reentryRestrictedUntilTick &&
+              !zone.health.preHarvestRestrictedUntilTick ? (
+                <p>No active restrictions.</p>
+              ) : null}
+            </div>
+          </Panel>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ZoneDetail;


### PR DESCRIPTION
## Summary
- add DashboardOverview, ZoneDetail, PersonnelView, and FinancesView composed from existing components and store selectors
- implement finances chart and table visualizations using Recharts alongside zone and personnel layouts
- adjust the frontend ESLint config to import the typescript-eslint module via namespace to satisfy lint

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d14a14f36c83259905a14da26e624c