### PR TITLE
docs: document facade intent envelope and duplication workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,30 @@ export function vpdProxy(T: number, RH: number, Tbase = 10): number {
 Provide `lib/rng.ts` with `createRng(seed: string, streamId?: string)`.
 All randomness (pests/events/market) comes from here.
 
+### 4.6 Facade Intent Catalog & Command Routing
+
+- **Modular registry.** `SimulationFacade` owns a domain registry built via
+  `registerDomain(domain, commands)`. Each domain maps actions to Zod schemas
+  and service handlers; Socket.IO clients issue `facade.intent` payloads with
+  `{ domain, action, payload?, requestId? }`.
+- **Result channels.** Responses for façade intents are emitted on
+  `<domain>.intent.result` and mirror the `CommandResult` shape
+  (`{ ok, data?, warnings?, errors? }`). Validation failures always return
+  `ERR_VALIDATION` with a dotted `path` back to the offending field.
+- **World intents** (beyond the original CRUD):
+  `renameStructure`, `deleteStructure`, `duplicateStructure`, `duplicateRoom`,
+  `duplicateZone` — all accept optional `name` overrides where applicable.
+- **Device intents** include `toggleDeviceGroup` (batch enable/disable by
+  domain/kind) alongside `installDevice`, `updateDevice`, `moveDevice`,
+  `removeDevice`.
+- **Plant intents** include `togglePlantingPlan` (automation enable/disable)
+  plus `addPlanting`, `cullPlanting`, `harvestPlanting`, `applyIrrigation`,
+  `applyFertilizer`.
+- **Future extensions.** When adding a domain/action, register it through the
+  façade builders, export the typed intent, and document it under
+  `/docs/system` + `/docs/tasks`. Keep Socket docs in sync so UI teams can
+  adopt new actions without spelunking through code.
+
 ---
 
 ## 5) Developer Ergonomics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduced the changelog to capture noteworthy changes for upcoming releases.
+- Recorded ADR 0003 describing the façade messaging overhaul and modular intent registry.
 
 ### Changed
 
@@ -17,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and documentation touchpoints.
 - Realigned workspace documentation and ADR 0001 with the `src/backend` and
   `src/frontend` layout plus the ESM backend build output.
+- Refreshed AGENTS.md, socket protocol, façade, and UI interaction docs to cover
+  `facade.intent`, duplication workflows, structure rename support, and
+  automation toggles.
 
 ### Fixed
 

--- a/docs/system/adr/0003-facade-messaging-overhaul.md
+++ b/docs/system/adr/0003-facade-messaging-overhaul.md
@@ -1,0 +1,71 @@
+# ADR 0003 — Facade Messaging Overhaul
+
+- **Status:** Accepted (2025-09-23)
+- **Owner:** Simulation Platform
+- **Context:** Backend facade & transport gateways
+
+## Context
+
+Frontend stores were emitting intents such as `world.duplicateRoom`,
+`devices.toggleDeviceGroup`, and `plants.togglePlantingPlan`, but the backend
+facade only exposed the legacy CRUD surface. Socket commands were scattered
+across bespoke handlers and the documentation still described the pre-facade
+command set, leaving UI teams to guess which actions were safe. The gap meant
+that duplication workflows and automation toggles silently failed even though
+the UI exposed them. We needed a unified contract that the backend, socket
+layer, and documentation could share.
+
+## Decision
+
+- Introduce a modular intent registry inside `SimulationFacade`. Domains such as
+  `world`, `devices`, and `plants` register actions with a `{ schema, handler }`
+  pair so validation, execution, and cataloguing live together.
+- Generalise the Socket.IO command surface behind a single
+  `facade.intent` envelope (`{ domain, action, payload?, requestId? }`).
+  Responses are emitted on `<domain>.intent.result` and follow
+  `CommandResult<T>`.
+- Expand the façade to cover the missing workflows:
+  - World: `renameStructure`, `deleteStructure`, `duplicateStructure`,
+    `duplicateRoom`, `duplicateZone` (optional name overrides, new IDs returned).
+  - Devices: `toggleDeviceGroup` returning affected `deviceIds`.
+  - Plants: `togglePlantingPlan` returning `{ enabled }`.
+- Update the socket protocol, façade reference docs, and UI interaction spec so
+  duplication flows, structure renames, and automation toggles are captured as
+  first-class, supported actions.
+
+## Consequences
+
+- UI teams now have an authoritative catalogue of façade intents and matching
+  documentation; Socket clients only need to learn one envelope instead of
+  bespoke events per command.
+- New domains/actions can be added by registering them with the façade builders,
+  guaranteeing schema validation and catalogue updates without touching the
+  gateway.
+- Automated workflows (duplication, group toggles, planting plan automation) now
+  return structured data, enabling optimistic UI updates and easier testing.
+- Documentation drift is reduced because ADRs and protocol references are tied
+  directly to the registry.
+
+## Alternatives Considered
+
+1. **Add ad-hoc socket events per workflow.** Rejected because each new command
+   would need bespoke validation and documentation; the catalogue would still be
+   fragmented across files.
+2. **Expose engine services directly over the socket.** Rejected to avoid
+   leaking internal state mutations and to preserve the façade’s invariants
+   (determinism, validation, atomic commits).
+3. **Keep the legacy CRUD surface and emulate missing workflows in the UI.**
+   Rejected because cloning/automation logic belongs in the engine, not the
+   client, and it would break determinism.
+
+## Rollback Plan
+
+If the unified `facade.intent` envelope blocks critical flows:
+
+- Re-enable the previous discrete socket events (`simulationControl`,
+  bespoke duplication handlers) while keeping the registry for validation.
+- Update the UI bridge to call the legacy events and mark the registry-backed
+  domains as experimental until parity is restored.
+- As a last resort, revert to commit prior to the registry introduction and
+  restore the CRUD-only façade methods while keeping this ADR in “superseded”
+  state for auditability.

--- a/docs/system/ui_archictecture.md
+++ b/docs/system/ui_archictecture.md
@@ -3,9 +3,11 @@
 _A tech‑agnostic overview of the UI and its architecture, aligned with the System Facade, Data Dictionary (DD), and Technical Design Document (TDD). The UI is intentionally logic‑free: it renders **snapshots** and turns user gestures into **facade commands**. All entity references use `id` (UUID v4)._
 
 ---
+
 ## 1) Core Philosophy — “Dumb” UI, Smart Engine
 
 **Separation of concerns.** The UI contains **no game logic**. It:
+
 - renders a **read‑only snapshot** of the authoritative state; and
 - converts user intent into **facade commands** (see System Facade).
 
@@ -16,31 +18,33 @@ _A tech‑agnostic overview of the UI and its architecture, aligned with the Sys
 **Single bridge.** All interactions go through the **System Facade**. The UI never mutates deep objects directly and never dereferences beyond documented read models.
 
 ---
+
 ## 2) Unidirectional Dataflow (Render → Act → Apply → Notify → Re‑render)
 
 1. **Render (read)**  
-    The UI receives a **read‑only Snapshot** of the Game State. Components render from snapshot fields (e.g., `snapshot.company.capital`).
+   The UI receives a **read‑only Snapshot** of the Game State. Components render from snapshot fields (e.g., `snapshot.company.capital`).
 2. **User Action (intent)**  
-    A user presses “Add Room”, “Install Device”, “Hire”, etc.
+   A user presses “Add Room”, “Install Device”, “Hire”, etc.
 3. **Command (through the Facade)**  
-    Event handlers call a **facade intent**, e.g.:
-    - `facade.createRoom(structureId, { name, purpose, area_m2, height_m })`
-    - `facade.installDevice(targetZoneId, deviceId, settings)`
-    - `facade.addPlanting(zoneId, { strainId, count })`
-    - `facade.applyTreatment(zoneId, optionId)`  
-        All parameters use **UUID `id`** for cross‑refs. The UI does not compute business rules.
+   Event handlers call a **facade intent**, e.g.:
+   - `facade.world.createRoom({ structureId, room: { name, purpose, area, height? } })`
+   - `facade.devices.installDevice({ targetId: targetZoneId, deviceId, settings })`
+   - `facade.plants.addPlanting({ zoneId, strainId, count })`
+   - `facade.health.applyTreatment({ zoneId, optionId })`
+     All parameters use **UUID `id`** for cross‑refs. The UI does not compute business rules.
 4. **Logic (engine)**  
-    The Facade validates, routes, and the engine applies rules: geometry checks, `allowedRoomPurposes`, treatment **reentryIntervalTicks**/PHI, costs, task generation, etc.
+   The Facade validates, routes, and the engine applies rules: geometry checks, `allowedRoomPurposes`, treatment **reentryIntervalTicks**/PHI, costs, task generation, etc.
 5. **State Update (commit)**  
-    The engine commits a new authoritative state. A **fresh snapshot** is produced.
+   The engine commits a new authoritative state. A **fresh snapshot** is produced.
 6. **Notification (events)**  
-    The Facade emits batched events (`sim.tickCompleted`, `world.zoneCreated`, `task.created`, `plant.harvested`, …) that reference entity UUIDs only.
+   The Facade emits batched events (`sim.tickCompleted`, `world.zoneCreated`, `task.created`, `plant.harvested`, …) that reference entity UUIDs only.
 7. **Re‑render (subscribe)**  
-    The UI’s subscription receives the new snapshot and re‑renders affected components.
+   The UI’s subscription receives the new snapshot and re‑renders affected components.
 
 This cycle enforces **one‑way dataflow**, making behavior predictable and debuggable.
 
 ---
+
 ## 3) Technical Building Blocks (UI layer)
 
 > The names below are illustrative. Any framework can be used; a React mapping is provided where helpful.
@@ -48,22 +52,27 @@ This cycle enforces **one‑way dataflow**, making behavior predictable and debu
 ### 3.1 Bridge Hook (UI ↔ Facade)
 
 **Purpose.** The single gateway for the UI to:
+
 - subscribe to **snapshots** and **events**; and
 - expose stable **command callbacks**.
 
 **Behavior.** On mount it subscribes to Facade events (`sim.ready`, `sim.tickCompleted`, `sim.paused`, `sim.hotReloaded`). On event, it swaps in the latest **Snapshot**. It memoizes command functions (e.g., `createRoom`, `installDevice`, `addPlanting`) so children don’t re‑render unnecessarily.
+
 ### 3.2 Application Orchestrator
 
 **Purpose.** Root composition that wires providers and high‑level views.  
 **Behavior.**
+
 - Requests the initial snapshot (or waits for `sim.ready`).
 - Provides **navigation state**, **modal state**, and **theme** to the tree.
 - Passes **snapshot** + **command callbacks** down as props/context.
+
 ### 3.3 Navigation Manager
 
 **Purpose.** Centralized routing between top‑level views and selected entities.  
 **State.** `{ currentView, selectedStructureId?, selectedRoomId?, selectedZoneId? }`.  
 **API.** `goTo(view, params)`, `selectEntity({ structureId?, roomId?, zoneId? })`, `back()`, `home()`.
+
 ### 3.4 Modal Manager (Input Workflows)
 
 **Purpose.** Unified control of dialogs/wizards (rent structure, add room/zone, install device, hire, treatments).  
@@ -73,6 +82,7 @@ This cycle enforces **one‑way dataflow**, making behavior predictable and debu
 
 - **Views**: page‑scale screens (e.g., `FinancesView`, `PersonnelView`, `ZoneDetail`, `StructuresOverview`), composed of many components, consume snapshots & callbacks.
 - **Components**: reusable building blocks (e.g., cards, tables, charts, `SkillBar`, `DeviceList`, `TreatmentPlanner`).
+
 ### 3.6 Styling & Theming
 
 - **Design tokens** (CSS variables): colors, spacing, typography under `:root` for quick theme changes.
@@ -80,6 +90,7 @@ This cycle enforces **one‑way dataflow**, making behavior predictable and debu
 - **Accessibility**: color contrast, keyboard nav, ARIA roles for all interactive elements.
 
 ---
+
 ## 4) Read Models & Identity in the UI
 
 - The UI reads only what it needs: **derived/projection selectors** (e.g., list of zones with current PPFD/CO₂, active tasks per structure, cost summaries).
@@ -87,33 +98,43 @@ This cycle enforces **one‑way dataflow**, making behavior predictable and debu
 - **Lineage** is displayed by resolving `strain.lineage.parents[]` (UUIDs) to names through snapshot lookups.
 
 ---
+
 ## 5) Command Usage Patterns (UI)
 
 **World building**
-- Add room → `createRoom(structureId, { name, purpose, area_m2, height_m })`
-- Add zone → `createZone(roomId, { name, area_m2, methodId })`
-- Install device → `installDevice(targetId, deviceId, settings)` (Facade rejects if `allowedRoomPurposes` violate.)
+
+- Add room → `facade.world.createRoom({ structureId, room: { name, purpose, area, height? } })`
+- Add zone → `facade.world.createZone({ roomId, zone: { name, area, methodId, targetPlantCount? } })`
+- Install device → `facade.devices.installDevice({ targetId, deviceId, settings })` (Facade rejects if `allowedRoomPurposes` violate.)
+- Duplicate → `facade.world.duplicateRoom({ roomId, name? })`, `facade.world.duplicateZone({ zoneId, name? })`, or `facade.world.duplicateStructure({ structureId, name? })`
 
 **Cultivation**
-- Start planting → `addPlanting(zoneId, { strainId, count })`
-- Harvest → `harvestPlanting(plantingId)`
-- Apply treatment → `applyTreatment(zoneId, optionId)` (Enforces **reentryIntervalTicks**/PHI.)
+
+- Start planting → `facade.plants.addPlanting({ zoneId, strainId, count })`
+- Harvest → `facade.plants.harvestPlanting({ plantingId })`
+- Apply treatment → `facade.health.applyTreatment({ zoneId, optionId })` (Enforces **reentryIntervalTicks**/PHI.)
+- Toggle planting plan → `facade.plants.togglePlantingPlan({ zoneId, enabled })`
 
 **Personnel & tasks**
-- Refresh candidates → `refreshCandidates()` (seeded, with offline fallback)
-- Hire/fire → `hire(candidateId, role, wage?)` / `fire(employeeId)`
-- Overtime policy → `setOvertimePolicy({ policy, multiplier? })`
+
+- Refresh candidates → `facade.workforce.refreshCandidates()` (seeded, with offline fallback)
+- Hire/fire → `facade.workforce.hire({ candidateId, role, wage? })` / `facade.workforce.fire({ employeeId })`
+- Overtime policy → `facade.workforce.setOvertimePolicy({ policy, multiplier? })`
 
 **Finance**
-- Sell lots → `sellInventory(lotId, grams)`
-- Adjust utilities → `setUtilityPrices({ electricityCostPerKWh, waterCostPerM3, nutrientsCostPerKg })`
+
+- Sell lots → `facade.finance.sellInventory({ lotId, grams })`
+- Adjust utilities → `facade.finance.setUtilityPrices({ electricityCostPerKWh?, waterCostPerM3?, nutrientsCostPerKg? })`
+- Maintenance policy → `facade.finance.setMaintenancePolicy({ strategy?, multiplier? })`
 
 All commands return `{ ok, warnings?, errors? }`; UI displays inline validation/notifications.
 
 ---
+
 ## 6) Event Consumption
 
 UI subscribes to Facade events and reacts via toasts, banners, and local updates:
+
 - **Simulation**: `sim.tickCompleted`, `sim.paused/resumed`, `sim.hotReloaded/reloadFailed`.
 - **World**: `world.structureRented`, `world.roomCreated`, `world.zoneCreated`, `world.deviceInstalled`.
 - **Plants/Health**: `plant.stageChanged`, `plant.harvested`, `pest.detected`, `treatment.applied`.
@@ -123,6 +144,7 @@ UI subscribes to Facade events and reacts via toasts, banners, and local updates
 Event payloads contain minimal fields + UUIDs; the UI **looks up details** in the snapshot.
 
 ---
+
 ## 7) Performance & Robustness
 
 - **Memoized selectors** for derived views (e.g., KPIs).
@@ -131,6 +153,7 @@ Event payloads contain minimal fields + UUIDs; the UI **looks up details** in th
 - **Error surfaces**: show validation errors from Facade; never try to "fix" state client‑side.
 
 ---
+
 ## 8) Anti‑Patterns (explicitly disallowed)
 
 - Computing business logic in the UI (e.g., pricing, growth, environment deltas).
@@ -139,6 +162,7 @@ Event payloads contain minimal fields + UUIDs; the UI **looks up details** in th
 - Emitting large object graphs in events; always fetch via snapshot.
 
 ---
+
 ## 9) Optional React Mapping (for teams using React)
 
 - **Bridge Hook** ≈ `useGameState()` that returns `{ snapshot, events, actions }` (memoized `useCallback`s wrapping Facade commands).

--- a/docs/system/ui_interactions_spec.md
+++ b/docs/system/ui_interactions_spec.md
@@ -3,6 +3,7 @@
 _A comprehensive, façade‑aligned description of user interactions, views, modals, and components. Tech‑agnostic by contract; React names below are **illustrative** only. All mutations go through the **System Facade**; all references use **`id` (UUID v4)**; economics are **currency‑neutral**; data and policies follow the **DD/TDD**._
 
 ---
+
 ## 1) Overview of Implemented User Interactions
 
 The interface is hierarchical and supports a strategic (macro) and operational (micro) loop. The UI renders **read‑only snapshots** and issues **facade commands**; it contains **no game logic**.
@@ -10,67 +11,70 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 ### A. Game Lifecycle & Setup
 
 - **Start a Game**  
-    From _StartScreen_, users can:
-    - **New Game**: provide company name and optional seed → `facade.newGame({ name, seed? })`.
-    - **Load Game**: select a prior snapshot → `facade.load(snapshot)`.
-    - **Import Game**: load from a JSON snapshot → `facade.importState(json)`.
+   From _StartScreen_, users can:
+  - **New Game**: provide company name and optional seed → `facade.newGame({ name, seed? })`.
+  - **Load Game**: select a prior snapshot → `facade.load(snapshot)`.
+  - **Import Game**: load from a JSON snapshot → `facade.importState(json)`.
 - **Saving/Loading**  
-    At any time via global menu:
-    - **Save** → `facade.save()` (named entry in client storage) and optional `facade.exportState()` for a portable JSON.
-    - **Load/Delete Slot** → `facade.load(snapshot)` / remove stored entry (client concern).
+   At any time via global menu:
+  - **Save** → `facade.save()` (named entry in client storage) and optional `facade.exportState()` for a portable JSON.
+  - **Load/Delete Slot** → `facade.load(snapshot)` / remove stored entry (client concern).
 - **Reset**  
-    Clear current run and stored entries; upon confirmation start fresh via `newGame`.
+   Clear current run and stored entries; upon confirmation start fresh via `newGame`.
 
 ### B. Infrastructure Management (Macro Loop)
 
-- **Rent Structures**  
-    From _Structures_ view: `facade.rentStructure(structureId)`; façade validates availability and applies fixed costs.
+- **Rent Structures**
+  From _Structures_ view: `facade.world.rentStructure({ structureId })`; façade validates availability and applies fixed costs.
 - **Drill‑Down Navigation**  
-    Structure → Rooms → Zones; breadcrumb navigation updates selected `{ structureId, roomId, zoneId }`.
+   Structure → Rooms → Zones; breadcrumb navigation updates selected `{ structureId, roomId, zoneId }`.
 - **Create & Manage Rooms/Zones**
-    - Room: `facade.createRoom(structureId, { name, purpose, area_m2, height_m? })` (purpose validated).
-    - Zone: `facade.createZone(roomId, { name, area_m2, methodId })`.
-    - Rename/Delete via generic modals → `update*`/`delete*` intents.
-- **Duplicate Room/Zone**  
-    One‑click duplication creates a copy of geometry and zone configuration; required devices are purchased per price maps and **installed only if `allowedRoomPurposes`** permit. Costs are currency‑neutral.
+  - Room: `facade.world.createRoom({ structureId, room: { name, purpose, area, height? } })` (purpose validated).
+  - Zone: `facade.world.createZone({ roomId, zone: { name, area, methodId, targetPlantCount? } })`.
+  - Rename/Delete via modals → `facade.world.renameStructure({ structureId, name })`, `facade.world.updateRoom({ roomId, patch })`, `facade.world.deleteZone({ zoneId })`, etc.
+- **Duplicate Structure/Room/Zone**
+  Quick actions call `facade.world.duplicateStructure({ structureId, name? })`, `facade.world.duplicateRoom({ roomId, name? })`, or `facade.world.duplicateZone({ zoneId, name? })`. Geometry, cultivation methods, automation plans, and eligible devices are cloned; pricing honours the existing CapEx rules and only installs blueprinted devices that pass `allowedRoomPurposes`.
+
 ### C. Cultivation & Zone Management (Micro Loop)
 
-- **Equip Zones**  
-    In _ZoneDetail_ users install devices and buy supplies:
-    - Devices → `facade.installDevice(targetId, deviceId, settings?)` (placement checks against `allowedRoomPurposes`).
-    - Supplies → `facade.applyIrrigation(zoneId, liters)` / fertilizer by grams `{ N,P,K }` (optional manual overrides in addition to automation).
-    - **Sufficiency Preview** shows estimated PPFD/DLI or climate coverage from device specs (`ppf_umol_s`, `coverage_m2`, airflow) vs. strain `ppfdTarget` and zone area.
+- **Equip Zones**
+  In _ZoneDetail_ users install devices and buy supplies:
+  - Devices → `facade.devices.installDevice({ targetId, deviceId, settings })` (placement checks against `allowedRoomPurposes`).
+    - Supplies → `facade.plants.applyIrrigation({ zoneId, liters })` / fertilizer by grams `{ N,P,K }` via `facade.plants.applyFertilizer({ zoneId, nutrients })` (optional manual overrides in addition to automation).
+  - **Sufficiency Preview** shows estimated PPFD/DLI or climate coverage from device specs (`ppf_umol_s`, `coverage_m2`, airflow) vs. strain `ppfdTarget` and zone area.
 - **Planting**  
-    Select strain and quantity → `facade.addPlanting(zoneId, { strainId, count })`. UI warns if exceeding capacity from cultivation method (`areaPerPlant`) or if method/strain hints conflict (qualitative `environmentalPreferences`).
-- **Environment Control**  
-    Batch‑edit device groups: e.g., set `targetTemperature` (with implicit `targetTemperatureRange` hysteresis), or change lighting cycle for the zone. Commands route through `updateDevice` or zone policy intents.
+   Select strain and quantity → `facade.plants.addPlanting({ zoneId, strainId, count })`. UI warns if exceeding capacity from cultivation method (`areaPerPlant`) or if method/strain hints conflict (qualitative `environmentalPreferences`).
+- **Environment Control**
+  Batch‑edit device groups: e.g., toggle HVAC banks via `facade.devices.toggleDeviceGroup({ zoneId, kind, enabled })`, adjust settings with `facade.devices.updateDevice({ instanceId, settings })`, or change lighting cycle for the zone. Commands route through façade intents so automation remains deterministic.
 - **Monitoring**  
-    Real‑time panels show `temperature_C`, `humidity` (0–1), `co2_ppm`, PPFD/DLI, water/nutrient stocks, and active safety constraints (e.g., `reentryIntervalTicks`).
+   Real‑time panels show `temperature_C`, `humidity` (0–1), `co2_ppm`, PPFD/DLI, water/nutrient stocks, and active safety constraints (e.g., `reentryIntervalTicks`).
 - **Harvesting**  
-    Harvest per planting or _Harvest All_ in a zone → `facade.harvestPlanting(plantingId)` (creates inventory lots; revenue occurs on sale events).
-- **Automation**  
-    _Planting Plan_: define default `strainId` and `count`; with **Auto‑Replant**, after harvest/cleaning the engine enqueues tasks automatically.
+   Harvest per planting or _Harvest All_ in a zone → `facade.plants.harvestPlanting({ plantingId })` (creates inventory lots; revenue occurs on sale events).
+- **Automation**
+  _Planting Plan_: define default `strainId` and `count`; the Auto‑Replant toggle maps to `facade.plants.togglePlantingPlan({ zoneId, enabled })`. After harvest/cleaning the engine enqueues tasks automatically when enabled and emits maintenance events.
 
 ### D. Personnel Management
 
 - **Hiring**  
-    In _Job Market_: review candidates; hire into a structure → `facade.hire(candidateId, role, wage?)`. Candidate refresh uses a seeded provider with offline fallback (per DD/TDD).
+   In _Job Market_: review candidates; hire into a structure → `facade.workforce.hire({ candidateId, role, wage? })`. Candidate refresh uses a seeded provider with offline fallback (per DD/TDD).
 - **Managing Staff**  
-    _Your Staff_ lists employees; assign role/structure → `facade.assignStructure(employeeId, structureId?)`; fire via `facade.fire(employeeId)`.
+   _Your Staff_ lists employees; assign role/structure → `facade.workforce.assignStructure({ employeeId, structureId })`; fire via `facade.workforce.fire({ employeeId })`.
 - **Salary Negotiation**  
-    Alerts surface raise requests; modal offers accept/decline/bonus. Accepted raises patch wage; decline risks morale drop (engine computes effects).
+   Alerts surface raise requests; modal offers accept/decline/bonus. Accepted raises patch wage; decline risks morale drop (engine computes effects).
 - **Policy Setting**  
-    Company‑wide overtime policy → `facade.setOvertimePolicy({ policy: 'payout'|'timeOff', multiplier? })`.
+   Company‑wide overtime policy → `facade.workforce.setOvertimePolicy({ policy: 'payout'|'timeOff', multiplier? })`.
+
 ### E. Financial & Strategic Overview
 
 - **Dashboard**  
-    At‑a‑glance KPIs (Capital, Cumulative Yield, Date/Time), sim controls (play/pause/speed), and alerts. Clicking an alert deep‑links to the relevant view (structure/room/zone/personnel).
+   At‑a‑glance KPIs (Capital, Cumulative Yield, Date/Time), sim controls (play/pause/speed), and alerts. Clicking an alert deep‑links to the relevant view (structure/room/zone/personnel).
 - **Finances View**  
-    Detailed breakdown of revenue/expenses (CapEx/OpEx, utilities, labor, maintenance) from façade reports (`finance.tick`).
+   Detailed breakdown of revenue/expenses (CapEx/OpEx, utilities, labor, maintenance) from façade reports (`finance.tick`).
 - **Alerts System**  
-    Notifications for low supplies, harvest‑ready, device failures, raise requests, PHI/re‑entry gates. Payloads contain **UUIDs**; UI resolves names from the snapshot.
+   Notifications for low supplies, harvest‑ready, device failures, raise requests, PHI/re‑entry gates. Payloads contain **UUIDs**; UI resolves names from the snapshot.
 
 ---
+
 ## 2) Technical UI Component Breakdown (illustrative)
 
 > Names are examples for teams using React. The architecture is façade‑first and remains valid with any UI stack.
@@ -78,82 +82,92 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 ### A. Core Application Structure
 
 - **App (root)**  
-    Initializes bridge hooks (snapshot/events/commands), view manager, and modals; composes main screens (Dashboard + MainView).
+   Initializes bridge hooks (snapshot/events/commands), view manager, and modals; composes main screens (Dashboard + MainView).
 - **hooks/bridge**  
-    Single contact point with the **System Facade** (subscribe to snapshots & events; expose stable command callbacks).
+   Single contact point with the **System Facade** (subscribe to snapshots & events; expose stable command callbacks).
 - **hooks/useViewManager**  
-    Navigation state machine managing `{ currentView, selectedStructureId?, selectedRoomId?, selectedZoneId? }` with `goTo`, `back`, `home`.
+   Navigation state machine managing `{ currentView, selectedStructureId?, selectedRoomId?, selectedZoneId? }` with `goTo`, `back`, `home`.
 - **hooks/useModals**  
-    Central modal controller; manages `visibleModal` and `formState`. Optionally **pauses** sim on open and **resumes** on close.
+   Central modal controller; manages `visibleModal` and `formState`. Optionally **pauses** sim on open and **resumes** on close.
+
 ### B. Primary Views
 
 - **StartScreen**  
-    New/Load/Import flows.
+   New/Load/Import flows.
 - **MainView**  
-    Router‑like composition that decides which primary content to show based on navigation state.
+   Router‑like composition that decides which primary content to show based on navigation state.
 - **FinancesView**  
-    Financial reports (CapEx/OpEx, utilities, labor, maintenance, revenue) with summaries and trends.
+   Financial reports (CapEx/OpEx, utilities, labor, maintenance, revenue) with summaries and trends.
 - **PersonnelView**  
-    Two tabs: _Your Staff_ (management) and _Job Market_ (candidates & hiring).
+   Two tabs: _Your Staff_ (management) and _Job Market_ (candidates & hiring).
+
 ### C. Hierarchical Detail Components
 
 - **Structures**  
-    Top‑level list of rented structures (cards with KPIs).
+   Top‑level list of rented structures (cards with KPIs).
 - **StructureDetail**  
-    Rooms list + actions (create/rename/delete/duplicate).
+   Rooms list + actions (create/rename/delete/duplicate).
 - **RoomDetail**  
-    Zones list; special rendering if `purpose != 'growroom'` (e.g., Lab/BreedingStation).
+   Zones list; special rendering if `purpose != 'growroom'` (e.g., Lab/BreedingStation).
 - **ZoneDetail**  
-    Deep control surface: devices, plantings, plan, environment, and safety state.
+   Deep control surface: devices, plantings, plan, environment, and safety state.
+
 ### D. UI Chrome & Navigation
 
 - **Dashboard**  
-    Persistent header: KPIs, sim controls, quick nav (Finances/Personnel), alerts & game lifecycle (save/load/reset/export/import).
+   Persistent header: KPIs, sim controls, quick nav (Finances/Personnel), alerts & game lifecycle (save/load/reset/export/import).
 - **Breadcrumbs**  
-    Hierarchical trail (e.g., _Structures / Warehouse A / Grow Room 1_); clicking updates selected entity IDs.
+   Hierarchical trail (e.g., _Structures / Warehouse A / Grow Room 1_); clicking updates selected entity IDs.
+
 ### E. Modals (managed by the modal controller)
 
-**Creation**
-- **RentModal** → `rentStructure(structureId)`.
-- **AddRoomModal** → `createRoom(structureId, { name, purpose, area_m2, height_m? })`.
-- **AddZoneModal** → `createZone(roomId, { name, area_m2, methodId })`.
-- **AddDeviceModal** → `installDevice(targetId, deviceId, settings?)` (enforces `allowedRoomPurposes`).
-- **AddSupplyModal** → `applyIrrigation` / fertilizer grams `{ N,P,K }`.
-- **PlantStrainModal** → `addPlanting(zoneId, { strainId, count })`.
+-**Creation**
+
+- **RentModal** → `facade.world.rentStructure({ structureId })`.
+- **AddRoomModal** → `facade.world.createRoom({ structureId, room: { name, purpose, area, height? } })`.
+- **AddZoneModal** → `facade.world.createZone({ roomId, zone: { name, area, methodId, targetPlantCount? } })`.
+- **AddDeviceModal** → `facade.devices.installDevice({ targetId, deviceId, settings })` (enforces `allowedRoomPurposes`).
+- **AddSupplyModal** → `facade.plants.applyIrrigation({ zoneId, liters })` / `facade.plants.applyFertilizer({ zoneId, nutrients })`.
+- **PlantStrainModal** → `facade.plants.addPlanting({ zoneId, strainId, count })`.
 - **BreedStrainModal** → select two parent strains by **UUID `id`** to create a new strain (lineage stores parent UUIDs; empty parents ⇒ ur‑plant).
 
 **Management & Editing**
-- **RenameModal** → generic rename for structure/room/zone.
+
+- **RenameModal** → `facade.world.renameStructure({ structureId, name })` or equivalent room/zone updates.
 - **DeleteModal** → generic delete (contextual warnings, e.g., severance on firing employees).
-- **EditDeviceModal** → batch adjust device settings (e.g., `targetTemperature`, hysteresis `targetTemperatureRange`).
+- **EditDeviceModal** → batch adjust device settings via `facade.devices.updateDevice({ instanceId, settings })`.
 - **EditLightCycleModal** → zone light hours; UI does not compute growth—engine does.
-- **PlantingPlanModal** → define automation plan (strain/quantity, **Auto‑Replant** toggle).
+- **PlantingPlanModal** → define automation plan (strain/quantity, **Auto‑Replant** toggle) with `facade.plants.togglePlantingPlan({ zoneId, enabled })`.
 
 **HR**
-- **HireEmployeeModal** → `hire(candidateId, role, wage?)` and assign structure.
+
+- **HireEmployeeModal** → `facade.workforce.hire({ candidateId, role, wage? })` and assign structure.
 - **NegotiateSalaryModal** → respond to raise alert (accept/decline/bonus) and patch wage.
 
 **Game Lifecycle**
+
 - **NewGameModal** → `newGame` with name/seed.
 - **SaveGameModal** → `save`.
 - **LoadGameModal** → list/load/delete saved snapshots.
 - **ResetModal** → confirm full reset.
+
 ### F. Reusable & Specialized Components
 
 - **Card**  
-    Generic container for structure/room/zone/employee summaries.
+   Generic container for structure/room/zone/employee summaries.
 - **BreedingStation**  
-    Specialized panel in Lab views listing custom strains (lineage shown via parent UUID resolution to names).
+   Specialized panel in Lab views listing custom strains (lineage shown via parent UUID resolution to names).
 - **ZoneInfoPanel**  
-    Zone KPIs: environment (T/RH/CO₂), PPFD/DLI, supplies, safety (PHI/re‑entry timers).
+   Zone KPIs: environment (T/RH/CO₂), PPFD/DLI, supplies, safety (PHI/re‑entry timers).
 - **ZoneDeviceList**  
-    Devices by type; install/remove/update; placement validated by `allowedRoomPurposes`.
+   Devices by type; install/remove/update; placement validated by `allowedRoomPurposes`.
 - **ZonePlantingList**  
-    Plantings with per‑planting harvest; access to PlantStrain modal.
+   Plantings with per‑planting harvest; access to PlantStrain modal.
 - **ZonePlantingPlan**  
-    Automation plan management (auto‑replant pipeline).
+   Automation plan management (auto‑replant pipeline).
 
 ---
+
 ## 3) Identity, Validation & Safety (UI Contract)
 
 - **Identity**: All cross‑refs are **UUID `id`**; UI may display `name`/`slug` only.
@@ -161,6 +175,7 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 - **Safety**: The Facade enforces: device purpose binding, quarantine and **reentryIntervalTicks**/**preHarvestIntervalTicks**, certifications for treatments, inventory locks, and geometry constraints.
 
 ---
+
 ## 4) Performance & UX Notes
 
 - **Selectors & memoization** for derived views and KPIs.
@@ -169,6 +184,7 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 - **Modals** may pause the sim; resuming is explicit on close.
 
 ---
+
 ## 5) Anti‑Patterns (explicitly disallowed)
 
 - Computing prices, growth, stress, or environment deltas in the UI.

--- a/docs/tasks/20250923-todo-findings.md
+++ b/docs/tasks/20250923-todo-findings.md
@@ -8,6 +8,7 @@ Revise AGENTS.MD and other .md files to reflect current architecture. Document t
 
 Create tasks to fix the issues:
 Unsupported intents: frontend sends world.updateStructure, world.duplicateRoom, world.duplicateZone, world.deleteStructure, devices.toggleDeviceGroup, plants.togglePlantingPlan, etc., but backend facade only supports rent/create/update/delete (room/zone) and lacks these; calls will be rejected. Overhaul the messaging system used and create an open and modular one, which handles later needs.
+Status: ✅ Completed 2025-09-23 — façade registry now exposes duplication, rename, and toggle intents; socket docs updated alongside ADR 0003 and AGENTS.md.
 Revise AGENTS.MD and other .md files to reflect current architecture. Document the changes and ADR-style decisions. Document every issue when it's considered as done.
 
 Create tasks to fix the issues:


### PR DESCRIPTION
## Summary
- update AGENTS.md and system docs to describe the modular facade intent registry and new world/device/plant actions
- document the generalized `facade.intent` socket envelope and add ADR 0003 capturing the messaging overhaul
- refresh UI interaction specs and changelog and mark the unsupported-intents task as completed

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d206f8702083259a2915a834cbda21