### PR TITLE
feat: enrich fixtures with finance history and blueprint data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the changelog to capture noteworthy changes for upcoming releases.
 - Recorded ADR 0003 describing the façade messaging overhaul and modular intent registry.
 - Created a clickdummy fixture translator (`src/frontend/src/fixtures/translator.ts`) to hydrate stores with `SimulationSnapshot`-konformen Daten inklusive normalisierter SI-Einheiten und Geometriefeldern.
+- Erweiterte die clickdummy-Fixtures um strain-/Stadium-Metadaten, Geräte-Blueprint-Kennungen und deterministische `financeHistory`-Einträge, sodass Frontend-Stores vollständige Snapshot-Typen erhalten.
 
 ### Changed
 

--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -79,7 +79,7 @@
      PPFD, DLI, Ressourcenstände, Verbräuche) auf SI-Einheiten und leitet daraus
      versorgungs- sowie Gesundheitsrestriktionen ab, bevor die Daten in die Stores gelangen
      (`src/frontend/src/fixtures/translator.ts`; Tests sichern die Konvertierung).
-3. Pflanzen-, Geräte-, Personal- und Finanzobjekte anreichern: Erweitere Fixtures um strain-IDs, Stadien, Geräte-Blueprint-Informationen, per-Tick-Kosten sowie tickbasierte Finanzhistorien, damit sie die Snapshot-Typen erfüllen.
+3. ✅ Pflanzen-, Geräte-, Personal- und Finanzobjekte anreichern: Fixtures liefern jetzt konsistente strain-IDs/Stadien, Geräte-Blueprint-Metadaten sowie per-Tick-Kosten mitsamt `financeHistory`. Die Umsetzung lebt in `src/frontend/src/fixtures/translator.ts` und den zugehörigen Tests.
 
 4. Deterministische Hilfsfunktionen zentralisieren: Ersetze deterministicUuid und globale SeededRandom-Instanzen durch eine seeded Helper-Utility in store/utils, die wiederholbare IDs und Zufallsdaten liefert.
 


### PR DESCRIPTION
## Summary
- enrich the clickdummy translator with device blueprint metadata, strain stage normalization, and deterministic finance history output
- update fixture tests to cover blueprint ids, finance aggregation, and per-tick salary conversions
- document the completed migration step and note the fixture enrichment in the changelog

## Testing
- pnpm --filter frontend test -- translator

------
https://chatgpt.com/codex/tasks/task_e_68d37c3e6408832589b9d4105a56bd36