### PR TITLE
Normalize clickdummy zone telemetry hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aliases, and recorded ADR 0007 to explain the consolidation. Confirmed the
   frontend `@/engine` alias cleanup so the tooling no longer advertises the
   defunct path.
+- Expanded the clickdummy translator to normalize zone telemetry, resources,
+  and health restrictions in SI units before the frontend stores hydrate.
 
 ### Fixed
 

--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -75,7 +75,10 @@
    - ✅ `translateClickDummyGameData` mappt die Klickdummy-Fixtures jetzt in `src/frontend/src/fixtures/translator.ts` auf vollständige `SimulationSnapshot`-Slices inklusive volumetrischer Geometrie, Ressourcen, Gerätegruppen sowie normalisierten Temperatur-/RH-/VPD-Werten. Tests (`src/frontend/src/fixtures/translator.test.ts`) sichern die SI-Konvertierungen und Gehalts-/Kosten-Normalisierung ab.
 
 2. Zone-Daten konvertieren: Rechne alle zonalen Kennzahlen (RH, KPIs, Ressourcen) in die erwarteten numerischen SI-Einheiten um und fülle fehlende Telemetrie-/Gesundheitsfelder auf, bevor sie die Stores hydratisieren.
-
+   - ✅ Die Übersetzungsschicht normalisiert jetzt sämtliche Zonenkennzahlen (Temperatur, RH, CO₂,
+     PPFD, DLI, Ressourcenstände, Verbräuche) auf SI-Einheiten und leitet daraus
+     versorgungs- sowie Gesundheitsrestriktionen ab, bevor die Daten in die Stores gelangen
+     (`src/frontend/src/fixtures/translator.ts`; Tests sichern die Konvertierung).
 3. Pflanzen-, Geräte-, Personal- und Finanzobjekte anreichern: Erweitere Fixtures um strain-IDs, Stadien, Geräte-Blueprint-Informationen, per-Tick-Kosten sowie tickbasierte Finanzhistorien, damit sie die Snapshot-Typen erfüllen.
 
 4. Deterministische Hilfsfunktionen zentralisieren: Ersetze deterministicUuid und globale SeededRandom-Instanzen durch eine seeded Helper-Utility in store/utils, die wiederholbare IDs und Zufallsdaten liefert.

--- a/src/frontend/src/fixtures/translator.test.ts
+++ b/src/frontend/src/fixtures/translator.test.ts
@@ -37,6 +37,85 @@ const SAMPLE_DATA: ClickDummyGameData = {
               kpis: [
                 { title: 'PPFD', value: '882', unit: 'µmol/m²/s', target: 900, status: 'optimal' },
                 { title: 'VPD', value: '1.2', unit: 'kPa', target: 1.1, status: 'warning' },
+                {
+                  title: 'Temperature',
+                  value: '25.2 °C',
+                  unit: '°C',
+                  target: 25,
+                  status: 'optimal',
+                },
+                { title: 'Humidity', value: '52 %', unit: '%', target: 50, status: 'optimal' },
+                {
+                  title: 'CO₂ level',
+                  value: '1,180',
+                  unit: 'ppm',
+                  target: 1200,
+                  status: 'warning',
+                },
+                {
+                  title: 'Water reserve',
+                  value: '1,200 L',
+                  unit: 'L',
+                  target: 1000,
+                  status: 'warning',
+                },
+                {
+                  title: 'Nutrient solution',
+                  value: '480 L',
+                  unit: 'L',
+                  target: 450,
+                  status: 'warning',
+                },
+                {
+                  title: 'Nutrient strength',
+                  value: '90 %',
+                  unit: '%',
+                  target: 100,
+                  status: 'warning',
+                },
+                {
+                  title: 'Reservoir level',
+                  value: '68%',
+                  unit: '%',
+                  target: 70,
+                  status: 'warning',
+                },
+                {
+                  title: 'Substrate health',
+                  value: '82 %',
+                  unit: '%',
+                  target: 90,
+                  status: 'warning',
+                },
+                { title: 'Transpiration', value: '14 L', unit: 'L', target: 12, status: 'warning' },
+                { title: 'Stress level', value: '45 %', unit: '%', target: 30, status: 'warning' },
+                { title: 'Pending treatments', value: '3', unit: '', target: 0, status: 'danger' },
+                { title: 'Applied treatments', value: '1', unit: '', target: 0, status: 'warning' },
+                { title: 'Disease incidents', value: '2', unit: '', target: 0, status: 'danger' },
+                { title: 'Pest sightings', value: '1', unit: '', target: 0, status: 'warning' },
+                { title: 'Re-entry wait', value: '12', unit: 'h', target: 0, status: 'warning' },
+                {
+                  title: 'Pre-harvest interval',
+                  value: '2',
+                  unit: 'days',
+                  target: 0,
+                  status: 'warning',
+                },
+                {
+                  title: 'Daily water consumption',
+                  value: '180',
+                  unit: 'L/day',
+                  target: 150,
+                  status: 'warning',
+                },
+                {
+                  title: 'Daily nutrient consumption',
+                  value: '90',
+                  unit: 'L/day',
+                  target: 80,
+                  status: 'warning',
+                },
+                { title: 'DLI', value: '32', unit: 'mol/m²/d', target: 30, status: 'optimal' },
               ],
               plants: [
                 {
@@ -109,10 +188,36 @@ describe('translateClickDummyGameData', () => {
 
     expect(snapshot.zones).toHaveLength(1);
     const [zone] = snapshot.zones;
+    expect(zone.environment.temperature).toBeCloseTo(25.2, 5);
     expect(zone.environment.relativeHumidity).toBeCloseTo(0.52, 5);
+    expect(zone.environment.co2).toBeCloseTo(1180, 5);
     expect(zone.environment.vpd).toBeCloseTo(1.2, 5);
     expect(zone.lighting?.photoperiodHours?.on).toBe(12);
-    expect(zone.lighting?.dli).toBeGreaterThan(0);
+    expect(zone.lighting?.dli).toBeCloseTo(32, 5);
+    expect(zone.lighting?.averagePpfd).toBeCloseTo(882, 5);
+
+    expect(zone.resources.waterLiters).toBeCloseTo(1200, 5);
+    expect(zone.resources.nutrientSolutionLiters).toBeCloseTo(480, 5);
+    expect(zone.resources.nutrientStrength).toBeCloseTo(0.9, 5);
+    expect(zone.resources.reservoirLevel).toBeCloseTo(0.68, 5);
+    expect(zone.resources.substrateHealth).toBeCloseTo(0.82, 5);
+    expect(zone.resources.lastTranspirationLiters).toBeCloseTo(14, 5);
+
+    expect(zone.metrics.averageTemperature).toBeCloseTo(25.2, 5);
+    expect(zone.metrics.averageHumidity).toBeCloseTo(0.52, 5);
+    expect(zone.metrics.averageCo2).toBeCloseTo(1180, 5);
+    expect(zone.metrics.averagePpfd).toBeCloseTo(882, 5);
+    expect(zone.metrics.stressLevel).toBeCloseTo(0.45, 5);
+
+    expect(zone.supplyStatus?.dailyWaterConsumptionLiters).toBeCloseTo(180, 5);
+    expect(zone.supplyStatus?.dailyNutrientConsumptionLiters).toBeCloseTo(90, 5);
+
+    expect(zone.health.diseases).toBe(2);
+    expect(zone.health.pests).toBe(1);
+    expect(zone.health.pendingTreatments).toBe(3);
+    expect(zone.health.appliedTreatments).toBe(1);
+    expect(zone.health.reentryRestrictedUntilTick).toBe(170);
+    expect(zone.health.preHarvestRestrictedUntilTick).toBe(206);
 
     expect(zone.plants).toHaveLength(1);
     const [plant] = zone.plants;


### PR DESCRIPTION
## Summary
- Normalize clickdummy zone KPI values, environment calculations, resource stores, and health restrictions to SI units before hydrating frontend stores.
- Extend translator fixtures tests to cover the new telemetry/resource conversions and health restriction logic.
- Mark the migration step as complete and note the normalization work in the changelog.

## Testing
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d378b6b628832582179eba4e92e2e7