### PR TITLE
Fix PPFD accumulation per tick

### DIFF
--- a/src/backend/src/engine/environment/deviceEffects.ts
+++ b/src/backend/src/engine/environment/deviceEffects.ts
@@ -440,13 +440,23 @@ export const computeZoneDeviceDeltas = (
   geometry: ZoneGeometry,
   context: DeviceEffectContext,
 ): DeviceEffect => {
-  return zone.devices.reduce<DeviceEffect>(
-    (accumulator, device) => {
-      const effect = computeSingleDeviceEffect(device, zone, geometry, context);
-      return addDeviceEffects(accumulator, effect);
-    },
-    { ...DEFAULT_DEVICE_EFFECT },
-  );
+  const aggregate: DeviceEffect = { ...DEFAULT_DEVICE_EFFECT };
+  let lightingPpfd = 0;
+
+  for (const device of zone.devices) {
+    const effect = computeSingleDeviceEffect(device, zone, geometry, context);
+
+    aggregate.temperatureDelta += effect.temperatureDelta;
+    aggregate.humidityDelta += effect.humidityDelta;
+    aggregate.co2Delta += effect.co2Delta;
+    aggregate.airflow += effect.airflow;
+    aggregate.energyKwh += effect.energyKwh;
+    lightingPpfd += effect.ppfd;
+  }
+
+  aggregate.ppfd = lightingPpfd;
+
+  return aggregate;
 };
 
 export const hasActiveDevices = (zone: ZoneState): boolean => {

--- a/src/backend/src/engine/environment/zoneEnvironment.ts
+++ b/src/backend/src/engine/environment/zoneEnvironment.ts
@@ -183,17 +183,19 @@ export class ZoneEnvironmentService {
             },
             tickLengthMinutes,
           );
+          let zoneLightingPpfd = 0;
+
           const effect = computeZoneDeviceDeltas(zone, geometry, {
             tickHours,
             powerLevels,
           });
 
-          const lightingPpfd = Math.max(0, effect.ppfd);
+          zoneLightingPpfd += effect.ppfd;
 
           zone.environment.temperature += effect.temperatureDelta;
           zone.environment.relativeHumidity += effect.humidityDelta;
           zone.environment.co2 += effect.co2Delta;
-          zone.environment.ppfd = lightingPpfd;
+          zone.environment.ppfd = Math.max(0, zoneLightingPpfd);
 
           this.deviceEffects.set(zone.id, { airflow: effect.airflow });
           if (accounting && effect.energyKwh > 0) {

--- a/src/backend/src/sim/loop.test.ts
+++ b/src/backend/src/sim/loop.test.ts
@@ -348,17 +348,20 @@ describe('SimulationLoop', () => {
     const zone = state.structures[0]?.rooms[0]?.zones[0];
     expect(zone).toBeDefined();
 
-    await loop.processTick();
-    const firstTickPpfd = zone?.environment.ppfd ?? 0;
+    const ppfdReadings: number[] = [];
 
-    await loop.processTick();
-    const secondTickPpfd = zone?.environment.ppfd ?? 0;
+    for (let index = 0; index < 5; index += 1) {
+      await loop.processTick();
+      ppfdReadings.push(zone?.environment.ppfd ?? 0);
+    }
 
-    await loop.processTick();
-    const thirdTickPpfd = zone?.environment.ppfd ?? 0;
+    expect(ppfdReadings).toHaveLength(5);
+
+    const [firstTickPpfd, ...subsequentReadings] = ppfdReadings;
 
     expect(firstTickPpfd).toBeCloseTo(21.6, 4);
-    expect(secondTickPpfd).toBeCloseTo(firstTickPpfd, 3);
-    expect(thirdTickPpfd).toBeCloseTo(firstTickPpfd, 3);
+    for (const reading of subsequentReadings) {
+      expect(reading).toBeCloseTo(firstTickPpfd, 3);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- accumulate per-zone lighting PPFD locally before writing to the environment each tick
- adjust device effect aggregation so grow lights report instantaneous PPFD output
- extend the simulation loop test to verify PPFD stability across multiple ticks

## Testing
- `pnpm --filter @weebbreed/backend test`
- `UPDATE_GOLDENS=1 pnpm --filter @weebbreed/backend test -- --runInBand src/sim/loop.golden.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d26d0fba90832590ec6d5714dd4926