### PR TITLE
Document frontend stack decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,20 +48,22 @@
 
 ## 3) Toolchain & Config (frontend)
 
-- Vite React with TypeScript template under `src/frontend`.
-- No CRA. Keep it lean. Use ESLint + Prettier aligned with backend.
-- Eventually we have to consider to usa a library like TailWind
+- React + Vite TypeScript app under `src/frontend`. No CRA. Keep the setup lean and
+  align ESLint/Prettier rules with the backend package.
+- Tailwind CSS is part of the standard UI stack. It is wired through
+  `index.css`, `postcss.config.js`, and `tailwind.config.js` with design tokens
+  exposed as CSS custom properties.
 
-**`src/frontend/package.json` (key scripts)**
+**`src/frontend/package.json` scripts**
 
 ```json
 {
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "format": "prettier --write ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "preview": "vite preview"
   }
 }
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Documentation Changelog
+
+## [Unreleased]
+
+### Added
+
+- Documented the adopted frontend stack (Tailwind, Zustand, Socket.IO bridge) in
+  [ADR 0002](system/adr/0002-frontend-realtime-stack.md) and updated the frontend
+  README to guide contributors.

--- a/docs/system/adr/0002-frontend-realtime-stack.md
+++ b/docs/system/adr/0002-frontend-realtime-stack.md
@@ -1,0 +1,70 @@
+# ADR 0002 — Frontend Real-Time Dashboard Stack
+
+- **Status:** Accepted (2025-02-17)
+- **Owner:** Simulation Platform
+- **Context:** Frontend dashboard
+
+## Context
+
+The dashboard needs to visualise live simulation ticks, accept control commands,
+and expose operational summaries without blocking future UI experiments. Earlier
+iterations relied on the default Vite template docs and ad-hoc styling guidance,
+leaving new contributors uncertain about the canonical state management pattern
+and the styling/tooling guarantees. We must document the frontend stack so teams
+can build features confidently and know which abstractions are stable.
+
+## Decision
+
+- Keep React + Vite as the application foundation, using the TypeScript entry
+  point under `src/frontend`.
+- Adopt [`socket.io-client`](https://socket.io/) with the bespoke
+  `useSimulationBridge` hook as the integration point to the simulation gateway.
+  The hook owns connection lifecycle, event fan-out, and exposes command helpers
+  to the stores.
+- Use [`zustand`](https://github.com/pmndrs/zustand) as the global state
+  container. Store slices are organised by domain (`game`, `zone`, `personnel`)
+  plus lightweight UI state (`useAppStore`), enabling selective subscription and
+  derived selectors.
+- Standardise Tailwind CSS as the styling layer, backed by CSS design tokens to
+  keep the look & feel consistent with the Weed Breed visual language.
+- Document the expected workspace scripts for the frontend package and link this
+  ADR from contributor-facing docs (`src/frontend/README.md`, docs changelog) so
+  the rationale stays visible.
+
+## Consequences
+
+- Contributors can rely on the Socket.IO bridge hook and Zustand stores as the
+  supported extension points for real-time data instead of rolling bespoke
+  wiring per view.
+- Styling guidance is now explicit: Tailwind + design tokens is the baseline,
+  which shortens onboarding and avoids drift toward inline styles or ad-hoc
+  component libraries.
+- Tests and linting integrate cleanly with the shared workspace scripts because
+  the documented commands match `package.json`.
+- Any future state management or styling swap must come with a new ADR because
+  the current approach is now an accepted decision.
+
+## Alternatives Considered
+
+1. **Keep React Context for global state.** Rejected because the volume of
+   real-time updates makes reducer/context solutions chatty and harder to
+   optimise compared with Zustand's selectors and store slices.
+2. **Adopt a component library instead of Tailwind.** Deferred: Tailwind paired
+   with design tokens provides enough velocity while allowing us to build bespoke
+   simulation widgets without fighting component overrides.
+3. **Use the raw Socket.IO client per component.** Rejected to avoid duplicated
+   connection logic and ensure consistent command routing back to the backend.
+
+## Rollback Plan
+
+If the combination of Tailwind, Zustand, or the Socket.IO bridge proves
+untenable:
+
+- Replace the bridge hook with a thinner wrapper around `socket.io-client`,
+  update stores to connect directly, and document the new responsibilities.
+- Swap Zustand for an alternative (e.g. Redux Toolkit) by introducing a parallel
+  store implementation, migrating consumers incrementally, and updating this ADR
+  once complete.
+- Substitute Tailwind with another styling approach by refactoring the build
+  pipeline (PostCSS/Vite config) and replacing utility classes in components.
+  Document the new baseline in both the ADR series and the frontend README.

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -1,12 +1,92 @@
-# React + Vite
+# Weed Breed Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This package contains the real-time dashboard that visualises the simulation
+loop exposed by the backend. The app is built with React + Vite and uses
+Zustand for state management, Tailwind CSS for rapid UI composition, and a
+Socket.IO bridge to ingest tick updates.
 
-Currently, two official plugins are available:
+## Development commands
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Run these from the repository root unless noted otherwise:
 
-## Expanding the ESLint configuration
+- `pnpm install` – install workspace dependencies.
+- `pnpm --filter frontend dev` – start the Vite dev server on
+  [http://localhost:5173](http://localhost:5173) and connect to the backend
+  Socket.IO gateway.
+- `pnpm --filter frontend build` – generate the production bundle in
+  `src/frontend/dist`.
+- `pnpm --filter frontend lint` – run ESLint across the frontend sources.
+- `pnpm --filter frontend test` – execute the Vitest suite.
+- `pnpm --filter frontend preview` – serve the production build locally for
+  smoke-testing.
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+The workspace-level scripts (e.g. `pnpm dev`) still work; they simply execute
+the same commands for both backend and frontend packages in parallel.
+
+## Simulation bridge (`useSimulationBridge`)
+
+`src/frontend/src/hooks/useSimulationBridge.ts` encapsulates the Socket.IO
+client lifecycle. The hook:
+
+- lazily creates the Socket.IO connection (auto-connect by default, with
+  optional manual control),
+- wires reconnection and status events into `useGameStore` so the UI can display
+  connectivity state and last error details,
+- fans out `simulationUpdate` payloads into the specialised stores:
+  - `useGameStore` captures raw events, time metadata, and exposes handlers for
+    issuing `simulationControl` and `config.update` commands back to the
+    backend,
+  - `useZoneStore` normalises zone/room/structure snapshots, maintains rolling
+    timelines and finance history, and stores the latest setpoints,
+  - `usePersonnelStore` aggregates HR roster changes and domain events.
+- exposes helper methods (`sendControlCommand`, `sendConfigUpdate`,
+  `sendFacadeIntent`) that store slices call when the UI triggers actions, and
+- provides a `subscribe` helper so features can hook into additional socket
+  channels without re-implementing connection management.
+
+The bridge also performs light domain-specific shaping (e.g. mapping finance
+payloads, splitting HR events) so components can consume ready-to-render data.
+
+## State management with Zustand
+
+State is split into targeted stores under `src/frontend/src/store/`:
+
+- `gameStore.ts` tracks connection status, tick metadata, and the rolling domain
+  event buffer. It also stores the socket command handlers injected by the
+  bridge so UI elements can issue control/config updates via `issueControlCommand`
+  and `requestTickLength`.
+- `zoneStore.ts` keeps normalised structures, rooms, zones, devices, and plant
+  records. It builds compact time-series timelines and finance histories from
+  each tick. Handlers for zone config changes and facade intents live here so
+  view components can submit updates.
+- `personnelStore.ts` records employees, open positions, and HR-specific events.
+- `index.ts` exposes `useAppStore`, which merges UI-only slices (`navigation`,
+  `modal`, etc.) alongside re-exports of the domain stores and typed selectors.
+
+Selectors in `selectors.ts` (with tests in `selectors.test.ts`) provide derived
+views over the normalised data to keep components minimal.
+
+## Styling with Tailwind
+
+Tailwind CSS is baked into the build via `postcss.config.js` and
+`tailwind.config.js`. The theme extends Tailwind tokens to read from the design
+system variables declared in `src/frontend/src/styles/designTokens.css`. The
+global stylesheet (`src/frontend/src/index.css`) imports the tokens, applies the
+Tailwind layers, and sets the base typography/background for the dashboard.
+
+Components combine Tailwind utility classes with semantic CSS variables, giving
+us consistent spacing/typography while still enabling custom layout or data-viz
+styling when needed.
+
+## Project layout
+
+Key directories to explore:
+
+- `src/components/` – reusable UI widgets (forms, panels, charts).
+- `src/views/` – page-level compositions that stitch together components and
+  store selectors.
+- `src/providers/` – React context providers (theme, i18n, etc.).
+- `src/types/` – shared TypeScript contracts for simulation payloads.
+
+Refer to the ADRs in `docs/system/adr/` (see ADR 0002) for the motivation behind
+the chosen frontend stack.


### PR DESCRIPTION
## Summary
- refresh the AGENTS frontend toolchain section with the real scripts and note Tailwind as part of the default stack
- replace the frontend README with guidance on the Socket.IO bridge, Zustand stores, Tailwind usage, and workspace commands
- add ADR 0002 capturing the adopted frontend stack and link it from the docs changelog

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d1f4e0cc388325b7848d666cec3180