### PR TITLE
feat: load personnel skills from blueprints

### DIFF
--- a/data/blueprints/personnel/skills/Administration.json
+++ b/data/blueprints/personnel/skills/Administration.json
@@ -1,0 +1,6 @@
+{
+  "id": "Administration",
+  "name": "Administration",
+  "description": "Planning, reporting, compliance oversight, and documentation workflows.",
+  "tags": ["management", "compliance"]
+}

--- a/data/blueprints/personnel/skills/Cleanliness.json
+++ b/data/blueprints/personnel/skills/Cleanliness.json
@@ -1,0 +1,6 @@
+{
+  "id": "Cleanliness",
+  "name": "Cleanliness",
+  "description": "Sanitation, hygiene, and compliance routines across rooms and devices.",
+  "tags": ["quality", "safety"]
+}

--- a/data/blueprints/personnel/skills/Gardening.json
+++ b/data/blueprints/personnel/skills/Gardening.json
@@ -1,0 +1,6 @@
+{
+  "id": "Gardening",
+  "name": "Gardening",
+  "description": "Plant care, canopy management, pruning, and phenology adjustments.",
+  "tags": ["cultivation"]
+}

--- a/data/blueprints/personnel/skills/Logistics.json
+++ b/data/blueprints/personnel/skills/Logistics.json
@@ -1,0 +1,6 @@
+{
+  "id": "Logistics",
+  "name": "Logistics",
+  "description": "Inventory stewardship, material handling, and production scheduling.",
+  "tags": ["operations"]
+}

--- a/data/blueprints/personnel/skills/Maintenance.json
+++ b/data/blueprints/personnel/skills/Maintenance.json
@@ -1,0 +1,6 @@
+{
+  "id": "Maintenance",
+  "name": "Maintenance",
+  "description": "Device diagnostics, preventive maintenance, and facility upkeep routines.",
+  "tags": ["operations", "technical"]
+}

--- a/src/backend/src/engine/workforce/jobMarketService.ts
+++ b/src/backend/src/engine/workforce/jobMarketService.ts
@@ -13,7 +13,11 @@ import type {
   PersonnelRoleSkillTemplate,
   SkillName,
 } from '@/state/models.js';
-import { DEFAULT_PERSONNEL_ROLE_BLUEPRINTS, EMPLOYEE_SKILL_NAMES } from '@/state/models.js';
+import {
+  DEFAULT_PERSONNEL_ROLE_BLUEPRINTS,
+  DEFAULT_PERSONNEL_SKILL_BLUEPRINTS,
+  getEmployeeSkillNames,
+} from '@/state/models.js';
 import { generateId } from '@/state/initialization/common.js';
 import {
   loadPersonnelDirectory,
@@ -546,15 +550,22 @@ export class JobMarketService {
     primary: SkillName,
     secondary?: SkillName,
   ): PersonnelRoleSkillTemplate[] {
-    return EMPLOYEE_SKILL_NAMES.filter((skill) => skill !== primary && skill !== secondary).map(
-      (skill) =>
-        ({
-          skill,
-          startingLevel: 1,
-          roll: { min: 1, max: 3 },
-          weight: 1,
-        }) satisfies PersonnelRoleSkillTemplate,
-    );
+    const available = getEmployeeSkillNames();
+    const source =
+      available.length > 0
+        ? available
+        : DEFAULT_PERSONNEL_SKILL_BLUEPRINTS.map((skill) => skill.id);
+    return source
+      .filter((skill) => skill !== primary && skill !== secondary)
+      .map(
+        (skill) =>
+          ({
+            skill,
+            startingLevel: 1,
+            roll: { min: 1, max: 3 },
+            weight: 1,
+          }) satisfies PersonnelRoleSkillTemplate,
+      );
   }
 
   private rollSkills(blueprint: PersonnelRoleBlueprint, stream: RngStream): EmployeeSkills {

--- a/src/backend/src/persistence/schemas.test.ts
+++ b/src/backend/src/persistence/schemas.test.ts
@@ -45,4 +45,31 @@ describe('saveGameEnvelopeSchema', () => {
     const result = saveGameEnvelopeSchema.safeParse(invalid);
     expect(result.success).toBe(false);
   });
+
+  it('rejects save games that contain unknown personnel skills', async () => {
+    const context = createStateFactoryContext('schema-skill-unknown');
+    const state = await createInitialState(context);
+    const employee = state.personnel.employees[0];
+    expect(employee).toBeDefined();
+    if (employee) {
+      employee.skills = { ...employee.skills, UnknownSkill: 3 };
+    }
+
+    const envelope = {
+      header: {
+        kind: SAVEGAME_KIND,
+        version: '1.0.0',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      metadata: {
+        tickLengthMinutes: state.metadata.tickLengthMinutes,
+        rngSeed: context.rng.getSeed(),
+      },
+      rng: context.rng.serialize(),
+      state,
+    } as const;
+
+    const result = saveGameEnvelopeSchema.safeParse(envelope);
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/backend/src/state/models.test.ts
+++ b/src/backend/src/state/models.test.ts
@@ -1,5 +1,15 @@
+import { promises as fs } from 'node:fs';
+import os from 'os';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { getApplicantPersonalSeed, type ApplicantState } from './models.js';
+import {
+  getApplicantPersonalSeed,
+  getEmployeeSkillNames,
+  isKnownSkillName,
+  loadPersonnelSkillBlueprints,
+  resetPersonnelSkillBlueprints,
+  type ApplicantState,
+} from './models.js';
 
 describe('getApplicantPersonalSeed', () => {
   const baseApplicant: ApplicantState = {
@@ -20,5 +30,35 @@ describe('getApplicantPersonalSeed', () => {
     expect(getApplicantPersonalSeed(baseApplicant)).toBeUndefined();
     const blankSeed: ApplicantState = { ...baseApplicant, personalSeed: '   ' };
     expect(getApplicantPersonalSeed(blankSeed)).toBeUndefined();
+  });
+});
+
+describe('personnel skill blueprints', () => {
+  it('loads skill blueprints from disk and updates the known skill registry', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-skill-blueprints-'));
+    try {
+      const skillsDir = path.join(tempDir, 'blueprints', 'personnel', 'skills');
+      await fs.mkdir(skillsDir, { recursive: true });
+      const researchBlueprint = {
+        id: 'Research',
+        name: 'Research',
+        description: 'Lab analytics and cultivar experimentation.',
+        tags: ['lab'],
+      } as const;
+      await fs.writeFile(
+        path.join(skillsDir, 'Research.json'),
+        JSON.stringify(researchBlueprint, null, 2),
+      );
+
+      const loaded = await loadPersonnelSkillBlueprints(tempDir);
+
+      expect(loaded).toEqual([expect.objectContaining({ id: 'Research', name: 'Research' })]);
+      expect(getEmployeeSkillNames()).toEqual(['Research']);
+      expect(isKnownSkillName('Research')).toBe(true);
+      expect(isKnownSkillName('Gardening')).toBe(false);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetPersonnelSkillBlueprints();
+    }
   });
 });

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -1,3 +1,9 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { readJsonFile } from './initialization/common.js';
+
 /**
  * Core TypeScript interfaces for the simulation game state.
  * These structures intentionally mirror the blueprint driven domain model
@@ -408,15 +414,215 @@ export interface FinanceState {
   summary: FinancialSummary;
 }
 
-export const EMPLOYEE_SKILL_NAMES = [
-  'Gardening',
-  'Maintenance',
-  'Logistics',
-  'Cleanliness',
-  'Administration',
-] as const;
+export type SkillName = string;
 
-export type SkillName = (typeof EMPLOYEE_SKILL_NAMES)[number];
+export interface PersonnelSkillBlueprint {
+  id: SkillName;
+  name: string;
+  description?: string;
+  tags?: string[];
+}
+
+const personnelSkillBlueprintSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().optional(),
+    tags: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+const sanitizeSkillTags = (tags: unknown): string[] | undefined => {
+  if (!Array.isArray(tags)) {
+    return undefined;
+  }
+  const normalized = tags
+    .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+    .filter((tag) => tag.length > 0);
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  return Array.from(new Set(normalized));
+};
+
+const normalizeSkillBlueprint = (blueprint: PersonnelSkillBlueprint): PersonnelSkillBlueprint => {
+  const id = blueprint.id.trim();
+  const name = (blueprint.name ?? id).trim() || id;
+  const description =
+    typeof blueprint.description === 'string' ? blueprint.description.trim() : undefined;
+  const tags = sanitizeSkillTags(blueprint.tags);
+  return {
+    id,
+    name,
+    ...(description ? { description } : {}),
+    ...(tags ? { tags } : {}),
+  } satisfies PersonnelSkillBlueprint;
+};
+
+const toNormalizedSkillBlueprints = (
+  blueprints: readonly PersonnelSkillBlueprint[],
+): PersonnelSkillBlueprint[] => {
+  const byId = new Map<SkillName, PersonnelSkillBlueprint>();
+  for (const entry of blueprints) {
+    if (!entry || typeof entry.id !== 'string') {
+      continue;
+    }
+    const normalized = normalizeSkillBlueprint(entry);
+    if (normalized.id.length === 0) {
+      continue;
+    }
+    byId.set(normalized.id, normalized);
+  }
+  return Array.from(byId.values());
+};
+
+const PERSONNEL_SKILL_BLUEPRINT_DIR = path.join('personnel', 'skills');
+const PERSONNEL_SKILL_BLUEPRINT_EXTENSION = '.json';
+
+export const DEFAULT_PERSONNEL_SKILL_BLUEPRINTS = [
+  {
+    id: 'Gardening',
+    name: 'Gardening',
+    description: 'Canopy management, pruning, and growth optimisation skills.',
+    tags: ['cultivation'],
+  },
+  {
+    id: 'Maintenance',
+    name: 'Maintenance',
+    description: 'Upkeep of facilities, devices, and preventive repair routines.',
+    tags: ['operations'],
+  },
+  {
+    id: 'Logistics',
+    name: 'Logistics',
+    description: 'Inventory handling, scheduling, and supply coordination.',
+    tags: ['operations'],
+  },
+  {
+    id: 'Cleanliness',
+    name: 'Cleanliness',
+    description: 'Sanitation, hygiene, and compliance procedures.',
+    tags: ['quality'],
+  },
+  {
+    id: 'Administration',
+    name: 'Administration',
+    description: 'Planning, reporting, and regulatory record keeping.',
+    tags: ['management'],
+  },
+] as const satisfies readonly PersonnelSkillBlueprint[];
+
+const skillBlueprintCache: PersonnelSkillBlueprint[] = [];
+const employeeSkillNamesCache: SkillName[] = [];
+const skillNameSet = new Set<SkillName>();
+
+const applySkillBlueprints = (source: readonly PersonnelSkillBlueprint[]): void => {
+  const normalized = toNormalizedSkillBlueprints(source);
+  const effective =
+    normalized.length > 0
+      ? normalized
+      : toNormalizedSkillBlueprints(DEFAULT_PERSONNEL_SKILL_BLUEPRINTS);
+  skillBlueprintCache.length = 0;
+  skillBlueprintCache.push(...effective.map((entry) => ({ ...entry })));
+  skillNameSet.clear();
+  employeeSkillNamesCache.length = 0;
+  for (const blueprint of skillBlueprintCache) {
+    skillNameSet.add(blueprint.id);
+    employeeSkillNamesCache.push(blueprint.id);
+  }
+};
+
+applySkillBlueprints(DEFAULT_PERSONNEL_SKILL_BLUEPRINTS);
+
+export const EMPLOYEE_SKILL_NAMES = employeeSkillNamesCache;
+
+export const getEmployeeSkillNames = (): SkillName[] => [...employeeSkillNamesCache];
+
+export const getPersonnelSkillBlueprints = (): PersonnelSkillBlueprint[] =>
+  skillBlueprintCache.map((entry) => ({ ...entry }));
+
+export const isKnownSkillName = (value: unknown): value is SkillName =>
+  typeof value === 'string' && skillNameSet.has(value);
+
+export const setPersonnelSkillBlueprints = (
+  blueprints: readonly PersonnelSkillBlueprint[],
+): void => {
+  applySkillBlueprints(blueprints);
+};
+
+export const resetPersonnelSkillBlueprints = (): void => {
+  applySkillBlueprints(DEFAULT_PERSONNEL_SKILL_BLUEPRINTS);
+};
+
+const listSkillBlueprintFiles = async (directory: string): Promise<string[] | undefined> => {
+  try {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => name.toLowerCase().endsWith(PERSONNEL_SKILL_BLUEPRINT_EXTENSION))
+      .sort((a, b) => a.localeCompare(b));
+    return files.length > 0 ? files : undefined;
+  } catch (error) {
+    const cause = error as NodeJS.ErrnoException;
+    if (cause.code === 'ENOENT') {
+      return undefined;
+    }
+    throw new Error(
+      `Failed to read personnel skill blueprint directory at ${directory}: ${cause.message}`,
+    );
+  }
+};
+
+const parsePersonnelSkillBlueprint = (
+  raw: unknown,
+  sourceLabel: string,
+): PersonnelSkillBlueprint => {
+  const parsed = personnelSkillBlueprintSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const pathInfo = issue?.path?.length ? ` at ${issue.path.join('.')}` : '';
+    throw new Error(
+      `Invalid personnel skill blueprint in ${sourceLabel}${pathInfo}: ${
+        issue?.message ?? 'unknown validation error'
+      }`,
+    );
+  }
+  return normalizeSkillBlueprint(parsed.data);
+};
+
+export const normalizePersonnelSkillBlueprints = (
+  blueprints: readonly PersonnelSkillBlueprint[] | undefined,
+): PersonnelSkillBlueprint[] => {
+  if (!blueprints || blueprints.length === 0) {
+    return getPersonnelSkillBlueprints();
+  }
+  const normalized = toNormalizedSkillBlueprints(blueprints);
+  return normalized.length > 0 ? normalized : getPersonnelSkillBlueprints();
+};
+
+export const loadPersonnelSkillBlueprints = async (
+  dataDirectory: string,
+): Promise<PersonnelSkillBlueprint[]> => {
+  const blueprintRoot = path.join(dataDirectory, 'blueprints');
+  const directoryPath = path.join(blueprintRoot, PERSONNEL_SKILL_BLUEPRINT_DIR);
+  const files = await listSkillBlueprintFiles(directoryPath);
+  if (!files || files.length === 0) {
+    applySkillBlueprints(DEFAULT_PERSONNEL_SKILL_BLUEPRINTS);
+    return getPersonnelSkillBlueprints();
+  }
+  const drafts: PersonnelSkillBlueprint[] = [];
+  for (const fileName of files) {
+    const filePath = path.join(directoryPath, fileName);
+    const raw = await readJsonFile<unknown>(filePath);
+    if (raw === undefined) {
+      continue;
+    }
+    drafts.push(parsePersonnelSkillBlueprint(raw, filePath));
+  }
+  applySkillBlueprints(drafts);
+  return getPersonnelSkillBlueprints();
+};
 
 export interface PersonnelRoleSkillRoll {
   min: number;


### PR DESCRIPTION
## Summary
- add personnel skill blueprint JSON files and a loader that populates the skill registry
- validate personnel roles, persistence schemas, and job market behaviour against dynamically loaded skill names
- cover skill loading, validation failures, and runtime integration with new unit and integration tests

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d2b8bb9c84832590650887baea03fc