### PR TITLE
feat: drive personnel roles from blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Refer to the docs for simulation tuning, schema updates, and naming conventions
 before changing blueprints or code. Review the changelog and ADRs when planning
 tooling or architecture updates to stay aligned with previous decisions.
 
+### Personnel Role Blueprints
+
+- Author editable role definitions under
+  [`data/blueprints/personnelRoles.json`](docs/system/personnel_roles_blueprint.md).
+  The backend validates and normalizes the file at startup so changes feed both
+  the initial roster factory and the job market without code edits. Keep the doc
+  in sync when adding new roles or fields and run `pnpm validate:data` before
+  committing blueprint updates.
+
 ## Contributing
 
 Contribution guidelines, review expectations, and commit hygiene requirements

--- a/data/blueprints/personnelRoles.json
+++ b/data/blueprints/personnelRoles.json
@@ -1,0 +1,274 @@
+{
+  "version": "1.0.0",
+  "roles": [
+    {
+      "id": "Gardener",
+      "name": "Gardener",
+      "salary": {
+        "basePerTick": 24,
+        "skillFactor": {
+          "base": 0.85,
+          "perPoint": 0.04,
+          "min": 0.85,
+          "max": 1.45
+        },
+        "randomRange": {
+          "min": 0.9,
+          "max": 1.1
+        },
+        "skillWeights": {
+          "primary": 1.2,
+          "secondary": 0.6,
+          "tertiary": 0.35
+        }
+      },
+      "maxMinutesPerTick": 90,
+      "roleWeight": 0.35,
+      "skillProfile": {
+        "primary": {
+          "skill": "Gardening",
+          "startingLevel": 4,
+          "roll": {
+            "min": 3,
+            "max": 5
+          }
+        },
+        "secondary": {
+          "skill": "Cleanliness",
+          "startingLevel": 2,
+          "roll": {
+            "min": 1,
+            "max": 4
+          }
+        },
+        "tertiary": {
+          "chance": 0.25,
+          "roll": {
+            "min": 1,
+            "max": 3
+          },
+          "candidates": [
+            { "skill": "Logistics", "startingLevel": 1 },
+            { "skill": "Administration", "startingLevel": 1 },
+            { "skill": "Maintenance", "startingLevel": 1 }
+          ]
+        }
+      }
+    },
+    {
+      "id": "Technician",
+      "name": "Technician",
+      "salary": {
+        "basePerTick": 28,
+        "skillFactor": {
+          "base": 0.85,
+          "perPoint": 0.04,
+          "min": 0.85,
+          "max": 1.45
+        },
+        "randomRange": {
+          "min": 0.9,
+          "max": 1.12
+        },
+        "skillWeights": {
+          "primary": 1.25,
+          "secondary": 0.65,
+          "tertiary": 0.4
+        }
+      },
+      "maxMinutesPerTick": 120,
+      "roleWeight": 0.2,
+      "skillProfile": {
+        "primary": {
+          "skill": "Maintenance",
+          "startingLevel": 4,
+          "roll": {
+            "min": 3,
+            "max": 5
+          }
+        },
+        "secondary": {
+          "skill": "Logistics",
+          "startingLevel": 2,
+          "roll": {
+            "min": 1,
+            "max": 4
+          }
+        },
+        "tertiary": {
+          "chance": 0.25,
+          "roll": {
+            "min": 1,
+            "max": 3
+          },
+          "candidates": [
+            { "skill": "Gardening", "startingLevel": 1 },
+            { "skill": "Administration", "startingLevel": 1 },
+            { "skill": "Cleanliness", "startingLevel": 1 }
+          ]
+        }
+      }
+    },
+    {
+      "id": "Janitor",
+      "name": "Janitor",
+      "salary": {
+        "basePerTick": 18,
+        "skillFactor": {
+          "base": 0.85,
+          "perPoint": 0.04,
+          "min": 0.85,
+          "max": 1.45
+        },
+        "randomRange": {
+          "min": 0.88,
+          "max": 1.08
+        },
+        "skillWeights": {
+          "primary": 1.1,
+          "secondary": 0.55,
+          "tertiary": 0.3
+        }
+      },
+      "maxMinutesPerTick": 75,
+      "preferredShiftId": "shift.night",
+      "roleWeight": 0.15,
+      "skillProfile": {
+        "primary": {
+          "skill": "Cleanliness",
+          "startingLevel": 4,
+          "roll": {
+            "min": 3,
+            "max": 5
+          }
+        },
+        "secondary": {
+          "skill": "Logistics",
+          "startingLevel": 1,
+          "roll": {
+            "min": 0,
+            "max": 3
+          }
+        },
+        "tertiary": {
+          "chance": 0.3,
+          "roll": {
+            "min": 1,
+            "max": 3
+          },
+          "candidates": [
+            { "skill": "Administration", "startingLevel": 1 },
+            { "skill": "Gardening", "startingLevel": 1 },
+            { "skill": "Maintenance", "startingLevel": 1 }
+          ]
+        }
+      }
+    },
+    {
+      "id": "Operator",
+      "name": "Operator",
+      "salary": {
+        "basePerTick": 22,
+        "skillFactor": {
+          "base": 0.85,
+          "perPoint": 0.04,
+          "min": 0.85,
+          "max": 1.45
+        },
+        "randomRange": {
+          "min": 0.9,
+          "max": 1.1
+        },
+        "skillWeights": {
+          "primary": 1.15,
+          "secondary": 0.6,
+          "tertiary": 0.35
+        }
+      },
+      "maxMinutesPerTick": 90,
+      "preferredShiftId": "shift.day",
+      "roleWeight": 0.18,
+      "skillProfile": {
+        "primary": {
+          "skill": "Logistics",
+          "startingLevel": 3,
+          "roll": {
+            "min": 2,
+            "max": 4
+          }
+        },
+        "secondary": {
+          "skill": "Administration",
+          "startingLevel": 2,
+          "roll": {
+            "min": 1,
+            "max": 4
+          }
+        },
+        "tertiary": {
+          "chance": 0.25,
+          "roll": {
+            "min": 1,
+            "max": 3
+          },
+          "candidates": [
+            { "skill": "Cleanliness", "startingLevel": 1 },
+            { "skill": "Gardening", "startingLevel": 1 },
+            { "skill": "Maintenance", "startingLevel": 1 }
+          ]
+        }
+      }
+    },
+    {
+      "id": "Manager",
+      "name": "Manager",
+      "salary": {
+        "basePerTick": 35,
+        "skillFactor": {
+          "base": 0.85,
+          "perPoint": 0.04,
+          "min": 0.85,
+          "max": 1.5
+        },
+        "randomRange": {
+          "min": 0.95,
+          "max": 1.18
+        },
+        "skillWeights": {
+          "primary": 1.3,
+          "secondary": 0.7,
+          "tertiary": 0.45
+        }
+      },
+      "maxMinutesPerTick": 60,
+      "preferredShiftId": "shift.day",
+      "roleWeight": 0.12,
+      "skillProfile": {
+        "primary": {
+          "skill": "Administration",
+          "startingLevel": 4,
+          "roll": {
+            "min": 3,
+            "max": 5
+          }
+        },
+        "secondary": {
+          "skill": "Logistics",
+          "startingLevel": 2,
+          "roll": {
+            "min": 1,
+            "max": 4
+          }
+        },
+        "tertiary": {
+          "chance": 0.4,
+          "roll": {
+            "min": 1,
+            "max": 3
+          },
+          "candidates": [{ "skill": "Cleanliness", "startingLevel": 2, "weight": 2 }]
+        }
+      }
+    }
+  ]
+}

--- a/docs/system/personnel_roles_blueprint.md
+++ b/docs/system/personnel_roles_blueprint.md
@@ -1,0 +1,124 @@
+# Weedbreed.AI — Personnel Role Blueprint
+
+Personnel role blueprints describe every playable staff role without touching code.
+The simulation loads them from JSON during startup and uses them to drive initial
+roster creation, applicant synthesis, and persistence validation.
+
+- **Location:** `data/blueprints/personnelRoles.json`
+- **Schema owner:** Workforce systems (job market + personnel initialization)
+- **Validation:** `loadPersonnelRoleBlueprints()` (`zod`) normalizes data and falls
+  back to `DEFAULT_PERSONNEL_ROLE_BLUEPRINTS` when fields are missing.
+
+---
+
+## Top-Level Structure
+
+```jsonc
+{
+  "version": "1.0.0", // optional semantic version tag
+  "roles": [
+    {
+      /* PersonnelRoleBlueprint */
+    },
+  ],
+}
+```
+
+Each `roles[]` entry must declare a unique `id`. Unknown fields are ignored but
+preserved during normalization so designers can keep notes or tracking metadata
+alongside the required properties.
+
+---
+
+## PersonnelRoleBlueprint Fields
+
+| Field               | Type/Range                      | Notes                                                                                       |
+| ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------- |
+| `id`                | `string`                        | Canonical role identifier (`EmployeeRole`).                                                 |
+| `name`              | `string`                        | Display name in UI. Defaults to `id` when omitted.                                          |
+| `description`       | `string?`                       | Optional flavor text for dashboards.                                                        |
+| `preferredShiftId`  | `string?`                       | Matches IDs from `SHIFT_TEMPLATES` (e.g. `shift.day`).                                      |
+| `maxMinutesPerTick` | `number? (> 0)`                 | Per-tick labor cap; defaults to 90 minutes.                                                 |
+| `roleWeight`        | `number? (>= 0)`                | Relative applicant generation weight. When missing or zero the default role weight is used. |
+| `salary`            | [Salary config](#salary-config) | Required. Base pay plus optional modifiers.                                                 |
+| `skillProfile`      | [Skill profile](#skill-profile) | Required. Defines primary/secondary/tertiary skills.                                        |
+
+### Salary Config
+
+```jsonc
+{
+  "basePerTick": 24, // required base salary per tick
+  "skillFactor": {
+    // optional scaling by rolled skills
+    "base": 0.85,
+    "perPoint": 0.04,
+    "min": 0.85,
+    "max": 1.45,
+  },
+  "randomRange": {
+    // optional salary noise multiplier
+    "min": 0.9,
+    "max": 1.1,
+  },
+  "skillWeights": {
+    // optional contribution weights for salary score
+    "primary": 1.2,
+    "secondary": 0.6,
+    "tertiary": 0.35,
+  },
+}
+```
+
+- Omitted fields inherit the default blueprint values.
+- `skillFactor.*` values let designers tweak how aggressively skill points affect pay.
+- `randomRange` controls per-applicant salary noise; `min`/`max` are clamped and swapped if misordered.
+- `skillWeights` tune how primary/secondary/tertiary skills contribute to the salary multiplier. Missing entries fall back to defaults (1.2 / 0.6 / 0.35).
+
+### Skill Profile
+
+```jsonc
+{
+  "primary": {
+    "skill": "Gardening",       // required, must be one of EMPLOYEE_SKILL_NAMES
+    "startingLevel": 4,
+    "roll": { "min": 3, "max": 5 },
+    "weight": 2                 // optional, used when picking tertiary candidates
+  },
+  "secondary": { ... },          // optional second guaranteed skill
+  "tertiary": {                  // optional pool of probabilistic skills
+    "chance": 0.25,              // probability (0..1) of rolling a tertiary skill
+    "roll": { "min": 1, "max": 3 },
+    "candidates": [
+      { "skill": "Logistics", "startingLevel": 1, "weight": 1 },
+      { "skill": "Administration", "startingLevel": 1 }
+    ]
+  }
+}
+```
+
+- Primary skills are mandatory. Secondary and tertiary blocks are optional but inherit rolls/weights from defaults when omitted.
+- `roll` bounds are clamped and swapped automatically if `min > max`.
+- `weight` biases candidate selection when multiple tertiary skills exist.
+- Unknown skills are rejected during validation—only `EMPLOYEE_SKILL_NAMES` (`Gardening`, `Maintenance`, `Logistics`, `Cleanliness`, `Administration`) are allowed.
+
+---
+
+## Normalization & Fallbacks
+
+`normalizePersonnelRoleBlueprints()` merges user-provided data with the shipped defaults. Key behaviours:
+
+1. **Missing roles inherit defaults.** Every default role is always present even if the JSON omits it.
+2. **New roles are allowed.** Any role with an unknown `id` is accepted and will be surfaced to the job market and personnel factory.
+3. **Graceful roll handling.** Invalid or missing roll bounds are coerced to non-negative integer ranges (0–5).
+4. **Probability clamping.** Tertiary `chance` values are clamped to `[0, 1]`.
+5. **Salary guards.** Base salary defaults to the fallback role, and random ranges are sanitized so `min <= max` when both are provided.
+
+---
+
+## Runtime Consumers
+
+- `state/initialization/personnel.ts` — seeds the starting roster and exposes the loader/normalizer used in tests and factories.
+- `engine/workforce/jobMarketService.ts` — draws applicant roles, rolls skills, and computes salary expectations directly from the blueprints.
+- `persistence/schemas.ts` — derives the `EmployeeRole` enum and skill schema for save-game validation.
+
+Refer to [Job Market Population](./job_market_population.md) for the applicant pipeline and to this document when authoring new role definitions.

--- a/src/backend/src/persistence/schemas.ts
+++ b/src/backend/src/persistence/schemas.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { DEFAULT_PERSONNEL_ROLE_BLUEPRINTS, EMPLOYEE_SKILL_NAMES } from '@/state/models.js';
+import type { EmployeeRole } from '@/state/models.js';
 
 const isoDateString = z
   .string()
@@ -320,13 +322,7 @@ const financeStateSchema = z.object({
   summary: financialSummarySchema,
 });
 
-const skillNames = [
-  'Gardening',
-  'Maintenance',
-  'Logistics',
-  'Cleanliness',
-  'Administration',
-] as const;
+const skillNames = EMPLOYEE_SKILL_NAMES;
 const employeeSkillsSchema = z
   .object(
     Object.fromEntries(skillNames.map((name) => [name, z.number()])) as Record<
@@ -335,6 +331,12 @@ const employeeSkillsSchema = z
     >,
   )
   .partial();
+
+const employeeRoleValues = DEFAULT_PERSONNEL_ROLE_BLUEPRINTS.map((role) => role.id) as [
+  EmployeeRole,
+  ...EmployeeRole[],
+];
+const employeeRoleEnum = z.enum(employeeRoleValues);
 
 const employeeShiftSchema = z.object({
   shiftId: nonEmptyString,
@@ -347,7 +349,7 @@ const employeeShiftSchema = z.object({
 const employeeStateSchema = z.object({
   id: nonEmptyString,
   name: nonEmptyString,
-  role: z.enum(['Gardener', 'Technician', 'Janitor', 'Operator', 'Manager']),
+  role: employeeRoleEnum,
   salaryPerTick: z.number(),
   status: z.enum(['idle', 'assigned', 'offShift', 'training']),
   morale: z.number(),
@@ -369,7 +371,7 @@ const employeeStateSchema = z.object({
 const applicantStateSchema = z.object({
   id: nonEmptyString,
   name: nonEmptyString,
-  desiredRole: z.enum(['Gardener', 'Technician', 'Janitor', 'Operator', 'Manager']),
+  desiredRole: employeeRoleEnum,
   expectedSalary: z.number(),
   traits: z.array(nonEmptyString),
   skills: employeeSkillsSchema,
@@ -380,7 +382,7 @@ const applicantStateSchema = z.object({
 const trainingProgramSchema = z.object({
   id: nonEmptyString,
   name: nonEmptyString,
-  targetRole: z.enum(['Gardener', 'Technician', 'Janitor', 'Operator', 'Manager']),
+  targetRole: employeeRoleEnum,
   progress: z.number(),
   attendees: z.array(nonEmptyString),
 });

--- a/src/backend/src/state/initialization/personnel.test.ts
+++ b/src/backend/src/state/initialization/personnel.test.ts
@@ -3,8 +3,12 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { RngService, RNG_STREAM_IDS } from '@/lib/rng.js';
-import type { PersonnelNameDirectory } from '@/state/models.js';
-import { createPersonnel, loadPersonnelDirectory } from './personnel.js';
+import type { PersonnelNameDirectory, PersonnelRoleBlueprint } from '@/state/models.js';
+import {
+  createPersonnel,
+  loadPersonnelDirectory,
+  loadPersonnelRoleBlueprints,
+} from './personnel.js';
 
 describe('state/initialization/personnel', () => {
   it('loads personnel name directories with gender-specific files', async () => {
@@ -43,6 +47,54 @@ describe('state/initialization/personnel', () => {
       expect(directory.randomSeeds).toEqual(['seed-0']);
       expect(directory.lastNames).toContain('Patel');
       expect(directory.traits[0]?.id).toBe('trait_detail');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads and normalizes personnel role blueprints with fallback data', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-role-blueprints-'));
+    try {
+      const blueprintDir = path.join(tempDir, 'blueprints');
+      await fs.mkdir(blueprintDir, { recursive: true });
+      const customRoles: { roles: PersonnelRoleBlueprint[] } = {
+        roles: [
+          {
+            id: 'Gardener',
+            name: 'Field Gardener',
+            salary: { basePerTick: 26 },
+            skillProfile: {
+              primary: { skill: 'Gardening', startingLevel: 5, roll: { min: 3, max: 5 } },
+            },
+          } as PersonnelRoleBlueprint,
+          {
+            id: 'Specialist',
+            name: 'IPM Specialist',
+            roleWeight: 0.05,
+            salary: { basePerTick: 30 },
+            skillProfile: {
+              primary: { skill: 'Cleanliness', startingLevel: 4, roll: { min: 2, max: 4 } },
+            },
+          } as PersonnelRoleBlueprint,
+        ],
+      };
+      await fs.writeFile(
+        path.join(blueprintDir, 'personnelRoles.json'),
+        JSON.stringify(customRoles, null, 2),
+      );
+
+      const roles = await loadPersonnelRoleBlueprints(tempDir);
+      const gardener = roles.find((role) => role.id === 'Gardener');
+      const specialist = roles.find((role) => role.id === 'Specialist');
+
+      expect(gardener?.salary.basePerTick).toBe(26);
+      expect(gardener?.skillProfile.secondary?.skill).toBe('Cleanliness');
+      expect(gardener?.salary.skillFactor?.perPoint).toBeCloseTo(0.04);
+
+      expect(specialist?.maxMinutesPerTick).toBeGreaterThan(0);
+      expect(specialist?.skillProfile.primary.skill).toBe('Cleanliness');
+      expect(specialist?.skillProfile.secondary).toBeUndefined();
+      expect(specialist?.salary.skillFactor?.base).toBeGreaterThan(0);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -408,14 +408,244 @@ export interface FinanceState {
   summary: FinancialSummary;
 }
 
-export type EmployeeRole = 'Gardener' | 'Technician' | 'Janitor' | 'Operator' | 'Manager';
+export const EMPLOYEE_SKILL_NAMES = [
+  'Gardening',
+  'Maintenance',
+  'Logistics',
+  'Cleanliness',
+  'Administration',
+] as const;
 
-export type SkillName =
-  | 'Gardening'
-  | 'Maintenance'
-  | 'Logistics'
-  | 'Cleanliness'
-  | 'Administration';
+export type SkillName = (typeof EMPLOYEE_SKILL_NAMES)[number];
+
+export interface PersonnelRoleSkillRoll {
+  min: number;
+  max: number;
+}
+
+export interface PersonnelRoleSkillTemplate {
+  skill: SkillName;
+  startingLevel: number;
+  roll?: PersonnelRoleSkillRoll;
+  weight?: number;
+}
+
+export interface PersonnelRoleTertiarySkillConfig {
+  chance?: number;
+  roll?: PersonnelRoleSkillRoll;
+  candidates: PersonnelRoleSkillTemplate[];
+}
+
+export interface PersonnelRoleSkillProfile {
+  primary: PersonnelRoleSkillTemplate;
+  secondary?: PersonnelRoleSkillTemplate;
+  tertiary?: PersonnelRoleTertiarySkillConfig;
+}
+
+export interface PersonnelRoleSalaryWeights {
+  primary?: number;
+  secondary?: number;
+  tertiary?: number;
+}
+
+export interface PersonnelRoleSalaryRandomRange {
+  min?: number;
+  max?: number;
+}
+
+export interface PersonnelRoleSalaryFactorConfig {
+  base?: number;
+  perPoint?: number;
+  min?: number;
+  max?: number;
+}
+
+export interface PersonnelRoleSalaryConfig {
+  basePerTick: number;
+  skillFactor?: PersonnelRoleSalaryFactorConfig;
+  randomRange?: PersonnelRoleSalaryRandomRange;
+  skillWeights?: PersonnelRoleSalaryWeights;
+}
+
+export interface PersonnelRoleBlueprint {
+  id: string;
+  name: string;
+  description?: string;
+  preferredShiftId?: string;
+  maxMinutesPerTick?: number;
+  roleWeight?: number;
+  salary: PersonnelRoleSalaryConfig;
+  skillProfile: PersonnelRoleSkillProfile;
+}
+
+export const DEFAULT_PERSONNEL_ROLE_BLUEPRINTS = [
+  {
+    id: 'Gardener',
+    name: 'Gardener',
+    maxMinutesPerTick: 90,
+    roleWeight: 0.35,
+    salary: {
+      basePerTick: 24,
+      skillFactor: { base: 0.85, perPoint: 0.04, min: 0.85, max: 1.45 },
+      randomRange: { min: 0.9, max: 1.1 },
+      skillWeights: { primary: 1.2, secondary: 0.6, tertiary: 0.35 },
+    },
+    skillProfile: {
+      primary: {
+        skill: 'Gardening',
+        startingLevel: 4,
+        roll: { min: 3, max: 5 },
+      },
+      secondary: {
+        skill: 'Cleanliness',
+        startingLevel: 2,
+        roll: { min: 1, max: 4 },
+      },
+      tertiary: {
+        chance: 0.25,
+        roll: { min: 1, max: 3 },
+        candidates: [
+          { skill: 'Logistics', startingLevel: 1 },
+          { skill: 'Administration', startingLevel: 1 },
+          { skill: 'Maintenance', startingLevel: 1 },
+        ],
+      },
+    },
+  },
+  {
+    id: 'Technician',
+    name: 'Technician',
+    maxMinutesPerTick: 120,
+    roleWeight: 0.2,
+    salary: {
+      basePerTick: 28,
+      skillFactor: { base: 0.85, perPoint: 0.04, min: 0.85, max: 1.45 },
+      randomRange: { min: 0.9, max: 1.12 },
+      skillWeights: { primary: 1.25, secondary: 0.65, tertiary: 0.4 },
+    },
+    skillProfile: {
+      primary: {
+        skill: 'Maintenance',
+        startingLevel: 4,
+        roll: { min: 3, max: 5 },
+      },
+      secondary: {
+        skill: 'Logistics',
+        startingLevel: 2,
+        roll: { min: 1, max: 4 },
+      },
+      tertiary: {
+        chance: 0.25,
+        roll: { min: 1, max: 3 },
+        candidates: [
+          { skill: 'Gardening', startingLevel: 1 },
+          { skill: 'Administration', startingLevel: 1 },
+          { skill: 'Cleanliness', startingLevel: 1 },
+        ],
+      },
+    },
+  },
+  {
+    id: 'Janitor',
+    name: 'Janitor',
+    maxMinutesPerTick: 75,
+    preferredShiftId: 'shift.night',
+    roleWeight: 0.15,
+    salary: {
+      basePerTick: 18,
+      skillFactor: { base: 0.85, perPoint: 0.04, min: 0.85, max: 1.45 },
+      randomRange: { min: 0.88, max: 1.08 },
+      skillWeights: { primary: 1.1, secondary: 0.55, tertiary: 0.3 },
+    },
+    skillProfile: {
+      primary: {
+        skill: 'Cleanliness',
+        startingLevel: 4,
+        roll: { min: 3, max: 5 },
+      },
+      secondary: {
+        skill: 'Logistics',
+        startingLevel: 1,
+        roll: { min: 0, max: 3 },
+      },
+      tertiary: {
+        chance: 0.3,
+        roll: { min: 1, max: 3 },
+        candidates: [
+          { skill: 'Administration', startingLevel: 1 },
+          { skill: 'Gardening', startingLevel: 1 },
+          { skill: 'Maintenance', startingLevel: 1 },
+        ],
+      },
+    },
+  },
+  {
+    id: 'Operator',
+    name: 'Operator',
+    maxMinutesPerTick: 90,
+    preferredShiftId: 'shift.day',
+    roleWeight: 0.18,
+    salary: {
+      basePerTick: 22,
+      skillFactor: { base: 0.85, perPoint: 0.04, min: 0.85, max: 1.45 },
+      randomRange: { min: 0.9, max: 1.1 },
+      skillWeights: { primary: 1.15, secondary: 0.6, tertiary: 0.35 },
+    },
+    skillProfile: {
+      primary: {
+        skill: 'Logistics',
+        startingLevel: 3,
+        roll: { min: 2, max: 4 },
+      },
+      secondary: {
+        skill: 'Administration',
+        startingLevel: 2,
+        roll: { min: 1, max: 4 },
+      },
+      tertiary: {
+        chance: 0.25,
+        roll: { min: 1, max: 3 },
+        candidates: [
+          { skill: 'Cleanliness', startingLevel: 1 },
+          { skill: 'Gardening', startingLevel: 1 },
+          { skill: 'Maintenance', startingLevel: 1 },
+        ],
+      },
+    },
+  },
+  {
+    id: 'Manager',
+    name: 'Manager',
+    maxMinutesPerTick: 60,
+    preferredShiftId: 'shift.day',
+    roleWeight: 0.12,
+    salary: {
+      basePerTick: 35,
+      skillFactor: { base: 0.85, perPoint: 0.04, min: 0.85, max: 1.5 },
+      randomRange: { min: 0.95, max: 1.18 },
+      skillWeights: { primary: 1.3, secondary: 0.7, tertiary: 0.45 },
+    },
+    skillProfile: {
+      primary: {
+        skill: 'Administration',
+        startingLevel: 4,
+        roll: { min: 3, max: 5 },
+      },
+      secondary: {
+        skill: 'Logistics',
+        startingLevel: 2,
+        roll: { min: 1, max: 4 },
+      },
+      tertiary: {
+        chance: 0.4,
+        roll: { min: 1, max: 3 },
+        candidates: [{ skill: 'Cleanliness', startingLevel: 2, weight: 2 }],
+      },
+    },
+  },
+] as const satisfies readonly PersonnelRoleBlueprint[];
+
+export type EmployeeRole = (typeof DEFAULT_PERSONNEL_ROLE_BLUEPRINTS)[number]['id'];
 
 export type EmployeeSkills = Partial<Record<SkillName, number>>;
 

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -16,6 +16,7 @@ import type {
   GlobalInventoryState,
   HarvestBatch,
   PersonnelNameDirectory,
+  PersonnelRoleBlueprint,
   PlantHealthState,
   PlantState,
   ResourceInventory,
@@ -40,7 +41,11 @@ import {
   selectBlueprint,
 } from './state/initialization/blueprints.js';
 import { createFinanceState } from './state/initialization/finance.js';
-import { createPersonnel, loadPersonnelDirectory } from './state/initialization/personnel.js';
+import {
+  createPersonnel,
+  loadPersonnelDirectory,
+  loadPersonnelRoleBlueprints,
+} from './state/initialization/personnel.js';
 import { createTasks, loadTaskDefinitions } from './state/initialization/tasks.js';
 import { resolveRoomPurposeId, requireRoomPurposeByName } from './engine/roomPurposes/index.js';
 import type { RoomPurpose, RoomPurposeSlug } from './engine/roomPurposes/index.js';
@@ -48,7 +53,10 @@ import { validateStructureGeometry } from './state/geometry.js';
 import { addDeviceToZone } from './state/devices.js';
 
 export { loadStructureBlueprints } from './state/initialization/blueprints.js';
-export { loadPersonnelDirectory } from './state/initialization/personnel.js';
+export {
+  loadPersonnelDirectory,
+  loadPersonnelRoleBlueprints,
+} from './state/initialization/personnel.js';
 export { loadTaskDefinitions } from './state/initialization/tasks.js';
 
 const DEFAULT_TICK_LENGTH_MINUTES = 60;
@@ -125,6 +133,7 @@ export interface StateFactoryContext {
   dataDirectory?: string;
   structureBlueprints?: StructureBlueprint[];
   personnelDirectory?: PersonnelNameDirectory;
+  personnelRoleBlueprints?: PersonnelRoleBlueprint[];
   taskDefinitions?: TaskDefinitionMap;
   defaultStructureHeightMeters?: number;
 }
@@ -496,6 +505,10 @@ export const createInitialState = async (
     context.personnelDirectory ??
     (context.dataDirectory ? await loadPersonnelDirectory(context.dataDirectory) : undefined);
 
+  const personnelRoleBlueprints =
+    context.personnelRoleBlueprints ??
+    (context.dataDirectory ? await loadPersonnelRoleBlueprints(context.dataDirectory) : undefined);
+
   const employeeCounts: Record<EmployeeRole, number> = {
     ...DEFAULT_EMPLOYEE_COUNTS,
     ...options.employeeCountByRole,
@@ -507,6 +520,7 @@ export const createInitialState = async (
     personnelDirectory,
     context.rng,
     idStream,
+    { roleBlueprints: personnelRoleBlueprints },
   );
 
   const inventory = createInventory(strain, structureResult.plantCount, idStream);


### PR DESCRIPTION
## Summary
- add a personnel role blueprint JSON file and document the schema for designers
- load and normalize role blueprints during state initialization, job market population, and persistence validation
- extend workforce tests with blueprint-driven fixtures including a golden applicant snapshot

## Testing
- pnpm --filter @weebbreed/backend test -- src/engine/workforce/__tests__/jobMarketService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2a3d830a48325af898f7bd028663a