### PR TITLE
Normalize recurring costs by tick length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,16 @@ All randomness (pests/events/market) comes from here.
 - Successful updates emit `env.setpointUpdated` with `{ zoneId, metric, value,
 control }` and, when humidity is derived (RH/VPD), `effectiveHumidity`.
 
+### 4.7a Recurring Cost Normalization
+
+- Treat `structure.rentPerTick` and `devicePrices[].baseMaintenanceCostPerTick`
+  as **hourly** base rates. Multiply by the current tick length in hours when
+  charging rent or maintenance so recurring costs track simulated hours, not raw
+  tick counts.
+- Tick-length updates via `facade.setTickLength` (which refresh
+  `state.metadata.tickLengthMinutes`) must be observed before the accounting
+  phase runs, ensuring immediate normalization.
+
 ---
 
 ### 4.8 UI Snapshot & Time Status Contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VITE_SOCKET_URL`, and the localhost default) across AGENTS.md, the socket
   protocol guide, package READMEs, and ADR 0006 after wiring the shared
   `SOCKET_URL` constant.
+- Normalized rent and maintenance accounting to use hourly base rates scaled by
+  the active tick length, keeping recurring costs consistent across runtime tick
+  changes.
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,3 +10,9 @@
 - Recorded the accepted zone setpoint routing contract in
   [ADR 0004](system/adr/0004-zone-setpoint-routing.md) and aligned the socket
   protocol/AGENTS docs with the implemented metrics and response semantics.
+
+### Changed
+
+- Clarified that `baseMaintenanceCostPerTick`, `rentPerTick`, and room purpose
+  base rent values are stored as hourly rates that must be multiplied by the
+  active tick length when booking recurring costs.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -4,11 +4,11 @@
 
 - **Primary key**: `id` (string, **UUID v4**). No `uuid` attribute is used anywhere.
 - **Human identifiers**: `name` (display), `slug` (URL-friendly), optional; never authoritative.
-- **Units** (SI, no unit suffixes in keys):  RH `0–1`; temperature `°C`; power `kW`; airflow `m³/h`; PPFD `µmol·m⁻²·s⁻¹`; CO₂ `ppm`; area `m²`; volume `L`; costs/prices are currency-neutral numbers.
+- **Units** (SI, no unit suffixes in keys): RH `0–1`; temperature `°C`; power `kW`; airflow `m³/h`; PPFD `µmol·m⁻²·s⁻¹`; CO₂ `ppm`; area `m²`; volume `L`; costs/prices are currency-neutral numbers.
 - **Booleans** are explicit `true/false`; no “truthy” strings.
 - **Ranges**: show as inclusive unless stated otherwise.
 - **Validation principles**:
-- Required keys must exist with the right type.- Optional keys may be omitted; if omitted, default behavior is defined below.- Cross-references must use **`id` (UUID)**; never free text.    
+- Required keys must exist with the right type.- Optional keys may be omitted; if omitted, default behavior is defined below.- Cross-references must use **`id` (UUID)**; never free text.
 - **Formatting**: JSON with 2-space indentation; UTF-8; LF line endings.
 
 ---
@@ -39,24 +39,24 @@ Defines cultivar genetics, physiology, environmental requirements, nutrition pro
 **Environment**
 
 - `environment: {`
-- `temperature: { optMin_C: number, optMax_C: number }` — Optimal canopy temperature.- `humidity: { optMin: number, optMax: number }` — RH `0–1`.- `co2?: { opt_ppm?: number }` — Target CO₂ concentration.- `light?: { ppfdTarget?: number }` — Target PPFD at canopy.      `}`      _Engine clamps deviations and converts distance to stress._    
+- `temperature: { optMin_C: number, optMax_C: number }` — Optimal canopy temperature.- `humidity: { optMin: number, optMax: number }` — RH `0–1`.- `co2?: { opt_ppm?: number }` — Target CO₂ concentration.- `light?: { ppfdTarget?: number }` — Target PPFD at canopy. `}` _Engine clamps deviations and converts distance to stress._
 
 **Nutrition & water**
 
 - `nutrients: {`
-- `npkCurve: {`- `vegetative: { N: number|null, P: number|null, K: number|null },`- `flowering: { N: number|null, P: number|null, K: number|null }`- `} // Units for N/P/K: g/m²/day`      `}`    
+- `npkCurve: {`- `vegetative: { N: number|null, P: number|null, K: number|null },`- `flowering: { N: number|null, P: number|null, K: number|null }`- `} // Units for N/P/K: g/m²/day` `}`
 - `water?: { dailyUsePerM2_L: number }` — Liters per m² per day at baseline conditions.
 
 **Growth & morphology** _(project-specific keys allowed; examples below)_
 
 - `morphology?: { leafAreaIndex?: number, yieldFactor?: number }`
 - `growthModel?: {`
-- `maxBiomassDry_g?: number` — Per plant.- `baseLUE_gPerMol?: number` — Light-use efficiency (g dry per mol photons).- `maintenanceFracPerDay?: number (0–1)` — Respiration cost.- `dryMatterFraction?: { vegetation?: number, flowering?: number }`- `harvestIndex?: { targetFlowering?: number }`- `phaseCapMultiplier?: { vegetation?: number, flowering?: number }`- `stressPenaltyCap?: number (0–1)`      `}`    
+- `maxBiomassDry_g?: number` — Per plant.- `baseLUE_gPerMol?: number` — Light-use efficiency (g dry per mol photons).- `maintenanceFracPerDay?: number (0–1)` — Respiration cost.- `dryMatterFraction?: { vegetation?: number, flowering?: number }`- `harvestIndex?: { targetFlowering?: number }`- `phaseCapMultiplier?: { vegetation?: number, flowering?: number }`- `stressPenaltyCap?: number (0–1)` `}`
 
 **Phenology & photoperiod**
 
 - `phenology: { seedlingDays: number, vegetativeDays: number, floweringDays: number }`
-- `photoperiod?: { vegHoursLight?: number, flowerHoursLight?: number }`  _Defaults: if missing, engine policy may assume `18/6` veg, `12/12` flower._
+- `photoperiod?: { vegHoursLight?: number, flowerHoursLight?: number }` _Defaults: if missing, engine policy may assume `18/6` veg, `12/12` flower._
 
 **Harvest & post-harvest**
 
@@ -70,7 +70,7 @@ Defines cultivar genetics, physiology, environmental requirements, nutrition pro
 
 **Lineage**
 
-- `lineage?: { parents: string[] }` — **List of parent `id` (UUID)**.  If `parents` is empty or missing ⇒ **ur-plant** (foundational strain).
+- `lineage?: { parents: string[] }` — **List of parent `id` (UUID)**. If `parents` is empty or missing ⇒ **ur-plant** (foundational strain).
 
 ### Example (minimal)
 
@@ -79,9 +79,16 @@ Defines cultivar genetics, physiology, environmental requirements, nutrition pro
   "id": "3d6c5c0b-5b68-4c6a-8a2a-1c17f3f2a5a7",
   "slug": "ak-47",
   "name": "AK-47",
-  "environment": {"temperature": { "optMin_C": 22, "optMax_C": 28 },"humidity": { "optMin": 0.45, "optMax": 0.65 },"light": { "ppfdTarget": 700 }
+  "environment": {
+    "temperature": { "optMin_C": 22, "optMax_C": 28 },
+    "humidity": { "optMin": 0.45, "optMax": 0.65 },
+    "light": { "ppfdTarget": 700 }
   },
-  "nutrients": {"npkCurve": {  "vegetative": { "N": 2.5, "P": 0.8, "K": 2.0 },  "flowering":  { "N": 1.3, "P": 1.2, "K": 2.5 }}
+  "nutrients": {
+    "npkCurve": {
+      "vegetative": { "N": 2.5, "P": 0.8, "K": 2.0 },
+      "flowering": { "N": 1.3, "P": 1.2, "K": 2.5 }
+    }
   },
   "phenology": { "seedlingDays": 10, "vegetativeDays": 28, "floweringDays": 63 },
   "lineage": { "parents": [] }
@@ -105,8 +112,8 @@ Declares physical equipment (lights, HVAC, CO₂, dehumidifiers, fans, furniture
 - `quality?: number (0–1)` — Reliability proxy.
 - `complexity?: number (0–1)` — Maintenance difficulty proxy.
 - `lifespanInHours?: number` — Technical lifetime horizon.
-- `allowedRoomPurposes: string[]` — **Placement rule**.  Defaults:
-- **GrowLight, Climate/HVAC** ⇒ `["growroom"]`- Other devices ⇒ `["*"]` (allowed anywhere) unless otherwise specified.    
+- `allowedRoomPurposes: string[]` — **Placement rule**. Defaults:
+- **GrowLight, Climate/HVAC** ⇒ `["growroom"]`- Other devices ⇒ `["*"]` (allowed anywhere) unless otherwise specified.
 - `settings: object` — Kind-specific parameters:
 
 **GrowLight**
@@ -141,8 +148,7 @@ Declares physical equipment (lights, HVAC, CO₂, dehumidifiers, fans, furniture
   "name": "Veg Light 01",
   "kind": "GrowLight",
   "allowedRoomPurposes": ["growroom"],
-  "settings": {"power": 0.6,"ppf_umol_s": 1500,"ppe_umol_J": 2.5,"coverage_m2": 1.2
-  }
+  "settings": { "power": 0.6, "ppf_umol_s": 1500, "ppe_umol_J": 2.5, "coverage_m2": 1.2 }
 }
 ```
 
@@ -186,10 +192,10 @@ Data-driven pathogen behavior for infection/progression/damage, env & transmissi
 - `pathogenType: "fungus" | "bacteria" | "virus" | "physiological"`
 - `targets: string[]` — E.g., `"leaves"`, `"stems"`, `"buds"`, `"roots"`.
 - `environmentalRisk?: {`
-- `temperatureRange?: [number, number] (°C)`- `idealHumidityRange?: [number, number] (0–1)`- `leafWetnessRequired?: boolean`- `lowAirflowRisk?: number (0–1)`- `overwateringRisk?: number (0–1)`- `overfertilizationRisk?: number (0–1)`      `}`    
+- `temperatureRange?: [number, number] (°C)`- `idealHumidityRange?: [number, number] (0–1)`- `leafWetnessRequired?: boolean`- `lowAirflowRisk?: number (0–1)`- `overwateringRisk?: number (0–1)`- `overfertilizationRisk?: number (0–1)` `}`
 - `transmission?: { airborne?: boolean, contact?: boolean, tools?: boolean }`
 - `model?: {`
-- `dailyInfectionIncrement?: number` — Baseline infection growth/day (will be modulated by env/balancing).- `infectionThreshold?: number (0–1)` — Established infection point.- `degenerationRate?: number` — Symptom severity growth/day.- `recoveryRate?: number` — Passive recovery/day under good conditions.- `regenerationRate?: number` — Tissue repair/day if modeled separately.- `fatalityThreshold?: number (0–1)`      `}`    
+- `dailyInfectionIncrement?: number` — Baseline infection growth/day (will be modulated by env/balancing).- `infectionThreshold?: number (0–1)` — Established infection point.- `degenerationRate?: number` — Symptom severity growth/day.- `recoveryRate?: number` — Passive recovery/day under good conditions.- `regenerationRate?: number` — Tissue repair/day if modeled separately.- `fatalityThreshold?: number (0–1)` `}`
 - `detection?: { symptoms?: string[] }`
 
 ---
@@ -211,9 +217,9 @@ Population models for pests, their damage mechanisms, environment preferences, a
 - `environmentalRisk?: { temperatureRange?: [°C,°C], humidityRange?: [0–1,0–1], lowAirflowRisk?: number, overwateringRisk?: number }`
 - `populationModel?: { reproductionPerDay?: number, mortalityPerDay?: number, carryingCapacityFactor?: number }`
 - `damageModel?: {`
-- `photosynthesisReductionPerDay?: number (0–1)`- `rootUptakeReductionPerDay?: number (0–1)`- `budLossFractionPerDay?: number (0–1)`- `diseaseVectorRisk?: number (0–1)`- `honeydew?: boolean`      `}`    
+- `photosynthesisReductionPerDay?: number (0–1)`- `rootUptakeReductionPerDay?: number (0–1)`- `budLossFractionPerDay?: number (0–1)`- `diseaseVectorRisk?: number (0–1)`- `honeydew?: boolean` `}`
 - `detection?: { symptoms?: string[], monitoring?: string[] }`
-- `controlOptions?: { cultural?: string[], biological?: string[], mechanical?: string[], chemical?: string[] }`  _(descriptive; operational details are in treatment options)_
+- `controlOptions?: { cultural?: string[], biological?: string[], mechanical?: string[], chemical?: string[] }` _(descriptive; operational details are in treatment options)_
 
 ---
 
@@ -229,9 +235,9 @@ Catalog of actionable treatments; global stacking/safety/cost rules; tick-based 
 - `version?: string`
 - `notes?: string`
 - `global?: {`
-- `stackingRules?: {`    - `maxConcurrentTreatmentsPerZone?: number`        - `mechanicalAlwaysStacks?: boolean`        - `chemicalAndBiologicalCantShareSameMoAWithin7Days?: boolean`        - `cooldownDaysDefault?: number`          `}`    - `sideEffects?: { phytotoxicityRiskKeys?: string[], beneficialsHarmRiskKeys?: string[] }`- `costModel?: {`    - `costBasis?: "perZone" | "perPlant" | "perSquareMeter"` — Default scaling base.        - `totalCostFormula?: string` — Human description; engine computes actuals.          `}`          `}`        
+- `stackingRules?: {` - `maxConcurrentTreatmentsPerZone?: number` - `mechanicalAlwaysStacks?: boolean` - `chemicalAndBiologicalCantShareSameMoAWithin7Days?: boolean` - `cooldownDaysDefault?: number` `}` - `sideEffects?: { phytotoxicityRiskKeys?: string[], beneficialsHarmRiskKeys?: string[] }`- `costModel?: {` - `costBasis?: "perZone" | "perPlant" | "perSquareMeter"` — Default scaling base. - `totalCostFormula?: string` — Human description; engine computes actuals. `}` `}`
 - `options: Array<{`
-- `id: string (UUID v4)`- `name: string`- `category: "cultural" | "biological" | "chemical" | "mechanical" | "UV"`- `targets: Array<"disease" | "pest">`- `applicability?: string[]` — Growth phases where it’s allowed.- `materialsCost?: number` — Neutral cost per application; scaled by `costBasis`.- `laborMinutes?: number`- `energyPerHourKWh?: number`- `cooldownDays?: number`- `reentryIntervalTicks?: number` — Access restriction; engine can derive this from hours/days if present elsewhere.- `preHarvestIntervalTicks?: number` — PHI; same conversion rule.- `effects?: {`    - `pest?: { reproductionMultiplier?: number, mortalityMultiplier?: number, damageMultiplier?: number }`        - `disease?: { infectionMultiplier?: number, degenerationMultiplier?: number, recoveryMultiplier?: number }`          `}`    - `costBasis?: "perZone" | "perPlant" | "perSquareMeter"` — Overrides global default.- `notes?: string`      `}>`    
+- `id: string (UUID v4)`- `name: string`- `category: "cultural" | "biological" | "chemical" | "mechanical" | "UV"`- `targets: Array<"disease" | "pest">`- `applicability?: string[]` — Growth phases where it’s allowed.- `materialsCost?: number` — Neutral cost per application; scaled by `costBasis`.- `laborMinutes?: number`- `energyPerHourKWh?: number`- `cooldownDays?: number`- `reentryIntervalTicks?: number` — Access restriction; engine can derive this from hours/days if present elsewhere.- `preHarvestIntervalTicks?: number` — PHI; same conversion rule.- `effects?: {` - `pest?: { reproductionMultiplier?: number, mortalityMultiplier?: number, damageMultiplier?: number }` - `disease?: { infectionMultiplier?: number, degenerationMultiplier?: number, recoveryMultiplier?: number }` `}` - `costBasis?: "perZone" | "perPlant" | "perSquareMeter"` — Overrides global default.- `notes?: string` `}>`
 
 ---
 
@@ -246,12 +252,12 @@ Catalog of actionable treatments; global stacking/safety/cost rules; tick-based 
 **Strains** — `strainPrices.json`
 
 - `strainPrices: { [strainIdOrSlug: string]: {`
-- `seedCost?: number` — Currency-neutral (alias for legacy `seedPrice`).- `harvestBasePricePerGram?: number` — Base sales price (alias for legacy `harvestPricePerGram`); runtime quality/market adjusters apply.      `}}`      _Keys MAY be UUID `id` or legacy slugs—engine should try UUID first, then slug fallback._    
+- `seedCost?: number` — Currency-neutral (alias for legacy `seedPrice`).- `harvestBasePricePerGram?: number` — Base sales price (alias for legacy `harvestPricePerGram`); runtime quality/market adjusters apply. `}}` _Keys MAY be UUID `id` or legacy slugs—engine should try UUID first, then slug fallback._
 
 **Devices** — `devicePrices.json`
 
 - `devicePrices: { [deviceIdOrSlug: string]: {`
-- `capitalCost?: number` — Alias for legacy `capitalExpenditure`.- `baseMaintenanceCostPerTick?: number`- `costIncreasePer1000Ticks?: number` — Aging curve scalar.      `}}`    
+- `capitalCost?: number` — Alias for legacy `capitalExpenditure`.- `baseMaintenanceCostPerTick?: number` — Hourly maintenance base rate (multiply by `tickLengthMinutes / 60`).- `costIncreasePer1000Ticks?: number` — Aging curve scalar. `}}`
 
 ---
 
@@ -286,5 +292,4 @@ Catalog of actionable treatments; global stacking/safety/cost rules; tick-based 
 
 - `firstNames.json: string[]`
 - `lastNames.json: string[]`
-- `traits.json: Array<{ id: string, name: string, description: string, type: "positive"|"negative"|string }>`  _(HR roles/skills/wages can be separate or engine defaults.)_
-
+- `traits.json: Array<{ id: string, name: string, description: string, type: "positive"|"negative"|string }>` _(HR roles/skills/wages can be separate or engine defaults.)_

--- a/docs/room-purpose-registry.md
+++ b/docs/room-purpose-registry.md
@@ -53,7 +53,11 @@ Each blueprint is validated against the following Zod schema:
       "type": "object",
       "properties": {
         "areaCost": { "type": "number", "minimum": 0 },
-        "baseRentPerTick": { "type": "number", "minimum": 0 }
+        "baseRentPerTick": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Hourly rent baseline; multiply by tick length in hours for per-tick cost"
+        }
       },
       "additionalProperties": false
     }

--- a/docs/system/simulation-engine.md
+++ b/docs/system/simulation-engine.md
@@ -160,11 +160,16 @@ At completion: convert negative energy to **overtime hours** (ticks).
 
 - **CapEx**: device purchases (`capitalCost`), structure setup; log & deduct immediately.
 - **OpEx (per tick)**:
-  - **Maintenance**: `baseMaintenanceCostPerTick` (+ aging via `costIncreasePer1000Ticks`).
+  - **Maintenance**: `baseMaintenanceCostPerTick` (hourly base rate) × tickHours, with aging via `costIncreasePer1000Ticks`.
   - **Energy**: sum `(device.power_kW × tickHours × electricityCostPerKWh)` for active devices.
   - **Water/Nutrients**: from zone demand using **g/m²/day** curves → per-tick spend via `waterCostPerM3`, `nutrientsCostPerKg`.
-  - **Rent**: structure fixed costs or `area_m2 × rentalRate`, normalized to ticks.
-  - **Labor**: daily sweep (every 24 ticks) or continuous accrual; overtime per policy.
+- **Rent**: structure fixed costs or `area_m2 × rentalRate`, stored as hourly rates and multiplied by tickHours.
+
+Recurring OpEx entries should always derive their per-tick charge from the current tick length
+(`tickHours = tickLengthMinutes / 60`) so that changing the tick length at runtime does not drift
+total rent or maintenance over real-time hours.
+
+- **Labor**: daily sweep (every 24 ticks) or continuous accrual; overtime per policy.
 - **Revenue**: `harvestBasePricePerGram × quality × market modifiers` on sales.
 - **Reports**: emit `finance.tick` summaries; categorize by device/structure/zone.
 

--- a/src/backend/src/sim/__golden__/loop-200d.json
+++ b/src/backend/src/sim/__golden__/loop-200d.json
@@ -32,22 +32,22 @@
       "waterLiters": 12000,
       "nutrientsGrams": 8000
     },
-    "cashOnHand": 566640.0849796439,
+    "cashOnHand": 555120.0849797971,
     "financeSummary": {
       "totalRevenue": 1500000,
-      "totalExpenses": 933359.9150202525,
+      "totalExpenses": 944879.915020253,
       "totalPayroll": 921600,
       "totalMaintenance": 46.03502025457756,
-      "netIncome": 566640.0849797475,
+      "netIncome": 555120.084979747,
       "lastTickRevenue": 0,
-      "lastTickExpenses": 192.1328591120789
+      "lastTickExpenses": 194.5328591120789
     }
   },
   "financials": {
     "revenue": 0,
-    "expenses": 922509.9150202532,
+    "expenses": 934029.9150202529,
     "capex": 0,
-    "opex": 922509.9150202532,
+    "opex": 934029.9150202529,
     "utilityCost": 863.8800000000276,
     "maintenanceCost": 46.03502025457762,
     "utilitiesConsumed": {
@@ -57,9 +57,9 @@
     }
   },
   "events": {
-    "dispatched": 28824,
+    "dispatched": 33624,
     "counts": {
-      "finance.opex": 24000,
+      "finance.opex": 28800,
       "finance.tick": 4800,
       "plant.healthAlert": 24
     }
@@ -73,11 +73,11 @@
       "avgVpd": 1.2142280864681247,
       "cumulativeBiomassDelta": 1.6873952663139298,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 192.126600066,
-      "cashOnHand": 1488957.873399934,
+      "cumulativeExpenses": 194.526600066,
+      "cashOnHand": 1488955.4733999341,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 6
+      "eventCount": 7
     },
     {
       "tick": 1200,
@@ -87,11 +87,11 @@
       "avgVpd": 1.3972378095664382,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 230624.12778267416,
-      "cashOnHand": 1258525.872217265,
+      "cumulativeExpenses": 233504.12778267442,
+      "cashOnHand": 1255645.8722173767,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 7224
+      "eventCount": 8424
     },
     {
       "tick": 1306,
@@ -101,11 +101,11 @@
       "avgVpd": 1.3972577166324385,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 250996.07165607932,
-      "cashOnHand": 1238153.9283438544,
+      "cumulativeExpenses": 254130.47165607964,
+      "cashOnHand": 1235019.528343976,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 7860
+      "eventCount": 9166
     },
     {
       "tick": 1506,
@@ -115,11 +115,11 @@
       "avgVpd": 1.3972948309107622,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 289433.70269198116,
-      "cashOnHand": 1199716.2973079437,
+      "cumulativeExpenses": 293048.1026919816,
+      "cashOnHand": 1196101.897308084,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 9060
+      "eventCount": 10566
     },
     {
       "tick": 1604,
@@ -129,11 +129,11 @@
       "avgVpd": 1.3973128247876152,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 308268.14241287997,
-      "cashOnHand": 1180881.8575870402,
+      "cumulativeExpenses": 312117.7424128805,
+      "cashOnHand": 1177032.2575871896,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 9648
+      "eventCount": 11252
     },
     {
       "tick": 2400,
@@ -143,11 +143,11 @@
       "avgVpd": 1.3974552385326617,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 461250.53797446546,
-      "cashOnHand": 1027899.462025419,
+      "cumulativeExpenses": 467010.5379744673,
+      "cashOnHand": 1022139.4620256281,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 14424
+      "eventCount": 16824
     },
     {
       "tick": 3718,
@@ -157,11 +157,11 @@
       "avgVpd": 1.3976805708490645,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 714557.6987239112,
-      "cashOnHand": 774592.3012759826,
+      "cumulativeExpenses": 723480.8987239114,
+      "cashOnHand": 765669.101276161,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 22332
+      "eventCount": 26050
     },
     {
       "tick": 4800,
@@ -171,11 +171,11 @@
       "avgVpd": 1.397858804246941,
       "cumulativeBiomassDelta": 2880.0000000000027,
       "cumulativeRevenue": 0,
-      "cumulativeExpenses": 922509.9150202532,
-      "cashOnHand": 566640.0849796439,
+      "cumulativeExpenses": 934029.9150202529,
+      "cashOnHand": 555120.0849797971,
       "waterRemaining": 12000,
       "nutrientsRemaining": 8000,
-      "eventCount": 28824
+      "eventCount": 33624
     }
   ]
 }

--- a/src/backend/src/sim/loop.ts
+++ b/src/backend/src/sim/loop.ts
@@ -415,6 +415,9 @@ export class SimulationLoop {
 
     const timestamp = new Date().toISOString();
     const runtime = this.accountingRuntime;
+    const tickLengthHours = Number.isFinite(context.tickLengthMinutes)
+      ? Math.max(context.tickLengthMinutes / 60, 0)
+      : 0;
 
     const utilities = runtime.utilities;
     if (utilities.energyKwh > 0 || utilities.waterLiters > 0 || utilities.nutrientsGrams > 0) {
@@ -429,6 +432,16 @@ export class SimulationLoop {
     }
 
     for (const structure of context.state.structures) {
+      this.costAccountingService.applyStructureRent(
+        context.state,
+        structure,
+        context.tick,
+        timestamp,
+        tickLengthHours,
+        runtime.accumulator,
+        context.events,
+      );
+
       for (const room of structure.rooms) {
         for (const zone of room.zones) {
           for (const device of zone.devices) {
@@ -437,6 +450,7 @@ export class SimulationLoop {
               device,
               context.tick,
               timestamp,
+              tickLengthHours,
               runtime.accumulator,
               context.events,
             );

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -350,6 +350,9 @@ const buildStructureState = (
     }
   }
 
+  const hoursPerMonth = 30 * 24;
+  const rentPerHour = (blueprint.rentalCostPerSqmPerMonth * footprint.area) / hoursPerMonth;
+
   const structure: StructureState = {
     id: structureId,
     blueprintId: blueprint.id,
@@ -357,7 +360,7 @@ const buildStructureState = (
     status: 'active',
     footprint,
     rooms: [growRoom, supportRoom],
-    rentPerTick: (blueprint.rentalCostPerSqmPerMonth * footprint.area) / (30 * 24),
+    rentPerTick: rentPerHour,
     upfrontCostPaid: blueprint.upfrontFee,
   };
 


### PR DESCRIPTION
## Summary
- scale hourly rent and device maintenance billing by the current tick length and add rent processing to the accounting phase
- extend accounting tests (plus regenerate the 200-day golden snapshot) to cover tick-length normalization and facade-driven changes
- document the hourly-rate requirement for recurring costs across AGENTS and system references

## Testing
- `pnpm --filter @weebbreed/backend exec -- vitest run src/engine/economy/costAccounting.test.ts src/sim/loop.accounting.test.ts src/sim/loop.golden.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d25693c5e883258daaea0ef7a01f04