### PR TITLE
Validate device blueprints with environment setpoint fields

### DIFF
--- a/src/backend/src/data/schemas/deviceSchema.test.ts
+++ b/src/backend/src/data/schemas/deviceSchema.test.ts
@@ -12,40 +12,143 @@ const co2InjectorBlueprintPath = path.resolve(
   __dirname,
   '../../../../../data/blueprints/devices/co2injector-01.json',
 );
+const climateUnitBlueprintPath = path.resolve(
+  __dirname,
+  '../../../../../data/blueprints/devices/climate_unit_01.json',
+);
+const humidityControlBlueprintPath = path.resolve(
+  __dirname,
+  '../../../../../data/blueprints/devices/humidity_control_unit_01.json',
+);
+
+const loadBlueprint = async (blueprintPath: string) => {
+  const blueprintSource = await readFile(blueprintPath, 'utf-8');
+  return JSON.parse(blueprintSource);
+};
+
+const createDeviceBlueprint = (kind: string, settings: Record<string, unknown>) => ({
+  id: '00000000-0000-4000-8000-000000000000',
+  kind,
+  name: `${kind} Test Device`,
+  quality: 0.8,
+  complexity: 0.2,
+  lifespan: 3_600,
+  roomPurposes: ['growroom'],
+  settings,
+  meta: {},
+});
 
 describe('deviceSchema', () => {
   it('validates the CO₂ injector blueprint', async () => {
-    const blueprintSource = await readFile(co2InjectorBlueprintPath, 'utf-8');
-    const blueprint = JSON.parse(blueprintSource);
+    const blueprint = await loadBlueprint(co2InjectorBlueprintPath);
 
     const result = deviceSchema.safeParse(blueprint);
 
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.settings?.targetCO2).toBe(1100);
+      expect(result.data.settings?.targetCO2Range).toEqual([400, 1500]);
+    }
+  });
+
+  it('validates the climate unit blueprint', async () => {
+    const blueprint = await loadBlueprint(climateUnitBlueprintPath);
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.settings?.targetTemperature).toBe(24);
+      expect(result.data.settings?.targetTemperatureRange).toEqual([18, 30]);
+    }
+  });
+
+  it('validates the humidity control blueprint', async () => {
+    const blueprint = await loadBlueprint(humidityControlBlueprintPath);
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.settings?.targetHumidity).toBeCloseTo(0.6);
     }
   });
 
   it('rejects non-numeric targetCO2 values', () => {
-    const baseBlueprint = {
-      id: '00000000-0000-4000-8000-000000000000',
-      kind: 'CO2Injector',
-      name: 'Invalid Injector',
-      quality: 0.8,
-      complexity: 0.2,
-      lifespan: 3_600,
-      roomPurposes: ['growroom'],
-      settings: {
-        targetCO2: '900',
-      },
-      meta: {},
-    };
+    const blueprint = createDeviceBlueprint('CO2Injector', {
+      targetCO2: '900',
+    });
 
-    const result = deviceSchema.safeParse(baseBlueprint);
+    const result = deviceSchema.safeParse(blueprint);
 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0]?.path).toEqual(['settings', 'targetCO2']);
+    }
+  });
+
+  it('rejects non-numeric targetTemperature values', () => {
+    const blueprint = createDeviceBlueprint('ClimateUnit', {
+      targetTemperature: 'warm',
+    });
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path)).toContainEqual([
+        'settings',
+        'targetTemperature',
+      ]);
+    }
+  });
+
+  it('rejects malformed targetTemperatureRange tuples', () => {
+    const blueprint = createDeviceBlueprint('ClimateUnit', {
+      targetTemperatureRange: [20, '30'],
+    });
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path)).toContainEqual([
+        'settings',
+        'targetTemperatureRange',
+        1,
+      ]);
+    }
+  });
+
+  it('rejects non-numeric targetHumidity values', () => {
+    const blueprint = createDeviceBlueprint('HumidityControlUnit', {
+      targetHumidity: '0.5',
+    });
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path)).toContainEqual([
+        'settings',
+        'targetHumidity',
+      ]);
+    }
+  });
+
+  it('rejects malformed targetCO2Range tuples', () => {
+    const blueprint = createDeviceBlueprint('CO2Injector', {
+      targetCO2Range: 'invalid',
+    });
+
+    const result = deviceSchema.safeParse(blueprint);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path)).toContainEqual([
+        'settings',
+        'targetCO2Range',
+      ]);
     }
   });
 });

--- a/src/backend/src/data/schemas/deviceSchema.ts
+++ b/src/backend/src/data/schemas/deviceSchema.ts
@@ -2,28 +2,35 @@ import { z } from 'zod';
 
 const roomPurposeCompatibilitySchema = z.union([z.literal('*'), z.array(z.string().min(1)).min(1)]);
 
-const rangeTuple = z.tuple([z.number(), z.number()]);
+const numericSetting = z.number();
+const rangeTuple = z.tuple([numericSetting, numericSetting]);
+const optionalNumericSetting = numericSetting.optional();
+const optionalRangeTuple = rangeTuple.optional();
 
 export const deviceSchema = z
   .object({
     id: z.string().uuid(),
     kind: z.string().min(1),
     name: z.string().min(1),
-    quality: z.number(),
-    complexity: z.number(),
-    lifespan: z.number(),
+    quality: numericSetting,
+    complexity: numericSetting,
+    lifespan: numericSetting,
     roomPurposes: roomPurposeCompatibilitySchema,
     settings: z
       .object({
-        power: z.number().optional(),
-        ppfd: z.number().optional(),
-        coverageArea: z.number().optional(),
-        spectralRange: rangeTuple.optional(),
-        heatFraction: z.number().optional(),
-        airflow: z.number().optional(),
-        coolingCapacity: z.number().optional(),
-        moistureRemoval: z.number().optional(),
-        targetCO2: z.number().optional(),
+        power: optionalNumericSetting,
+        ppfd: optionalNumericSetting,
+        coverageArea: optionalNumericSetting,
+        spectralRange: optionalRangeTuple,
+        heatFraction: optionalNumericSetting,
+        airflow: optionalNumericSetting,
+        coolingCapacity: optionalNumericSetting,
+        moistureRemoval: optionalNumericSetting,
+        targetTemperature: optionalNumericSetting,
+        targetTemperatureRange: optionalRangeTuple,
+        targetHumidity: optionalNumericSetting,
+        targetCO2: optionalNumericSetting,
+        targetCO2Range: optionalRangeTuple,
       })
       .passthrough(),
     meta: z


### PR DESCRIPTION
## Summary
- add numeric and tuple helpers to the device schema to validate optional environment setpoint fields
- extend fixture-based tests to cover climate, humidity, and CO₂ blueprints and ensure invalid data is rejected

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d22431301c8325918961af9da61bef