### PR TITLE
Add optional applicant personal seed and gender support

### DIFF
--- a/src/backend/src/engine/workforce/__tests__/jobMarketService.test.ts
+++ b/src/backend/src/engine/workforce/__tests__/jobMarketService.test.ts
@@ -164,6 +164,8 @@ describe('JobMarketService', () => {
     expect(state.personnel.applicants).toHaveLength(2);
     expect(state.personnel.applicants[0].name).toBe('Jamie Hammond');
     expect(state.personnel.applicants[0].personalSeed).toBe('alpha');
+    expect(state.personnel.applicants[0].gender).toBe('male');
+    expect(state.personnel.applicants[1]?.gender).toBe('female');
     expect(result.data?.source).toBe('remote');
     expect(context.events.size).toBe(1);
   });
@@ -187,6 +189,7 @@ describe('JobMarketService', () => {
     expect(result.data?.source).toBe('local');
     expect(state.personnel.applicants).toHaveLength(2);
     expect(state.personnel.applicants[0].personalSeed.startsWith('offline-')).toBe(true);
+    expect(state.personnel.applicants[0].gender).toBeDefined();
     expect(context.events.size).toBe(1);
   });
 
@@ -216,6 +219,7 @@ describe('JobMarketService', () => {
     await commitHook(firstContext);
     state.clock.tick = 1;
     expect(state.personnel.applicants).toHaveLength(1);
+    expect(state.personnel.applicants[0].gender).toBe('other');
     expect(firstBuffer).toHaveLength(1);
 
     const secondBuffer: unknown[] = [];

--- a/src/backend/src/lib/uiSnapshot.ts
+++ b/src/backend/src/lib/uiSnapshot.ts
@@ -1,15 +1,16 @@
 import { requireRoomPurpose, type RoomPurposeSource } from '@/engine/roomPurposes/index.js';
-import type {
-  ApplicantState,
-  DeviceInstanceState,
-  EmployeeState,
-  GameState,
-  PlantState,
-  StructureState,
-  ZoneControlState,
-  ZoneEnvironmentState,
-  ZoneMetricState,
-  ZoneResourceState,
+import {
+  getApplicantPersonalSeed,
+  type ApplicantState,
+  type DeviceInstanceState,
+  type EmployeeState,
+  type GameState,
+  type PlantState,
+  type StructureState,
+  type ZoneControlState,
+  type ZoneEnvironmentState,
+  type ZoneMetricState,
+  type ZoneResourceState,
 } from '@/state/models.js';
 
 export interface StructureSnapshot {
@@ -294,16 +295,27 @@ export const buildSimulationSnapshot = (
       status: employee.status,
       assignedStructureId: employee.assignedStructureId,
     })),
-    applicants: state.personnel.applicants.map((applicant) => ({
-      id: applicant.id,
-      name: applicant.name,
-      desiredRole: applicant.desiredRole,
-      expectedSalary: applicant.expectedSalary,
-      traits: [...applicant.traits],
-      skills: { ...applicant.skills },
-      personalSeed: applicant.personalSeed,
-      gender: applicant.gender,
-    })),
+    applicants: state.personnel.applicants.map((applicant) => {
+      const snapshot: ApplicantSnapshot = {
+        id: applicant.id,
+        name: applicant.name,
+        desiredRole: applicant.desiredRole,
+        expectedSalary: applicant.expectedSalary,
+        traits: [...applicant.traits],
+        skills: { ...applicant.skills },
+      };
+
+      const personalSeed = getApplicantPersonalSeed(applicant);
+      if (personalSeed) {
+        snapshot.personalSeed = personalSeed;
+      }
+
+      if (applicant.gender) {
+        snapshot.gender = applicant.gender;
+      }
+
+      return snapshot;
+    }),
     overallMorale: state.personnel.overallMorale,
   };
 

--- a/src/backend/src/persistence/schemas.ts
+++ b/src/backend/src/persistence/schemas.ts
@@ -373,7 +373,7 @@ const applicantStateSchema = z.object({
   expectedSalary: z.number(),
   traits: z.array(nonEmptyString),
   skills: employeeSkillsSchema,
-  personalSeed: nonEmptyString,
+  personalSeed: nonEmptyString.optional(),
   gender: z.enum(['male', 'female', 'other']).optional(),
 });
 

--- a/src/backend/src/state/models.test.ts
+++ b/src/backend/src/state/models.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getApplicantPersonalSeed, type ApplicantState } from './models.js';
+
+describe('getApplicantPersonalSeed', () => {
+  const baseApplicant: ApplicantState = {
+    id: 'applicant-1',
+    name: 'Test Candidate',
+    desiredRole: 'Gardener',
+    expectedSalary: 15,
+    traits: [],
+    skills: {},
+  };
+
+  it('returns a trimmed personal seed when present', () => {
+    const applicant: ApplicantState = { ...baseApplicant, personalSeed: '  seed-123  ' };
+    expect(getApplicantPersonalSeed(applicant)).toBe('seed-123');
+  });
+
+  it('returns undefined when personal seed is missing or blank', () => {
+    expect(getApplicantPersonalSeed(baseApplicant)).toBeUndefined();
+    const blankSeed: ApplicantState = { ...baseApplicant, personalSeed: '   ' };
+    expect(getApplicantPersonalSeed(blankSeed)).toBeUndefined();
+  });
+});

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -472,9 +472,18 @@ export interface ApplicantState {
   expectedSalary: number;
   traits: string[];
   skills: EmployeeSkills;
-  personalSeed: string;
+  personalSeed?: string;
   gender?: 'male' | 'female' | 'other';
 }
+
+export const getApplicantPersonalSeed = (applicant: ApplicantState): string | undefined => {
+  const value = applicant.personalSeed;
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
 
 export interface TrainingProgramState {
   id: string;


### PR DESCRIPTION
## Summary
- make applicant personalSeed optional in shared models and expose a helper to normalize it
- update persistence schema, UI snapshot, and job market generation to handle optional gender/personalSeed fields
- add unit coverage for the helper and extend job market tests to assert the new metadata

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d2828955b483258cc002bbdbce3ef2