### PR TITLE
docs: document socket url resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ export function vpdProxy(T: number, RH: number, Tbase = 10): number {
 - Minimal API: `emit(type, payload, tick, level = 'info')`.
 - Provide `uiStream$` with basic filtering/buffering for UI consumption.
 - **Transports:** Socket.IO gateway (`src/backend/src/server/socketGateway.ts`) and SSE gateway (`src/backend/src/server/sseGateway.ts`) both subscribe to the shared stream. Keep docs (`docs/system/socket_protocol.md`) and frontend bridge hooks in sync with payload updates.
+- **Socket endpoint discovery:** The dashboard resolves its Socket.IO endpoint through `src/frontend/src/config/socket.ts`. It exports a `SOCKET_URL` constant derived from `import.meta.env.VITE_SOCKET_URL` and falls back to `http://localhost:7331/socket.io` (backend dev default). Update the docs whenever this lookup changes so integrators can point non-proxied deployments at a custom URL.
 - **No commands through the event bus.**
 
 ### 4.4 Factories + JSON Blueprints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automation toggles.
 - Documented Socket.IO transport parity across AGENTS.md, the README, and the
   socket protocol reference; recorded ADR 0006 with the upgrade policy.
+- Explained Socket.IO endpoint discovery (`src/frontend/src/config/socket.ts`,
+  `VITE_SOCKET_URL`, and the localhost default) across AGENTS.md, the socket
+  protocol guide, package READMEs, and ADR 0006 after wiring the shared
+  `SOCKET_URL` constant.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ while a React front end streams telemetry for real-time visualization.
   and anchored by ADR 0005. Keep the Socket.IO server (`socket.io`) and client
   (`socket.io-client`) dependencies on the **same minor version** across
   packages to avoid protocol drift in the wire format and handshake helpers.
+- **Socket endpoint discovery** – The dashboard imports `SOCKET_URL` from
+  `src/frontend/src/config/socket.ts`. It reads `import.meta.env.VITE_SOCKET_URL`
+  (set via a `.env` file beside `src/frontend`) and falls back to
+  `http://localhost:7331/socket.io`, the backend development default
+  (`WEEBBREED_BACKEND_PORT=7331`).
 
 Detailed architecture, module boundaries, and naming rules live in the
 workspace documentation. Start with the product vision and system references in

--- a/docs/system/adr/0006-socket-transport-parity.md
+++ b/docs/system/adr/0006-socket-transport-parity.md
@@ -32,6 +32,10 @@ future upgrades cannot regress the dashboard connection behaviour.
   and the SSE fallback because both transports share the latest server features.
 - The ADR provides an audit trail for why cross-package version bumps are
   required, avoiding accidental downgrades during targeted fixes.
+- Configuration guidance now points to
+  `src/frontend/src/config/socket.ts`, which derives `SOCKET_URL` from
+  `VITE_SOCKET_URL` (defaulting to `http://localhost:7331/socket.io`) so ops and
+  developers have a single knob for non-proxied deployments.
 
 ## Alternatives Considered
 

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -47,11 +47,15 @@ buildSimulationSnapshot(state, repository))`.
 
 ### Frontend Configuration
 
-- The Vite dashboard reads the socket endpoint from the `VITE_SOCKET_URL`
-  environment variable. Create a `.env` file next to the frontend package (see
-  `.env.example`) to point the UI at a different host/port during development.
-- When the variable is omitted the UI falls back to
-  `http://localhost:7331/socket.io`, matching the default backend dev server.
+- `src/frontend/src/config/socket.ts` centralises the browser endpoint lookup
+  and exports a `SOCKET_URL` constant for hooks/components to consume.
+- `SOCKET_URL` inspects `import.meta.env.VITE_SOCKET_URL`; create a `.env` file
+  next to the frontend package (see `.env.example`) to point the UI at a
+  different host/port during development or when the app is served separately
+  from the backend.
+- When `VITE_SOCKET_URL` is omitted the helper falls back to
+  `http://localhost:7331/socket.io`, matching the default backend dev server
+  (`WEEBBREED_BACKEND_PORT=7331`).
 
 ## Outgoing Events
 

--- a/docs/tasks/20250923-todo-findings.md
+++ b/docs/tasks/20250923-todo-findings.md
@@ -33,6 +33,7 @@ Status: ✅ Duplicate of snapshot/time documentation update (2025-09-24).
 Create tasks to fix the issues:
 Unused config: src/frontend/src/config/socket.ts isn’t used by useSimulationBridge (hardcodes '/socket.io'); wire it up so VITE_SOCKET_URL works in non-proxied deployments.
 Revise AGENTS.MD and other .md files to reflect current architecture. Document the changes and ADR-style decisions. Document every issue when it's considered as done.
+Status: ✅ Completed 2025-09-25 — SOCKET_URL is now documented across AGENTS, READMEs, ADR 0006, and the socket protocol after wiring the shared config helper.
 
 Create tasks to fix the issues:
 Schema vs usage: deviceSchema.settings defines targetCo2 (camel) but code/JSON use targetCO2 (caps) plus other fields (targetTemperature, targetHumidity, targetCO2Range) not in schema; it’s allowed via .passthrough but consider documenting or extending zod for stronger validation.

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -15,6 +15,11 @@ pnpm --filter @weebbreed/backend dev
 The CLI entry point starts the blueprint loader, seeds the initial game state,
 attaches the Socket.IO and SSE gateways, and starts the simulation clock. Use
 `WEEBBREED_BACKEND_PORT` and `WEEBBREED_BACKEND_SEED` to override the defaults.
+The frontend resolves its Socket.IO endpoint from the `SOCKET_URL` export in
+`src/frontend/src/config/socket.ts`, which inspects
+`import.meta.env.VITE_SOCKET_URL` and otherwise defaults to
+`http://localhost:7331/socket.io`. Keep the backend port and the frontend env
+variable aligned when running the packages separately.
 
 ## Production build
 

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -23,6 +23,13 @@ Run these from the repository root unless noted otherwise:
 The workspace-level scripts (e.g. `pnpm dev`) still work; they simply execute
 the same commands for both backend and frontend packages in parallel.
 
+The Socket.IO bridge imports `SOCKET_URL` from
+`src/frontend/src/config/socket.ts`. The helper inspects
+`import.meta.env.VITE_SOCKET_URL` (set via a `.env` file alongside this
+package). When unset it falls back to `http://localhost:7331/socket.io`, which
+matches the backend development default. Override the env variable when running
+the dashboard against a remote or proxied backend.
+
 ## Simulation bridge (`useSimulationBridge`)
 
 `src/frontend/src/hooks/useSimulationBridge.ts` encapsulates the Socket.IO


### PR DESCRIPTION
## Summary
- document how the frontend resolves the Socket.IO endpoint across AGENTS.md, READMEs, and the socket protocol guide
- capture the configuration decision in ADR 0006, CHANGELOG, and mark the related task complete

## Testing
- pnpm exec prettier --write AGENTS.md README.md src/backend/README.md src/frontend/README.md docs/system/socket_protocol.md docs/system/adr/0006-socket-transport-parity.md CHANGELOG.md docs/tasks/20250923-todo-findings.md

------
https://chatgpt.com/codex/tasks/task_e_68d2217028088325ad7a40b25f3b1661