### PR TITLE
Align Socket.IO client version and document transport parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - **Do not rename JSON keys.** Only additive, user‑approved fields (optional) are allowed.
 - **Tick‑based engine, explicit phase order.** Events are **telemetry only** (no commands through the bus).
 - **Economics externalized.** Prices/maintenance are outside device blueprints (separate price maps). Do **not** re‑introduce prices into device JSONs.
+- **Socket transport parity.** Keep `socket.io` and `socket.io-client` on the **same minor version** across backend and frontend packages. Update both sides together to avoid wire-protocol drift.
 - **No breaking directory churn.** Prefer additive refactors with clear commits, green CI at every step.
 
 ---
@@ -109,10 +110,11 @@ export function vpdProxy(T: number, RH: number, Tbase = 10): number {
 }
 ```
 
-### 4.3 Event Bus (telemetry only)
+### 4.3 Event Bus & Real-Time Transports (telemetry only)
 
 - Minimal API: `emit(type, payload, tick, level = 'info')`.
 - Provide `uiStream$` with basic filtering/buffering for UI consumption.
+- **Transports:** Socket.IO gateway (`src/backend/src/server/socketGateway.ts`) and SSE gateway (`src/backend/src/server/sseGateway.ts`) both subscribe to the shared stream. Keep docs (`docs/system/socket_protocol.md`) and frontend bridge hooks in sync with payload updates.
 - **No commands through the event bus.**
 
 ### 4.4 Factories + JSON Blueprints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refreshed AGENTS.md, socket protocol, façade, and UI interaction docs to cover
   `facade.intent`, duplication workflows, structure rename support, and
   automation toggles.
+- Documented Socket.IO transport parity across AGENTS.md, the README, and the
+  socket protocol reference; recorded ADR 0006 with the upgrade policy.
 
 ### Fixed
 
 - Corrected the validate-data CLI import path to target the actual data loader module location.
+- Upgraded the frontend Socket.IO client to `^4.8.1` to match the backend
+  dependency and eliminate protocol drift.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ while a React front end streams telemetry for real-time visualization.
 - **Telemetry contract** – Socket and SSE gateways stream
   `SimulationSnapshot` payloads plus scheduler `TimeStatus` metadata. The shape
   is documented in [`docs/system/socket_protocol.md`](docs/system/socket_protocol.md)
-  and anchored by ADR 0005.
+  and anchored by ADR 0005. Keep the Socket.IO server (`socket.io`) and client
+  (`socket.io-client`) dependencies on the **same minor version** across
+  packages to avoid protocol drift in the wire format and handshake helpers.
 
 Detailed architecture, module boundaries, and naming rules live in the
 workspace documentation. Start with the product vision and system references in
@@ -37,6 +39,8 @@ workspace documentation. Start with the product vision and system references in
   [`docs/system/adr/0001-typescript-toolchain.md`](docs/system/adr/0001-typescript-toolchain.md)
   and the snapshot/time-status contract is captured in
   [`docs/system/adr/0005-snapshot-time-sync.md`](docs/system/adr/0005-snapshot-time-sync.md).
+  Real-time transport version parity is tracked in
+  [`docs/system/adr/0006-socket-transport-parity.md`](docs/system/adr/0006-socket-transport-parity.md).
 
 ## Continuous Verification
 

--- a/docs/system/adr/0006-socket-transport-parity.md
+++ b/docs/system/adr/0006-socket-transport-parity.md
@@ -1,0 +1,51 @@
+# ADR 0006 — Socket Transport Version Parity
+
+- **Status:** Accepted (2025-02-28)
+- **Owner:** Simulation Platform
+- **Context:** Real-time telemetry transports
+
+## Context
+
+The backend exposes both Socket.IO and server-sent events (SSE) gateways to fan
+out the simulation telemetry stream. While the backend and shared workspace
+already depend on `socket.io@^4.8.1`, the frontend still referenced
+`socket.io-client@^4.7.5`. The mismatch was survivable for basic messaging but
+risked subtle protocol differences (e.g., handshake headers, ping/pong cadence,
+namespace negotiation) that are only covered by integration tests on the newest
+minor release. We need an explicit decision to keep the transports aligned so
+future upgrades cannot regress the dashboard connection behaviour.
+
+## Decision
+
+- Pin both the backend (`socket.io`) and frontend (`socket.io-client`) packages
+  to the **same minor version**, currently `4.8.x`.
+- Update the `frontend` workspace package.json, regenerate the pnpm lockfile,
+  and verify that the dependency tree now resolves to `socket.io-client@4.8.1`.
+- Document the parity rule in `AGENTS.md`, the root `README`, and the socket
+  protocol reference so contributors have a single source of truth.
+
+## Consequences
+
+- Future dependency updates must bump both sides together; Renovate/Dependabot
+  PRs should be merged as a pair instead of individually.
+- QA can rely on consistent handshake semantics when testing the React bridge
+  and the SSE fallback because both transports share the latest server features.
+- The ADR provides an audit trail for why cross-package version bumps are
+  required, avoiding accidental downgrades during targeted fixes.
+
+## Alternatives Considered
+
+1. **Allow independent version drift.** Rejected because the protocol-level
+   behaviour can diverge subtly (e.g., new reserved event names or transport
+   negotiation) even within a major version.
+2. **Vendor the Socket.IO client.** Deferred — bundling the client manually would
+   complicate build tooling and make it harder to adopt upstream fixes.
+
+## Rollback Plan
+
+If a future Socket.IO release introduces a regression that affects one side
+only:
+
+- Revert both packages to the last known compatible minor version and note the
+  issue in the changelog until an upstream fix ships.
+- Gate upgrades behind end-to-end telemetry tests to catch regressions earlier.

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -6,6 +6,10 @@ adapters. Both the Socket.IO gateway and the server-sent events (SSE) gateway
 subscribe to the same observable, ensuring identical payloads regardless of
 transport. All payloads are JSON and use SI units unless stated otherwise.
 
+> **Version parity.** The Socket.IO server (`socket.io`) and browser client
+> (`socket.io-client`) **must** stay on the same minor version. See ADR 0006 for
+> the rationale and upgrade checklist.
+
 ## UI Stream (`uiStream$`)
 
 - `createUiStream` (from `runtime/eventBus.ts`) returns an observable of

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         specifier: ^2.8.0
         version: 2.15.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       socket.io-client:
-        specifier: ^4.7.5
+        specifier: ^4.8.1
         version: 4.8.1
       zustand:
         specifier: ^4.5.2

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^19.1.1",
     "react-i18next": "^15.5.2",
     "recharts": "^2.8.0",
-    "socket.io-client": "^4.7.5",
+    "socket.io-client": "^4.8.1",
     "zustand": "^4.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump the frontend socket.io-client dependency to ^4.8.1 and refresh the pnpm lockfile to match the backend gateway
- document the real-time transport parity policy across AGENTS.md, README, and the socket protocol guide
- record ADR 0006 describing the socket transport parity decision and reference it from the changelog

## Testing
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d21c7acd1083259808aecc0b071047