### PR TITLE
Fix validate-data CLI import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated ADR 0001 to reflect the accepted CommonJS-first TypeScript toolchain decision and documentation touchpoints.
+
+### Fixed
+
+- Corrected the validate-data CLI import path to target the actual data loader module location.

--- a/tools/validate-data.ts
+++ b/tools/validate-data.ts
@@ -8,7 +8,7 @@ import {
   DataLoaderError,
   type DataIssue,
   type DataLoadResult,
-} from '../src/backend/data/dataLoader.js';
+} from '../src/backend/src/data/dataLoader.js';
 
 interface CliArguments {
   dataDir: string;


### PR DESCRIPTION
## Summary
- point the validate-data CLI to the backend data loader's actual location so the module resolves
- note the correction in the changelog under the Unreleased Fixed section

## Testing
- pnpm exec tsx tools/validate-data.ts --help
- pnpm validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d1ef309f608325a9ce0f9616f36b44