### PR TITLE
Add clock metadata to simulation snapshots

### DIFF
--- a/src/backend/src/lib/uiSnapshot.ts
+++ b/src/backend/src/lib/uiSnapshot.ts
@@ -124,8 +124,17 @@ export interface FinanceSummarySnapshot {
   lastTickExpenses: number;
 }
 
+export interface SimulationClockSnapshot {
+  tick: number;
+  isPaused: boolean;
+  targetTickRate: number;
+  startedAt: string;
+  lastUpdatedAt: string;
+}
+
 export interface SimulationSnapshot {
   tick: number;
+  clock: SimulationClockSnapshot;
   structures: StructureSnapshot[];
   rooms: RoomSnapshot[];
   zones: ZoneSnapshot[];
@@ -181,6 +190,14 @@ export const buildSimulationSnapshot = (
   const structures: StructureSnapshot[] = [];
   const rooms: RoomSnapshot[] = [];
   const zones: ZoneSnapshot[] = [];
+
+  const clock: SimulationClockSnapshot = {
+    tick: state.clock.tick,
+    isPaused: state.clock.isPaused,
+    targetTickRate: state.clock.targetTickRate,
+    startedAt: state.clock.startedAt,
+    lastUpdatedAt: state.clock.lastUpdatedAt,
+  };
 
   for (const structure of state.structures) {
     const roomIds: string[] = [];
@@ -293,6 +310,7 @@ export const buildSimulationSnapshot = (
 
   return {
     tick: state.clock.tick,
+    clock,
     structures,
     rooms,
     zones,

--- a/src/backend/src/server/socketGateway.test.ts
+++ b/src/backend/src/server/socketGateway.test.ts
@@ -114,8 +114,25 @@ describe('SocketGateway uiStream integration', () => {
     expect(handshake).toBeDefined();
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
 
+    expect(handshake?.updates[0]?.snapshot.clock).toEqual({
+      tick: facadeStub.state.clock.tick,
+      isPaused: facadeStub.state.clock.isPaused,
+      targetTickRate: facadeStub.state.clock.targetTickRate,
+      startedAt: facadeStub.state.clock.startedAt,
+      lastUpdatedAt: facadeStub.state.clock.lastUpdatedAt,
+    });
+
+    const timestamp = new Date(0).toISOString();
+
     const baseSnapshot: SimulationSnapshot = {
       tick: 0,
+      clock: {
+        tick: 0,
+        isPaused: true,
+        targetTickRate: 1,
+        startedAt: timestamp,
+        lastUpdatedAt: timestamp,
+      },
       structures: [],
       rooms: [],
       zones: [],
@@ -140,7 +157,11 @@ describe('SocketGateway uiStream integration', () => {
         eventCount: 0,
         events: [],
         phaseTimings: createPhaseTimings(),
-        snapshot: { ...baseSnapshot, tick: 5 },
+        snapshot: {
+          ...baseSnapshot,
+          tick: 5,
+          clock: { ...baseSnapshot.clock, tick: 5 },
+        },
         time: baseTime,
       },
       {
@@ -150,7 +171,11 @@ describe('SocketGateway uiStream integration', () => {
         eventCount: 0,
         events: [],
         phaseTimings: createPhaseTimings(),
-        snapshot: { ...baseSnapshot, tick: 6 },
+        snapshot: {
+          ...baseSnapshot,
+          tick: 6,
+          clock: { ...baseSnapshot.clock, tick: 6 },
+        },
         time: baseTime,
       },
     ];

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -200,6 +200,8 @@ export interface SimulationSnapshot {
     tick: number;
     isPaused: boolean;
     targetTickRate: number;
+    startedAt: string;
+    lastUpdatedAt: string;
   };
   structures: StructureSnapshot[];
   rooms: RoomSnapshot[];


### PR DESCRIPTION
## Summary
- include clock metadata in simulation snapshots generated for UI transport
- assert Socket.IO and SSE gateways forward the new clock block in their tests
- align the frontend simulation snapshot type with the backend payload

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d2162087d48325a5afab88a4e63f48