### PR TITLE
feat: deterministic job market gender draws

### DIFF
--- a/src/runtime/rng.ts
+++ b/src/runtime/rng.ts
@@ -20,6 +20,7 @@ export const RNG_STREAM_IDS = {
   personnelMorale: 'personnel-morale',
   jobMarket: 'job-market',
   jobMarketCandidates: 'job-market.candidates',
+  jobMarketGender: 'job-market.gender',
   simulationTest: 'sim.test',
 } as const;
 


### PR DESCRIPTION
## Summary
- add a configurable `pDiverse` probability to the job market service and derive candidate gender from a dedicated seeded RNG stream
- update offline generation to decouple name selection from gender while documenting the new distribution controls
- expand job market tests to cover seeded gender outcomes and extreme diversity settings

## Testing
- `pnpm --filter @weebbreed/backend test`


------
https://chatgpt.com/codex/tasks/task_e_68d297e1d14883259ff02383a4c9020f