### PR TITLE
fix: align device schema CO₂ casing

### DIFF
--- a/src/backend/src/data/schemas/deviceSchema.test.ts
+++ b/src/backend/src/data/schemas/deviceSchema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { deviceSchema } from './deviceSchema.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const co2InjectorBlueprintPath = path.resolve(
+  __dirname,
+  '../../../../../data/blueprints/devices/co2injector-01.json',
+);
+
+describe('deviceSchema', () => {
+  it('validates the CO₂ injector blueprint', async () => {
+    const blueprintSource = await readFile(co2InjectorBlueprintPath, 'utf-8');
+    const blueprint = JSON.parse(blueprintSource);
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.settings?.targetCO2).toBe(1100);
+    }
+  });
+
+  it('rejects non-numeric targetCO2 values', () => {
+    const baseBlueprint = {
+      id: '00000000-0000-4000-8000-000000000000',
+      kind: 'CO2Injector',
+      name: 'Invalid Injector',
+      quality: 0.8,
+      complexity: 0.2,
+      lifespan: 3_600,
+      roomPurposes: ['growroom'],
+      settings: {
+        targetCO2: '900',
+      },
+      meta: {},
+    };
+
+    const result = deviceSchema.safeParse(baseBlueprint);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['settings', 'targetCO2']);
+    }
+  });
+});

--- a/src/backend/src/data/schemas/deviceSchema.ts
+++ b/src/backend/src/data/schemas/deviceSchema.ts
@@ -23,7 +23,7 @@ export const deviceSchema = z
         airflow: z.number().optional(),
         coolingCapacity: z.number().optional(),
         moistureRemoval: z.number().optional(),
-        targetCo2: z.number().optional(),
+        targetCO2: z.number().optional(),
       })
       .passthrough(),
     meta: z


### PR DESCRIPTION
## Summary
- align the device schema settings with the `targetCO2` casing used by blueprints and runtime logic
- add schema coverage for the CO₂ injector blueprint and ensure non-numeric CO₂ targets are rejected

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d22334b39c83258ee172accc97bd8c