### PR TITLE
docs: align workspace docs with esm toolchain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,24 +19,40 @@
 
 ## 1) Monorepo Layout (pnpm workspaces)
 
+- Root `pnpm-workspace.yaml` groups the backend and frontend packages alongside
+  shared libraries.
+- **Backend package:** `src/backend` (`@weebbreed/backend`). Source lives under
+  `src/backend/src`; build outputs are emitted to `src/backend/dist`. Scripts
+  run with the package directory as the working directory.
+- **Frontend package:** `src/frontend`. React + Vite application code resides in
+  `src/frontend/src`; production assets land in `src/frontend/dist`.
+- **Shared TypeScript modules:** `src/physio` (domain formulas) and
+  `src/runtime` (cross-cutting runtime helpers). These folders are consumed via
+  the `@/` and `@runtime/` path aliases exposed through the workspace
+  TypeScript configs.
+
 ## 2) Toolchain & Config (backend)
 
-- **Dev runner:** `tsx` (`tsx src/index.ts`) — **no experimental loaders**.
+- **Dev runner:** `tsx` (e.g., `pnpm --filter @weebbreed/backend dev`) — **no
+  experimental loaders**.
 - **Testing:** `vitest` (+ happy-dom or Node environment).
 - **Lint/format:** ESLint (TS) + Prettier.
 - **Path alias:** `@/*` → `./src/*` via `tsconfig.json` + `tsconfig.paths.json`.
+- **Build:** `tsup` bundles `src/index.ts` to an **ESM** artifact at
+  `dist/index.js` with sourcemaps. `pnpm start` executes `node dist/index.js`
+  under the package `type: module` contract.
 
-**`packages/backend/tsconfig.json` (minimal)**
+**`src/backend/tsconfig.json` (minimal)**
 
 ---
 
 ## 3) Toolchain & Config (frontend)
 
-- Vite React with TypeScript template.
+- Vite React with TypeScript template under `src/frontend`.
 - No CRA. Keep it lean. Use ESLint + Prettier aligned with backend.
 - Eventually we have to consider to usa a library like TailWind
 
-**`apps/frontend/package.json` (key scripts)**
+**`src/frontend/package.json` (key scripts)**
 
 ```json
 {
@@ -144,7 +160,7 @@ All randomness (pests/events/market) comes from here.
 ## 7) Definition of Done (DoD)
 
 - ✅ No usage of ts-node loaders; no `ExperimentalWarning` on startup.
-- ✅ `pnpm build` produces `packages/backend/dist/**` and `apps/frontend/dist/**`.
+- ✅ `pnpm build` produces `src/backend/dist/**` and `src/frontend/dist/**`.
 - ✅ Golden‑Master tests for physio modules green with tight tolerances.
 - ✅ Deterministic 200‑day run: same seed ⇒ identical summary metrics.
 - ✅ JSON blueprints conform to docs; naming rules respected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated ADR 0001 to reflect the accepted CommonJS-first TypeScript toolchain decision and documentation touchpoints.
+- Updated ADR 0001 to reflect the accepted `tsx` + `tsup` ESM backend toolchain
+  and documentation touchpoints.
+- Realigned workspace documentation and ADR 0001 with the `src/backend` and
+  `src/frontend` layout plus the ESM backend build output.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ while a React front end streams telemetry for real-time visualization.
 ## Architecture at a Glance
 
 - **Backend** – Deterministic simulation engine, schema validation, and
-  Socket.IO gateway housed under `packages/backend`.
-- **Frontend** – Vite + React dashboard in `apps/frontend` for live telemetry,
+  Socket.IO gateway housed under `src/backend`. The production build ships as an
+  ESM bundle at `dist/index.js` for direct execution on modern Node runtimes.
+- **Frontend** – Vite + React dashboard in `src/frontend` for live telemetry,
   controls, and analytics.
 - **Blueprint data** – Authoritative JSON bundles in `/data` define strains,
   devices, cultivation methods, and price tables per the data dictionary.


### PR DESCRIPTION
## Summary
- document the actual pnpm workspace layout under src/backend and src/frontend
- update README and ADR 0001 to capture the tsx dev flow and tsup ESM bundle
- refresh the changelog to record the documentation and ADR realignment

## Testing
- `pnpm exec prettier --check AGENTS.md README.md docs/system/adr/0001-typescript-toolchain.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68d1f00c20508325979535e6ebda5062