### PR TITLE
Align frontend simulation events with backend level property

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       vite:
         specifier: ^7.1.7
         version: 7.1.7(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.18.6)(jiti@1.21.7)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1)
 
 packages:
 
@@ -4304,6 +4307,14 @@ snapshots:
     optionalDependencies:
       vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
 
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.6(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -6730,6 +6741,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.7(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.1.6(@types/node@20.19.17)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
@@ -6740,6 +6772,21 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.17
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      tsx: 4.20.5
+      yaml: 2.8.1
+
+  vite@7.1.6(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.6
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.20.5
@@ -6802,6 +6849,48 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@22.18.6)(jiti@1.21.7)(jsdom@24.1.3)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.18.6)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.6
       jsdom: 24.1.3
     transitivePeerDependencies:
       - jiti

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.15.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/frontend/src/hooks/useSimulationBridge.ts
+++ b/src/frontend/src/hooks/useSimulationBridge.ts
@@ -70,7 +70,7 @@ const toSimulationEvent = (payload: unknown): SimulationEvent => {
 
   return {
     type: 'domain.untyped',
-    severity: 'debug',
+    level: 'debug',
     message: typeof payload === 'string' ? payload : JSON.stringify(payload),
   };
 };

--- a/src/frontend/src/i18n/locales/en/simulation.json
+++ b/src/frontend/src/i18n/locales/en/simulation.json
@@ -231,13 +231,13 @@
   "events": {
     "empty": "No events yet.",
     "columns": {
-      "severity": "Severity",
+      "level": "Level",
       "type": "Type",
       "message": "Message",
       "tick": "Tick",
       "timestamp": "Timestamp"
     },
-    "severity": {
+    "level": {
       "debug": "Debug",
       "info": "Info",
       "warning": "Warning",

--- a/src/frontend/src/store/selectors.test.ts
+++ b/src/frontend/src/store/selectors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { selectAlertCount, selectAlertEvents } from './selectors';
+import type { GameStoreState } from './types';
+import type { SimulationEvent } from '../types/simulation';
+
+const createState = (events: SimulationEvent[]): GameStoreState => ({
+  connectionStatus: 'idle',
+  events,
+  setConnectionStatus: vi.fn(),
+  ingestUpdate: vi.fn(),
+  appendEvents: vi.fn(),
+  registerTickCompleted: vi.fn(),
+  setCommandHandlers: vi.fn(),
+  issueControlCommand: vi.fn(),
+  requestTickLength: vi.fn(),
+  reset: vi.fn(),
+  sendControlCommand: undefined,
+  sendConfigUpdate: undefined,
+});
+
+describe('alert selectors', () => {
+  it('returns only warning and error events', () => {
+    const warningEvent: SimulationEvent = { type: 'zone.thresholdCrossed', level: 'warning' };
+    const errorEvent: SimulationEvent = { type: 'device.failed', level: 'error' };
+    const infoEvent: SimulationEvent = { type: 'sim.tickCompleted', level: 'info' };
+    const state = createState([warningEvent, infoEvent, errorEvent]);
+
+    expect(selectAlertEvents(state)).toEqual([warningEvent, errorEvent]);
+  });
+
+  it('counts warning and error events', () => {
+    const events: SimulationEvent[] = [
+      { type: 'zone.thresholdCrossed', level: 'warning' },
+      { type: 'device.failed', level: 'error' },
+      { type: 'sim.tickCompleted', level: 'info' },
+      { type: 'hr.hired', level: 'debug' },
+      { type: 'market.saleCompleted' },
+    ];
+    const state = createState(events);
+
+    expect(selectAlertCount(state)).toBe(2);
+  });
+});

--- a/src/frontend/src/store/selectors.ts
+++ b/src/frontend/src/store/selectors.ts
@@ -52,7 +52,7 @@ export const selectCurrentSpeed = (state: GameStoreState): number => {
 };
 
 export const selectAlertEvents = (state: GameStoreState) => {
-  return state.events.filter((event) => event.severity === 'warning' || event.severity === 'error');
+  return state.events.filter((event) => event.level === 'warning' || event.level === 'error');
 };
 
 export const selectRecentEvents = (limit: number) => (state: GameStoreState) => {
@@ -64,7 +64,7 @@ export const selectRecentEvents = (limit: number) => (state: GameStoreState) => 
 
 export const selectAlertCount = (state: GameStoreState): number => {
   return state.events.reduce((count, event) => {
-    return count + (event.severity === 'warning' || event.severity === 'error' ? 1 : 0);
+    return count + (event.level === 'warning' || event.level === 'error' ? 1 : 0);
   }, 0);
 };
 

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -210,7 +210,7 @@ export interface SimulationSnapshot {
 
 export interface SimulationEvent {
   type: string;
-  severity?: 'debug' | 'info' | 'warning' | 'error';
+  level?: 'debug' | 'info' | 'warning' | 'error';
   message?: string;
   tick?: number;
   ts?: number;


### PR DESCRIPTION
## Summary
- rename the `SimulationEvent` contract to expose the backend `level` field and update bridge fallback events accordingly
- switch alert selectors and localized labels to read `event.level` values
- add a vitest-based selector test to cover warning/error alerts and wire up the frontend test script

## Testing
- pnpm --filter frontend lint
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d1f2dec1b8832584cbe3a349731f04