### PR TITLE
Add facade zone setpoint overrides

### DIFF
--- a/src/backend/src/engine/economy/costAccounting.test.ts
+++ b/src/backend/src/engine/economy/costAccounting.test.ts
@@ -174,6 +174,7 @@ const attachDeviceToState = (state: GameState, device: DeviceInstanceState): voi
                 stressLevel: 0,
                 lastUpdatedTick: 0,
               },
+              control: { setpoints: {} },
               health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
               activeTaskIds: [],
             },

--- a/src/backend/src/engine/environment/deviceDegradation.test.ts
+++ b/src/backend/src/engine/environment/deviceDegradation.test.ts
@@ -173,6 +173,7 @@ const createStateWithDevice = (device: DeviceInstanceState): GameState => {
               plants: [],
               devices: [device],
               metrics: createMetrics(environment),
+              control: { setpoints: {} },
               health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
               activeTaskIds: [],
             },

--- a/src/backend/src/engine/environment/zoneEnvironment.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.ts
@@ -276,6 +276,24 @@ export class ZoneEnvironmentService {
     let humidity = this.baseSetpoints.humidity;
     let co2 = this.baseSetpoints.co2;
 
+    const controlSetpoints = zone.control?.setpoints ?? {};
+    const controlTemperature = this.extractNumeric(controlSetpoints.temperature);
+    const controlHumidity = this.extractNumeric(controlSetpoints.humidity);
+    const controlCo2 = this.extractNumeric(controlSetpoints.co2);
+    const hasControlTemperature = controlTemperature !== undefined;
+    const hasControlHumidity = controlHumidity !== undefined;
+    const hasControlCo2 = controlCo2 !== undefined;
+
+    if (hasControlTemperature) {
+      temperature = controlTemperature;
+    }
+    if (hasControlHumidity) {
+      humidity = controlHumidity;
+    }
+    if (hasControlCo2) {
+      co2 = controlCo2;
+    }
+
     for (const device of zone.devices) {
       if (device.status !== 'operational') {
         continue;
@@ -283,7 +301,7 @@ export class ZoneEnvironmentService {
 
       const settings = device.settings ?? {};
 
-      if (TEMPERATURE_DEVICE_KINDS.has(device.kind)) {
+      if (TEMPERATURE_DEVICE_KINDS.has(device.kind) && !hasControlTemperature) {
         const targetTemperature = this.extractNumeric(settings.targetTemperature);
         if (targetTemperature !== undefined) {
           temperature = targetTemperature;
@@ -296,14 +314,14 @@ export class ZoneEnvironmentService {
         }
       }
 
-      if (HUMIDITY_DEVICE_KINDS.has(device.kind)) {
+      if (HUMIDITY_DEVICE_KINDS.has(device.kind) && !hasControlHumidity) {
         const targetHumidity = this.extractNumeric(settings.targetHumidity);
         if (targetHumidity !== undefined) {
           humidity = targetHumidity;
         }
       }
 
-      if (CO2_DEVICE_KINDS.has(device.kind)) {
+      if (CO2_DEVICE_KINDS.has(device.kind) && !hasControlCo2) {
         const targetCo2 = this.extractNumeric(settings.targetCO2);
         if (targetCo2 !== undefined) {
           co2 = targetCo2;

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -191,6 +191,7 @@ const createGameState = (): GameState => {
     plants,
     devices: [],
     metrics: createMetrics(environment),
+    control: { setpoints: {} },
     health: createZoneHealth(plants),
     activeTaskIds: [],
   };

--- a/src/backend/src/engine/workforce/workforceEngine.test.ts
+++ b/src/backend/src/engine/workforce/workforceEngine.test.ts
@@ -75,6 +75,7 @@ const createBaseState = (): GameState => {
       stressLevel: 0.1,
       lastUpdatedTick: 0,
     },
+    control: { setpoints: {} },
     health: {
       plantHealth: {},
       pendingTreatments: [],

--- a/src/backend/src/engine/workforce/workforceIntegration.test.ts
+++ b/src/backend/src/engine/workforce/workforceIntegration.test.ts
@@ -55,6 +55,7 @@ const createBaseState = (): GameState => {
       stressLevel: 0.1,
       lastUpdatedTick: 0,
     },
+    control: { setpoints: {} },
     health: {
       plantHealth: {},
       pendingTreatments: [],

--- a/src/backend/src/engine/world/worldService.ts
+++ b/src/backend/src/engine/world/worldService.ts
@@ -67,6 +67,22 @@ const cloneEnvironment = (environment: ZoneState['environment']): ZoneState['env
   };
 };
 
+const cloneControl = (control: ZoneState['control'] | undefined): ZoneState['control'] => {
+  if (!control) {
+    return { setpoints: {} } satisfies ZoneState['control'];
+  }
+  const setpoints = control.setpoints ?? {};
+  return {
+    setpoints: {
+      temperature: setpoints.temperature,
+      humidity: setpoints.humidity,
+      co2: setpoints.co2,
+      ppfd: setpoints.ppfd,
+      vpd: setpoints.vpd,
+    },
+  } satisfies ZoneState['control'];
+};
+
 const deepCloneSettings = (settings: Record<string, unknown>): Record<string, unknown> => {
   return JSON.parse(JSON.stringify(settings));
 };
@@ -396,6 +412,7 @@ export class WorldService {
       plants: [],
       devices,
       metrics,
+      control: cloneControl(zone.control),
       health: createEmptyHealth(),
       activeTaskIds: [],
       plantingPlan: undefined,

--- a/src/backend/src/facade/config.test.ts
+++ b/src/backend/src/facade/config.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SimulationFacade } from './index.js';
+import type { GameState, SimulationEvent } from '@/state/models.js';
+import { EventBus } from '@/lib/eventBus.js';
+import type { SimulationLoop } from '@/sim/loop.js';
+import { saturationVaporPressure } from '@/physio/vpd.js';
+
+const createTestState = (): GameState => ({
+  metadata: {
+    gameId: 'game-1',
+    createdAt: new Date(0).toISOString(),
+    seed: 'seed-1',
+    difficulty: 'normal',
+    simulationVersion: '1.0.0',
+    tickLengthMinutes: 60,
+    economics: {
+      initialCapital: 0,
+      itemPriceMultiplier: 1,
+      harvestPriceMultiplier: 1,
+      rentPerSqmStructurePerTick: 0,
+      rentPerSqmRoomPerTick: 0,
+    },
+  },
+  clock: {
+    tick: 0,
+    isPaused: true,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+    targetTickRate: 1,
+  },
+  structures: [
+    {
+      id: 'structure-1',
+      blueprintId: 'structure-blueprint',
+      name: 'Alpha',
+      status: 'active',
+      footprint: { length: 10, width: 10, height: 4, area: 100, volume: 400 },
+      rooms: [
+        {
+          id: 'room-1',
+          structureId: 'structure-1',
+          name: 'Grow Room',
+          purposeId: 'grow-room',
+          area: 100,
+          height: 4,
+          volume: 400,
+          cleanliness: 0.9,
+          maintenanceLevel: 0.9,
+          zones: [
+            {
+              id: 'zone-1',
+              roomId: 'room-1',
+              name: 'Zone 1',
+              cultivationMethodId: 'method-1',
+              strainId: 'strain-1',
+              area: 80,
+              ceilingHeight: 4,
+              volume: 320,
+              environment: {
+                temperature: 24,
+                relativeHumidity: 0.6,
+                co2: 900,
+                ppfd: 500,
+                vpd: 1.2,
+              },
+              resources: {
+                waterLiters: 500,
+                nutrientSolutionLiters: 250,
+                nutrientStrength: 1,
+                substrateHealth: 1,
+                reservoirLevel: 0.75,
+              },
+              plants: [],
+              devices: [
+                {
+                  id: 'lamp-1',
+                  blueprintId: 'lamp-blueprint',
+                  kind: 'Lamp',
+                  name: 'Primary Lamp',
+                  zoneId: 'zone-1',
+                  status: 'operational',
+                  efficiency: 0.95,
+                  runtimeHours: 0,
+                  maintenance: {
+                    lastServiceTick: 0,
+                    nextDueTick: 720,
+                    condition: 1,
+                    runtimeHoursAtLastService: 0,
+                    degradation: 0,
+                  },
+                  settings: { power: 0.8, ppfd: 600, coverageArea: 12 },
+                },
+                {
+                  id: 'climate-1',
+                  blueprintId: 'climate-blueprint',
+                  kind: 'ClimateUnit',
+                  name: 'Climate Control',
+                  zoneId: 'zone-1',
+                  status: 'operational',
+                  efficiency: 0.9,
+                  runtimeHours: 0,
+                  maintenance: {
+                    lastServiceTick: 0,
+                    nextDueTick: 720,
+                    condition: 1,
+                    runtimeHoursAtLastService: 0,
+                    degradation: 0,
+                  },
+                  settings: {
+                    airflow: 320,
+                    coolingCapacity: 1.2,
+                    targetTemperature: 24,
+                    targetTemperatureRange: [22, 26],
+                    fullPowerAtDeltaK: 2,
+                  },
+                },
+                {
+                  id: 'humidity-1',
+                  blueprintId: 'humidity-blueprint',
+                  kind: 'HumidityControlUnit',
+                  name: 'Humidity Control',
+                  zoneId: 'zone-1',
+                  status: 'operational',
+                  efficiency: 0.9,
+                  runtimeHours: 0,
+                  maintenance: {
+                    lastServiceTick: 0,
+                    nextDueTick: 720,
+                    condition: 1,
+                    runtimeHoursAtLastService: 0,
+                    degradation: 0,
+                  },
+                  settings: {
+                    targetHumidity: 0.6,
+                    humidifyRateKgPerTick: 0.1,
+                    dehumidifyRateKgPerTick: 0.1,
+                  },
+                },
+                {
+                  id: 'co2-1',
+                  blueprintId: 'co2-blueprint',
+                  kind: 'CO2Injector',
+                  name: 'CO2 Injector',
+                  zoneId: 'zone-1',
+                  status: 'operational',
+                  efficiency: 0.9,
+                  runtimeHours: 0,
+                  maintenance: {
+                    lastServiceTick: 0,
+                    nextDueTick: 720,
+                    condition: 1,
+                    runtimeHoursAtLastService: 0,
+                    degradation: 0,
+                  },
+                  settings: {
+                    targetCO2: 900,
+                    targetCO2Range: [400, 1500],
+                    hysteresis: 50,
+                  },
+                },
+              ],
+              metrics: {
+                averageTemperature: 24,
+                averageHumidity: 0.6,
+                averageCo2: 900,
+                averagePpfd: 500,
+                stressLevel: 0,
+                lastUpdatedTick: 0,
+              },
+              control: { setpoints: {} },
+              health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
+              activeTaskIds: [],
+            },
+          ],
+        },
+      ],
+      rentPerTick: 0,
+      upfrontCostPaid: 0,
+    },
+  ],
+  inventory: {
+    resources: {
+      waterLiters: 0,
+      nutrientsGrams: 0,
+      co2Kg: 0,
+      substrateKg: 0,
+      packagingUnits: 0,
+      sparePartsValue: 0,
+    },
+    seeds: [],
+    devices: [],
+    harvest: [],
+    consumables: {},
+  },
+  finances: {
+    cashOnHand: 0,
+    reservedCash: 0,
+    outstandingLoans: [],
+    ledger: [],
+    summary: {
+      totalRevenue: 0,
+      totalExpenses: 0,
+      totalPayroll: 0,
+      totalMaintenance: 0,
+      netIncome: 0,
+      lastTickRevenue: 0,
+      lastTickExpenses: 0,
+    },
+  },
+  personnel: { employees: [], applicants: [], trainingPrograms: [], overallMorale: 1 },
+  tasks: { backlog: [], active: [], completed: [], cancelled: [] },
+  notes: [],
+});
+
+const createFacade = (state?: GameState) => {
+  const gameState = state ?? createTestState();
+  const eventBus = new EventBus();
+  const loopStub = { processTick: vi.fn() } as unknown as SimulationLoop;
+  const facade = new SimulationFacade({ state: gameState, eventBus, loop: loopStub });
+  return { facade, state: gameState, eventBus };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const subscribeToSetpoints = (facade: SimulationFacade) => {
+  const events: SimulationEvent[] = [];
+  const unsubscribe = facade.subscribe('env.setpointUpdated', (event) => events.push(event));
+  return { events, unsubscribe };
+};
+
+describe('SimulationFacade.setZoneSetpoint', () => {
+  it('updates climate device settings and emits events for temperature setpoints', () => {
+    const { facade, state } = createFacade();
+    const { events, unsubscribe } = subscribeToSetpoints(facade);
+
+    const result = facade.setZoneSetpoint('zone-1', 'temperature', 26);
+
+    expect(result.ok).toBe(true);
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    expect(zone.control.setpoints.temperature).toBe(26);
+    const climateUnit = zone.devices.find((device) => device.kind === 'ClimateUnit');
+    expect(climateUnit?.settings.targetTemperature).toBe(26);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toMatchObject({
+      zoneId: 'zone-1',
+      metric: 'temperature',
+      value: 26,
+    });
+
+    unsubscribe();
+  });
+
+  it('clamps relative humidity setpoints to the [0, 1] range', () => {
+    const { facade, state } = createFacade();
+
+    const result = facade.setZoneSetpoint('zone-1', 'relativeHumidity', 1.2);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContain(
+      'Relative humidity setpoint was clamped to the [0, 1] range.',
+    );
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    expect(zone.control.setpoints.humidity).toBe(1);
+    expect(zone.control.setpoints.vpd).toBeUndefined();
+    const humidityUnit = zone.devices.find((device) => device.kind === 'HumidityControlUnit');
+    expect(humidityUnit?.settings.targetHumidity).toBe(1);
+  });
+
+  it('clamps CO₂ setpoints to non-negative values', () => {
+    const { facade, state } = createFacade();
+
+    const result = facade.setZoneSetpoint('zone-1', 'co2', -100);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContain('CO₂ setpoint was clamped to zero or greater.');
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    expect(zone.control.setpoints.co2).toBe(0);
+    const injector = zone.devices.find((device) => device.kind === 'CO2Injector');
+    expect(injector?.settings.targetCO2).toBe(0);
+  });
+
+  it('scales lamp power proportionally when adjusting PPFD', () => {
+    const { facade, state } = createFacade();
+
+    const result = facade.setZoneSetpoint('zone-1', 'ppfd', 300);
+
+    expect(result.ok).toBe(true);
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    expect(zone.control.setpoints.ppfd).toBe(300);
+    const lamp = zone.devices.find((device) => device.kind === 'Lamp');
+    expect(lamp?.settings.ppfd).toBe(300);
+    expect(lamp?.settings.power).toBeCloseTo(0.4, 6);
+  });
+
+  it('derives humidity targets from VPD inputs', () => {
+    const { facade, state } = createFacade();
+    const { events, unsubscribe } = subscribeToSetpoints(facade);
+
+    const result = facade.setZoneSetpoint('zone-1', 'vpd', 1);
+
+    expect(result.ok).toBe(true);
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    const saturation = saturationVaporPressure(zone.environment.temperature);
+    const expectedHumidity = Math.min(Math.max(1 - 1 / saturation, 0), 1);
+    expect(zone.control.setpoints.vpd).toBe(1);
+    expect(zone.control.setpoints.humidity).toBeCloseTo(expectedHumidity, 6);
+    const humidityUnit = zone.devices.find((device) => device.kind === 'HumidityControlUnit');
+    expect(humidityUnit?.settings.targetHumidity).toBeCloseTo(expectedHumidity, 6);
+    expect(events[0]?.payload).toMatchObject({ metric: 'vpd', value: 1 });
+    const eventPayload = events[0]?.payload as { effectiveHumidity?: number } | undefined;
+    expect(eventPayload?.effectiveHumidity).toBeCloseTo(expectedHumidity, 6);
+
+    unsubscribe();
+  });
+
+  it('rejects updates for zones without compatible devices', () => {
+    const { facade, state } = createFacade();
+    const zone = state.structures[0]!.rooms[0]!.zones[0]!;
+    zone.devices = zone.devices.filter((device) => device.kind !== 'ClimateUnit');
+    const snapshot = JSON.stringify(zone);
+
+    const result = facade.setZoneSetpoint('zone-1', 'temperature', 20);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors?.[0]?.code).toBe('ERR_INVALID_STATE');
+    expect(JSON.stringify(zone)).toBe(snapshot);
+  });
+
+  it('rejects unknown metrics with ERR_INVALID_STATE', () => {
+    const { facade } = createFacade();
+
+    const result = facade.setZoneSetpoint('zone-1', 'ph' as never, 6.5);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors?.[0]?.code).toBe('ERR_INVALID_STATE');
+  });
+
+  it('rejects requests for missing zones', () => {
+    const { facade } = createFacade();
+
+    const result = facade.setZoneSetpoint('zone-unknown', 'temperature', 24);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors?.[0]?.code).toBe('ERR_INVALID_STATE');
+  });
+});

--- a/src/backend/src/facade/intent.integration.test.ts
+++ b/src/backend/src/facade/intent.integration.test.ts
@@ -130,6 +130,7 @@ const createTestState = (): GameState => ({
                 stressLevel: 0.1,
                 lastUpdatedTick: 0,
               },
+              control: { setpoints: {} },
               health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
               activeTaskIds: [],
               plantingPlan: {

--- a/src/backend/src/lib/uiSnapshot.ts
+++ b/src/backend/src/lib/uiSnapshot.ts
@@ -6,6 +6,7 @@ import type {
   GameState,
   PlantState,
   StructureState,
+  ZoneControlState,
   ZoneEnvironmentState,
   ZoneMetricState,
   ZoneResourceState,
@@ -84,6 +85,7 @@ export interface ZoneSnapshot {
   metrics: ZoneMetricState;
   devices: DeviceSnapshot[];
   plants: PlantSnapshot[];
+  control: ZoneControlState;
   health: ZoneHealthSnapshot;
 }
 
@@ -162,6 +164,16 @@ const cloneResources = (resources: ZoneResourceState): ZoneResourceState => ({
   reservoirLevel: resources.reservoirLevel,
 });
 
+const cloneControl = (control: ZoneControlState): ZoneControlState => ({
+  setpoints: {
+    temperature: control.setpoints.temperature,
+    humidity: control.setpoints.humidity,
+    co2: control.setpoints.co2,
+    ppfd: control.setpoints.ppfd,
+    vpd: control.setpoints.vpd,
+  },
+});
+
 export const buildSimulationSnapshot = (
   state: GameState,
   roomPurposeSource: RoomPurposeSource,
@@ -192,6 +204,7 @@ export const buildSimulationSnapshot = (
           environment: { ...zone.environment },
           resources: cloneResources(zone.resources),
           metrics: { ...zone.metrics },
+          control: cloneControl(zone.control ?? { setpoints: {} }),
           devices: zone.devices.map((device) => ({
             id: device.id,
             blueprintId: device.blueprintId,

--- a/src/backend/src/sim/loop.accounting.test.ts
+++ b/src/backend/src/sim/loop.accounting.test.ts
@@ -75,6 +75,7 @@ const createAccountingTestState = (): GameState => {
       stressLevel: 0,
       lastUpdatedTick: 0,
     } satisfies ZoneMetricState,
+    control: { setpoints: {} },
     health: {
       plantHealth: {},
       pendingTreatments: [],

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -179,6 +179,7 @@ const createGameStateWithZone = (): GameState => {
       stressLevel: 0.2,
       lastUpdatedTick: 0,
     } satisfies ZoneMetricState,
+    control: { setpoints: {} },
     health: {
       plantHealth: {},
       pendingTreatments: [],

--- a/src/backend/src/state/devices.test.ts
+++ b/src/backend/src/state/devices.test.ts
@@ -49,6 +49,11 @@ const createZone = (overrides: Partial<ZoneState> = {}): ZoneState => ({
       stressLevel: 0,
       lastUpdatedTick: 0,
     } satisfies ZoneState['metrics']),
+  control:
+    overrides.control ??
+    ({
+      setpoints: { ...(overrides.control?.setpoints ?? {}) },
+    } satisfies ZoneState['control']),
   health:
     overrides.health ??
     ({

--- a/src/backend/src/state/geometry.test.ts
+++ b/src/backend/src/state/geometry.test.ts
@@ -35,6 +35,7 @@ const createZone = (overrides: Partial<ZoneState> = {}): ZoneState => ({
     stressLevel: 0,
     lastUpdatedTick: 0,
   },
+  control: { setpoints: {} },
   health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
   activeTaskIds: [],
   ...overrides,

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -123,6 +123,18 @@ export interface ZoneMetricState {
   lastUpdatedTick: number;
 }
 
+export interface ZoneControlSetpoints {
+  temperature?: number;
+  humidity?: number;
+  co2?: number;
+  ppfd?: number;
+  vpd?: number;
+}
+
+export interface ZoneControlState {
+  setpoints: ZoneControlSetpoints;
+}
+
 export interface ZonePlantingPlanState {
   id: string;
   strainId: string;
@@ -233,6 +245,7 @@ export interface ZoneState {
   plants: PlantState[];
   devices: DeviceInstanceState[];
   metrics: ZoneMetricState;
+  control: ZoneControlState;
   health: ZoneHealthState;
   activeTaskIds: string[];
   plantingPlan?: ZonePlantingPlanState | null;

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -25,6 +25,7 @@ import type {
   StructureState,
   TaskDefinitionMap,
   ZoneEnvironmentState,
+  ZoneControlState,
   ZoneHealthState,
   ZoneMetricState,
   ZoneResourceState,
@@ -186,6 +187,10 @@ const createZoneEnvironment = (): ZoneEnvironmentState => ({
   vpd: 1.2,
 });
 
+const createZoneControl = (): ZoneControlState => ({
+  setpoints: {},
+});
+
 const createZoneResources = (): ZoneResourceState => ({
   waterLiters: DEFAULT_ZONE_WATER_LITERS,
   nutrientSolutionLiters: DEFAULT_ZONE_NUTRIENT_LITERS,
@@ -289,6 +294,7 @@ const buildStructureState = (
     plants,
     devices: [],
     metrics: createZoneMetrics(environment),
+    control: createZoneControl(),
     health: createZoneHealth(plants),
     activeTaskIds: [],
   };


### PR DESCRIPTION
## Summary
- persist zone control setpoints in state and expose them through environment services and UI snapshots
- add `SimulationFacade.setZoneSetpoint` to validate metrics, update device targets, and emit `env.setpointUpdated`
- update the socket gateway and tests to drive the new flow end to end

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d20bcde27483258bd7fc46b0565d01