### PR TITLE
Refactor frontend simulation stores into focused Zustand hooks

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,7 +1,7 @@
-import { useAppStore } from '@/store';
+import { useGameStore } from '@/store';
 
 const App = () => {
-  const connectionStatus = useAppStore((state) => state.connectionStatus);
+  const connectionStatus = useGameStore((state) => state.connectionStatus);
 
   return (
     <main className="min-h-screen bg-background text-text-primary font-sans">

--- a/src/frontend/src/store/gameStore.ts
+++ b/src/frontend/src/store/gameStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import type {
+  SimulationControlCommand,
+  SimulationTickEvent,
+  SimulationUpdateEntry,
+} from '@/types/simulation';
+import { mergeEvents } from './utils/events';
+import type { GameStoreState } from './types';
+
+const MAX_EVENTS = 250;
+
+export const useGameStore = create<GameStoreState>()((set) => ({
+  connectionStatus: 'idle',
+  events: [],
+  setConnectionStatus: (status, errorMessage) =>
+    set((state) => ({
+      connectionStatus: status,
+      lastError: status === 'error' ? (errorMessage ?? state.lastError) : undefined,
+    })),
+  ingestUpdate: (update: SimulationUpdateEntry) =>
+    set((state) => ({
+      events: update.events.length
+        ? mergeEvents(state.events, update.events, MAX_EVENTS)
+        : state.events,
+      timeStatus: update.time,
+      lastSnapshotTick: update.snapshot.tick,
+      lastSnapshotTimestamp: update.ts,
+      lastClockSnapshot: update.snapshot.clock,
+    })),
+  appendEvents: (events) =>
+    set((state) => ({
+      events: events.length ? mergeEvents(state.events, events, MAX_EVENTS) : state.events,
+    })),
+  registerTickCompleted: (event: SimulationTickEvent) =>
+    set(() => ({
+      lastTickCompleted: event,
+    })),
+  setCommandHandlers: (control, config) =>
+    set(() => ({
+      sendControlCommand: control,
+      sendConfigUpdate: config,
+    })),
+  issueControlCommand: (command: SimulationControlCommand) =>
+    set((state) => {
+      state.sendControlCommand?.(command);
+      return {};
+    }),
+  requestTickLength: (minutes: number) =>
+    set((state) => {
+      state.sendConfigUpdate?.({ type: 'tickLength', minutes });
+      return { lastRequestedTickLength: minutes };
+    }),
+  reset: () =>
+    set(() => ({
+      events: [],
+      timeStatus: undefined,
+      lastTickCompleted: undefined,
+      lastSnapshotTick: undefined,
+      lastSnapshotTimestamp: undefined,
+      lastClockSnapshot: undefined,
+      lastRequestedTickLength: undefined,
+    })),
+  sendControlCommand: undefined,
+  sendConfigUpdate: undefined,
+}));

--- a/src/frontend/src/store/index.ts
+++ b/src/frontend/src/store/index.ts
@@ -1,14 +1,15 @@
 import { create } from 'zustand';
 import { createModalSlice } from './slices/modalSlice';
 import { createNavigationSlice } from './slices/navigationSlice';
-import { createSimulationSlice } from './slices/simulationSlice';
 import type { AppStoreState } from './types';
 
 export const useAppStore = create<AppStoreState>()((...args) => ({
-  ...createSimulationSlice(...args),
   ...createNavigationSlice(...args),
   ...createModalSlice(...args),
 }));
 
+export * from './gameStore';
+export * from './zoneStore';
+export * from './personnelStore';
 export * from './types';
 export * from './selectors';

--- a/src/frontend/src/store/personnelStore.ts
+++ b/src/frontend/src/store/personnelStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import type { SimulationUpdateEntry } from '@/types/simulation';
+import { mergeEvents } from './utils/events';
+import type { PersonnelStoreState } from './types';
+
+const MAX_HR_EVENTS = 200;
+
+const extractHrEvents = (update: SimulationUpdateEntry) => {
+  return update.events.filter((event) => event.type.startsWith('hr.'));
+};
+
+export const usePersonnelStore = create<PersonnelStoreState>()((set) => ({
+  personnel: undefined,
+  hrEvents: [],
+  ingestUpdate: (update: SimulationUpdateEntry) =>
+    set((state) => ({
+      personnel: update.snapshot.personnel,
+      hrEvents: (() => {
+        const hrEvents = extractHrEvents(update);
+        return hrEvents.length
+          ? mergeEvents(state.hrEvents, hrEvents, MAX_HR_EVENTS)
+          : state.hrEvents;
+      })(),
+    })),
+  recordHREvent: (event) =>
+    set((state) => ({
+      hrEvents: mergeEvents(state.hrEvents, [event], MAX_HR_EVENTS),
+    })),
+  reset: () =>
+    set(() => ({
+      personnel: undefined,
+      hrEvents: [],
+    })),
+}));

--- a/src/frontend/src/store/selectors.ts
+++ b/src/frontend/src/store/selectors.ts
@@ -1,84 +1,73 @@
-import type { AppStoreState } from './types';
+import type { GameStoreState, ZoneStoreState } from './types';
 
-export const selectFinanceSummary = (state: AppStoreState) => state.financeSummary;
+export const selectFinanceSummary = (state: ZoneStoreState) => state.financeSummary;
 
-export const selectCapital = (state: AppStoreState): number => {
+export const selectCapital = (state: ZoneStoreState): number => {
   return state.financeSummary?.cashOnHand ?? 0;
 };
 
-export const selectCumulativeYield = (state: AppStoreState): number => {
+export const selectCumulativeYield = (state: ZoneStoreState): number => {
   return Object.values(state.plants).reduce(
     (total, plant) => total + (plant.yieldDryGrams ?? 0),
     0,
   );
 };
 
-export const selectCurrentTick = (state: AppStoreState): number => {
-  return state.timeStatus?.tick ?? state.lastSnapshot?.tick ?? 0;
+export const selectCurrentTick = (state: GameStoreState): number => {
+  return state.timeStatus?.tick ?? state.lastSnapshotTick ?? 0;
 };
 
-export const selectTimeStatus = (state: AppStoreState) => state.timeStatus;
+export const selectTimeStatus = (state: GameStoreState) => state.timeStatus;
 
-export const selectLastTickEvent = (state: AppStoreState) => state.lastTickCompleted;
+export const selectLastTickEvent = (state: GameStoreState) => state.lastTickCompleted;
 
-export const selectIsPaused = (state: AppStoreState): boolean => {
+export const selectIsPaused = (state: GameStoreState): boolean => {
   if (state.timeStatus) {
     return Boolean(state.timeStatus.paused);
   }
-  if (state.lastSnapshot?.clock) {
-    return state.lastSnapshot.clock.isPaused;
+  if (state.lastClockSnapshot) {
+    return state.lastClockSnapshot.isPaused;
   }
   return true;
 };
 
-export const selectTargetTickRate = (state: AppStoreState): number => {
+export const selectTargetTickRate = (state: GameStoreState): number => {
   if (state.timeStatus) {
     return state.timeStatus.targetTickRate;
   }
-  if (state.lastSnapshot?.clock) {
-    return state.lastSnapshot.clock.targetTickRate;
+  if (state.lastClockSnapshot) {
+    return state.lastClockSnapshot.targetTickRate;
   }
   return 1;
 };
 
-export const selectCurrentSpeed = (state: AppStoreState): number => {
+export const selectCurrentSpeed = (state: GameStoreState): number => {
   if (state.timeStatus) {
     return state.timeStatus.speed;
   }
-  if (state.lastSnapshot?.clock) {
-    return state.lastSnapshot.clock.targetTickRate;
+  if (state.lastClockSnapshot) {
+    return state.lastClockSnapshot.targetTickRate;
   }
   return 1;
 };
 
-export const selectAlertEvents = (state: AppStoreState) => {
+export const selectAlertEvents = (state: GameStoreState) => {
   return state.events.filter((event) => event.severity === 'warning' || event.severity === 'error');
 };
 
-export const selectRecentEvents = (limit: number) => (state: AppStoreState) => {
+export const selectRecentEvents = (limit: number) => (state: GameStoreState) => {
   if (limit <= 0) {
     return [];
   }
   return state.events.slice(-limit).reverse();
 };
 
-export const selectAlertCount = (state: AppStoreState): number => {
+export const selectAlertCount = (state: GameStoreState): number => {
   return state.events.reduce((count, event) => {
     return count + (event.severity === 'warning' || event.severity === 'error' ? 1 : 0);
   }, 0);
 };
 
-export const selectSelectedStructure = (state: AppStoreState) => {
-  const structureId = state.selectedStructureId;
-  return structureId ? state.structures[structureId] : undefined;
-};
-
-export const selectSelectedRoom = (state: AppStoreState) => {
-  const roomId = state.selectedRoomId;
-  return roomId ? state.rooms[roomId] : undefined;
-};
-
-export const selectSelectedZone = (state: AppStoreState) => {
-  const zoneId = state.selectedZoneId;
+export const selectZoneById = (zoneId?: string) => (state: ZoneStoreState) => {
   return zoneId ? state.zones[zoneId] : undefined;
 };

--- a/src/frontend/src/store/slices/navigationSlice.ts
+++ b/src/frontend/src/store/slices/navigationSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand';
+import { useZoneStore } from '../zoneStore';
 import type { AppStoreState, NavigationSlice, NavigationView } from '../types';
 
 export const createNavigationSlice: StateCreator<AppStoreState, [], [], NavigationSlice> = (
@@ -57,7 +58,7 @@ export const createNavigationSlice: StateCreator<AppStoreState, [], [], Navigati
       if (!roomId) {
         return { selectedRoomId: undefined, selectedZoneId: undefined };
       }
-      const room = state.rooms[roomId];
+      const room = useZoneStore.getState().rooms[roomId];
       return {
         selectedStructureId: room?.structureId ?? state.selectedStructureId,
         selectedRoomId: roomId,
@@ -70,7 +71,7 @@ export const createNavigationSlice: StateCreator<AppStoreState, [], [], Navigati
       if (!zoneId) {
         return { selectedZoneId: undefined };
       }
-      const zone = state.zones[zoneId];
+      const zone = useZoneStore.getState().zones[zoneId];
       return {
         selectedStructureId: zone?.structureId ?? state.selectedStructureId,
         selectedRoomId: zone?.roomId ?? state.selectedRoomId,

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -56,48 +56,54 @@ export interface MaintenanceExpenseEntry {
   degradationMultiplier: number;
 }
 
-export interface SimulationSlice {
+export interface GameStoreState {
   connectionStatus: ConnectionStatus;
   lastError?: string;
-  lastSnapshot?: SimulationSnapshot;
+  events: SimulationEvent[];
+  timeStatus?: SimulationTimeStatus;
+  lastTickCompleted?: SimulationTickEvent;
+  lastSnapshotTick?: number;
   lastSnapshotTimestamp?: number;
+  lastClockSnapshot?: SimulationSnapshot['clock'];
+  lastRequestedTickLength?: number;
+  sendControlCommand?: (command: SimulationControlCommand) => void;
+  sendConfigUpdate?: (update: SimulationConfigUpdate) => void;
+  setConnectionStatus: (status: ConnectionStatus, errorMessage?: string) => void;
+  ingestUpdate: (update: SimulationUpdateEntry) => void;
+  appendEvents: (events: SimulationEvent[]) => void;
+  registerTickCompleted: (event: SimulationTickEvent) => void;
+  setCommandHandlers: (
+    control: (command: SimulationControlCommand) => void,
+    config: (update: SimulationConfigUpdate) => void,
+  ) => void;
+  issueControlCommand: (command: SimulationControlCommand) => void;
+  requestTickLength: (minutes: number) => void;
+  reset: () => void;
+}
+
+export interface ZoneStoreState {
   structures: Record<string, StructureSnapshot>;
   rooms: Record<string, RoomSnapshot>;
   zones: Record<string, ZoneSnapshot>;
   devices: Record<string, DeviceSnapshot>;
   plants: Record<string, PlantSnapshot>;
-  events: SimulationEvent[];
   timeline: SimulationTimelineEntry[];
-  lastTickCompleted?: SimulationTickEvent;
-  lastRequestedTickLength?: number;
-  lastSetpoints: Record<string, number | undefined>;
-  timeStatus?: SimulationTimeStatus;
-  personnel?: PersonnelSnapshot;
   financeSummary?: FinanceSummarySnapshot;
   financeHistory: FinanceTickEntry[];
-  hrEvents: SimulationEvent[];
-  setConnectionStatus: (status: ConnectionStatus, errorMessage?: string) => void;
-  ingestUpdate: (update: SimulationUpdateEntry) => void;
-  appendEvents: (events: SimulationEvent[]) => void;
-  recordFinanceTick: (entry: FinanceTickEntry) => void;
-  recordHREvent: (event: SimulationEvent) => void;
-  registerTickCompleted: (event: SimulationTickEvent) => void;
-  resetSimulation: () => void;
-  sendControlCommand?: (command: SimulationControlCommand) => void;
+  lastSnapshotTimestamp?: number;
+  lastSnapshotTick?: number;
+  lastSetpoints: Record<string, number | undefined>;
   sendConfigUpdate?: (update: SimulationConfigUpdate) => void;
   sendFacadeIntent?: (intent: FacadeIntentCommand) => void;
-  issueControlCommand: (command: SimulationControlCommand) => void;
-  requestTickLength: (minutes: number) => void;
+  ingestUpdate: (update: SimulationUpdateEntry) => void;
+  recordFinanceTick: (entry: FinanceTickEntry) => void;
+  setConfigHandler: (handler: (update: SimulationConfigUpdate) => void) => void;
+  setIntentHandler: (handler: (intent: FacadeIntentCommand) => void) => void;
   sendSetpoint: (
     zoneId: string,
     metric: 'temperature' | 'relativeHumidity' | 'co2' | 'ppfd' | 'vpd',
     value: number,
   ) => void;
-  setCommandHandlers: (
-    control: (command: SimulationControlCommand) => void,
-    config: (update: SimulationConfigUpdate) => void,
-  ) => void;
-  setIntentHandler: (handler: (intent: FacadeIntentCommand) => void) => void;
   issueFacadeIntent: (intent: FacadeIntentCommand) => void;
   updateStructureName: (structureId: string, name: string) => void;
   updateRoomName: (roomId: string, name: string) => void;
@@ -113,6 +119,15 @@ export interface SimulationSlice {
   harvestPlanting: (plantingId: string) => void;
   harvestPlantings: (plantingIds: string[]) => void;
   togglePlantingPlan: (zoneId: string, enabled: boolean) => void;
+  reset: () => void;
+}
+
+export interface PersonnelStoreState {
+  personnel?: PersonnelSnapshot;
+  hrEvents: SimulationEvent[];
+  ingestUpdate: (update: SimulationUpdateEntry) => void;
+  recordHREvent: (event: SimulationEvent) => void;
+  reset: () => void;
 }
 
 export interface NavigationSlice {
@@ -155,4 +170,4 @@ export interface ModalSlice {
   setWasRunningBeforeModal: (wasRunning: boolean) => void;
 }
 
-export type AppStoreState = SimulationSlice & NavigationSlice & ModalSlice;
+export type AppStoreState = NavigationSlice & ModalSlice;

--- a/src/frontend/src/store/utils/collections.ts
+++ b/src/frontend/src/store/utils/collections.ts
@@ -1,0 +1,14 @@
+export const truncate = <T>(items: T[], limit: number): T[] => {
+  if (items.length <= limit) {
+    return items;
+  }
+
+  return items.slice(items.length - limit);
+};
+
+export const indexById = <T extends { id: string }>(items: T[]): Record<string, T> => {
+  return items.reduce<Record<string, T>>((accumulator, item) => {
+    accumulator[item.id] = item;
+    return accumulator;
+  }, {});
+};

--- a/src/frontend/src/store/utils/events.ts
+++ b/src/frontend/src/store/utils/events.ts
@@ -1,0 +1,41 @@
+import type { SimulationEvent } from '@/types/simulation';
+
+const eventKey = (event: SimulationEvent): string => {
+  return [
+    event.type,
+    event.tick ?? 'na',
+    event.ts ?? 'na',
+    event.message ?? '',
+    event.deviceId ?? '',
+    event.plantId ?? '',
+    event.zoneId ?? '',
+  ].join('|');
+};
+
+export const mergeEvents = (
+  existing: SimulationEvent[],
+  incoming: SimulationEvent[],
+  limit: number,
+): SimulationEvent[] => {
+  if (!incoming.length) {
+    return existing;
+  }
+
+  const seen = new Set(existing.map(eventKey));
+  const merged = [...existing];
+
+  for (const event of incoming) {
+    const key = eventKey(event);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(event);
+  }
+
+  if (merged.length <= limit) {
+    return merged;
+  }
+
+  return merged.slice(merged.length - limit);
+};

--- a/src/frontend/src/views/DashboardOverview.tsx
+++ b/src/frontend/src/views/DashboardOverview.tsx
@@ -8,7 +8,8 @@ import {
   selectCurrentTick,
   selectCumulativeYield,
   selectTimeStatus,
-  useAppStore,
+  useGameStore,
+  useZoneStore,
 } from '@/store';
 
 const currencyFormatter = new Intl.NumberFormat('en-US', {
@@ -27,15 +28,15 @@ const percentageFormatter = new Intl.NumberFormat('en-US', {
 });
 
 const DashboardOverview = () => {
-  const timeStatus = useAppStore(selectTimeStatus);
-  const currentTick = useAppStore(selectCurrentTick);
-  const cashOnHand = useAppStore(selectCapital);
-  const cumulativeYield = useAppStore(selectCumulativeYield);
-  const alertCount = useAppStore(selectAlertCount);
-  const structures = useAppStore((state) => Object.values(state.structures));
-  const rooms = useAppStore((state) => Object.values(state.rooms));
-  const zones = useAppStore((state) => Object.values(state.zones));
-  const plants = useAppStore((state) => Object.values(state.plants));
+  const timeStatus = useGameStore(selectTimeStatus);
+  const currentTick = useGameStore(selectCurrentTick);
+  const alertCount = useGameStore(selectAlertCount);
+  const cashOnHand = useZoneStore(selectCapital);
+  const cumulativeYield = useZoneStore(selectCumulativeYield);
+  const structures = useZoneStore((state) => Object.values(state.structures));
+  const rooms = useZoneStore((state) => Object.values(state.rooms));
+  const zones = useZoneStore((state) => Object.values(state.zones));
+  const plants = useZoneStore((state) => Object.values(state.plants));
 
   const headerStatus =
     timeStatus === undefined

--- a/src/frontend/src/views/FinancesView.tsx
+++ b/src/frontend/src/views/FinancesView.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
-import { selectFinanceSummary, useAppStore } from '@/store';
+import { selectFinanceSummary, useZoneStore } from '@/store';
 import {
   Area,
   AreaChart,
@@ -25,8 +25,8 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
 const formatCurrency = (value: number | undefined) => currencyFormatter.format(value ?? 0);
 
 const FinancesView = () => {
-  const financeSummary = useAppStore(selectFinanceSummary);
-  const financeHistory = useAppStore((state) => state.financeHistory);
+  const financeSummary = useZoneStore(selectFinanceSummary);
+  const financeHistory = useZoneStore((state) => state.financeHistory);
 
   const chartData = useMemo(() => {
     return financeHistory.slice(-24).map((entry) => ({

--- a/src/frontend/src/views/PersonnelView.tsx
+++ b/src/frontend/src/views/PersonnelView.tsx
@@ -2,7 +2,7 @@ import Card from '@/components/Card';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
-import { useAppStore } from '@/store';
+import { usePersonnelStore } from '@/store';
 
 const percentageFormatter = new Intl.NumberFormat('en-US', {
   style: 'percent',
@@ -36,8 +36,8 @@ const resolveBarTone = (value: number) => {
 };
 
 const PersonnelView = () => {
-  const personnel = useAppStore((state) => state.personnel);
-  const hrEvents = useAppStore((state) => state.hrEvents.slice(-12).reverse());
+  const personnel = usePersonnelStore((state) => state.personnel);
+  const hrEvents = usePersonnelStore((state) => state.hrEvents.slice(-12).reverse());
 
   if (!personnel) {
     return (

--- a/src/frontend/src/views/ZoneDetail.tsx
+++ b/src/frontend/src/views/ZoneDetail.tsx
@@ -2,7 +2,13 @@ import Card from '@/components/Card';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
-import { selectCurrentTick, selectSelectedZone, useAppStore } from '@/store';
+import {
+  selectCurrentTick,
+  selectZoneById,
+  useAppStore,
+  useGameStore,
+  useZoneStore,
+} from '@/store';
 
 const percentageFormatter = new Intl.NumberFormat('en-US', {
   style: 'percent',
@@ -14,9 +20,10 @@ const numberFormatter = new Intl.NumberFormat('en-US', {
 });
 
 const ZoneDetail = () => {
-  const zone = useAppStore(selectSelectedZone);
-  const currentTick = useAppStore(selectCurrentTick);
-  const timeline = useAppStore((state) => state.timeline);
+  const selectedZoneId = useAppStore((state) => state.selectedZoneId);
+  const zone = useZoneStore(selectZoneById(selectedZoneId));
+  const currentTick = useGameStore(selectCurrentTick);
+  const timeline = useZoneStore((state) => state.timeline);
 
   if (!zone) {
     return (


### PR DESCRIPTION
## Summary
- introduce dedicated game, zone, and personnel Zustand stores to manage simulation state slices separately
- update shared store types, selectors, and navigation to align with the modular stores
- refactor simulation bridge and dashboard views to consume the new store hooks instead of the monolithic app store

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d14eae735883258d3b21940f596768