### PR TITLE
Add ventilation airflow effects and tests

### DIFF
--- a/docs/DD.md
+++ b/docs/DD.md
@@ -108,7 +108,7 @@ Declares physical equipment (lights, HVAC, CO₂, dehumidifiers, fans, furniture
 - `id: string (UUID v4)`
 - `slug?: string`
 - `name: string`
-- `kind: string` — e.g., `GrowLight`, `ClimateUnit`, `Dehumidifier`, `ExhaustFan`, `CO2Injector`, `Shelf`, `Sensor`.
+- `kind: string` — e.g., `GrowLight`, `ClimateUnit`, `Dehumidifier`, `Ventilation`, `ExhaustFan`, `CO2Injector`, `Shelf`, `Sensor`.
 - `quality?: number (0–1)` — Reliability proxy.
 - `complexity?: number (0–1)` — Maintenance difficulty proxy.
 - `lifespanInHours?: number` — Technical lifetime horizon.
@@ -124,7 +124,7 @@ Declares physical equipment (lights, HVAC, CO₂, dehumidifiers, fans, furniture
 - `coverage_m2?: number` — Recommended coverage area.
 - `dliTarget_mol_m2_day?: number` — Optional DLI target.
 
-**Climate/HVAC (incl. AC, dehumidifier, exhaust/fan)**
+**Climate/HVAC (incl. AC, dehumidifier, ventilation/exhaust fan)**
 
 - `power?: number (kW)`
 - `coolingCapacity?: number (kW)`

--- a/src/backend/src/engine/environment/deviceEffects.test.ts
+++ b/src/backend/src/engine/environment/deviceEffects.test.ts
@@ -147,6 +147,35 @@ describe('deviceEffects', () => {
     expect(deltas.ppfd).toBe(0);
   });
 
+  it('exchanges air and trends toward ambient conditions for ventilation devices', () => {
+    const zone = createZone(
+      [
+        createDevice(
+          'Ventilation',
+          {
+            power: 0.05,
+            airflow: 170,
+          },
+          0.75,
+        ),
+      ],
+      createEnvironment({ temperature: 28, relativeHumidity: 0.7, co2: 900 }),
+    );
+
+    const deltas = computeZoneDeviceDeltas(
+      zone,
+      { area: 40, ceilingHeight: 3, volume: 120 },
+      { tickHours: 0.25 },
+    );
+
+    expect(deltas.airflow).toBeCloseTo(127.5, 4);
+    expect(deltas.temperatureDelta).toBeLessThan(0);
+    expect(deltas.temperatureDelta).toBeCloseTo(-2.13, 2);
+    expect(deltas.humidityDelta).toBeCloseTo(-0.053, 3);
+    expect(deltas.co2Delta).toBeCloseTo(-133, 0);
+    expect(deltas.energyKwh).toBeCloseTo(0.0125, 6);
+  });
+
   it('injects CO2 when below target within safety bounds', () => {
     const zone = createZone(
       [


### PR DESCRIPTION
## Summary
- treat Ventilation devices as HVAC airflow contributors and model mixing deltas toward ambient conditions
- extend device and zone environment tests to cover ventilation-driven airflow and normalization effects
- document Ventilation as a recognized device kind in the device blueprint schema reference

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d26fad5b8c832591be322a9608b496