### PR TITLE
feat: add finance time-range controls and breakdown panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created a clickdummy fixture translator (`src/frontend/src/fixtures/translator.ts`) to hydrate stores with `SimulationSnapshot`-konformen Daten inklusive normalisierter SI-Einheiten und Geometriefeldern.
 - Erweiterte die clickdummy-Fixtures um strain-/Stadium-Metadaten, Geräte-Blueprint-Kennungen und deterministische `financeHistory`-Einträge, sodass Frontend-Stores vollständige Snapshot-Typen erhalten.
 - Ergänzte ZoneDetail um interaktive Setpoint-Steuerungen, Pflanzenaktionen und Gerätegruppenlisten, nutzt dafür neue Form-Komponenten unter `components/forms` sowie die bestehenden Setpoint- und Intent-Dispatches des Zone-Stores.
+- Ergänzte das Finanzdashboard um einen tick-basierten Zeitbereichs-Umschalter samt Aufschlüsselungslisten für OpEx, Utilities und Wartungsgeräte. Die Listen basieren auf dem neuen `components/panels/BreakdownList`.
 
 ### Changed
 

--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -122,7 +122,9 @@
     - Hire-/Fire-Aktionen öffnen globale Modale aus dem Modal-Slice; Bestätigungen senden die Facade-Intents `workforce.hire` und `workforce.fire`.
     - Der neue `ModalHost` pausiert die Simulation bei modalem Fokus und nutzt den globalen Slice für alle HR-Workflows.
 
-12. Finanzdashboard abstimmen: Übertrage Zeitbereichs-Umschalter und Aufschlüsselungslisten in FinancesView und stelle sicher, dass sie tickbasierte financeHistory-Daten konsumieren.
+12. ✅ Finanzdashboard abstimmen: Übertrage Zeitbereichs-Umschalter und Aufschlüsselungslisten in FinancesView und stelle sicher, dass sie tickbasierte financeHistory-Daten konsumieren.
+    - `src/frontend/src/views/FinancesView.tsx` ergänzt jetzt einen Zeitbereichs-Schalter, der die Diagramme und Kennzahlen direkt über `financeHistory`-Ticks filtert, und fasst die gewählte Spanne in einer kompakten Kennzahlenzeile zusammen.
+    - Neue Breakdown-Listen (`components/panels/BreakdownList`) aggregieren OpEx-, Versorgungs- und Wartungskosten auf Basis der Tickdaten und nutzen Geräte-Metadaten für Wartungsaufschlüsselungen.
 
 ### Modale und Workflows
 

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -97,8 +97,11 @@ styling when needed.
 Key directories to explore:
 
 - `src/components/` – reusable UI widgets (forms, panels, charts).
+  - `components/panels/BreakdownList.tsx` liefert aufschlüsselbare Listen, die u.a. vom Finanzdashboard genutzt werden.
 - `src/views/` – page-level compositions that stitch together components and
   store selectors.
+  - `FinancesView.tsx` bindet die tickbasierte `financeHistory` an Zeitbereichs-Umschalter,
+    Diagramme und Kostenaufschlüsselungen.
 - `src/providers/` – React context providers (theme, i18n, etc.).
 - `src/types/` – shared TypeScript contracts for simulation payloads.
 

--- a/src/frontend/src/components/panels/BreakdownList.tsx
+++ b/src/frontend/src/components/panels/BreakdownList.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+
+export type BreakdownListItem = {
+  id: string;
+  label: string;
+  value: number;
+  description?: ReactNode;
+};
+
+export type BreakdownListProps = {
+  items: BreakdownListItem[];
+  total?: number;
+  valueFormatter?: (value: number) => ReactNode;
+  emptyPlaceholder?: ReactNode;
+};
+
+const defaultFormatter = (value: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+    maximumFractionDigits: value < 1 ? 2 : 0,
+  }).format(value);
+
+const BreakdownList = ({
+  items,
+  total,
+  valueFormatter = defaultFormatter,
+  emptyPlaceholder = 'No data available for the selected range.',
+}: BreakdownListProps) => {
+  const computedTotal =
+    typeof total === 'number'
+      ? total
+      : items.reduce((sum, item) => sum + (Number.isFinite(item.value) ? item.value : 0), 0);
+
+  if (!items.length || computedTotal <= 0) {
+    return <p className="text-sm text-text-muted">{emptyPlaceholder}</p>;
+  }
+
+  return (
+    <ul className="space-y-4">
+      {items.map((item) => {
+        const share = computedTotal > 0 ? Math.max(item.value / computedTotal, 0) : 0;
+        const width = `${Math.max(share * 100, item.value > 0 ? 4 : 0)}%`;
+        return (
+          <li key={item.id} className="space-y-2">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium text-text-primary">{item.label}</span>
+              <span className="flex items-baseline gap-2 font-mono text-xs text-text-secondary">
+                <span>{valueFormatter(item.value)}</span>
+                <span className="rounded bg-surfaceAlt/80 px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase text-text-muted">
+                  {(share * 100).toFixed(0)}%
+                </span>
+              </span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-surfaceAlt/60">
+              <div className="h-full rounded-full bg-accent/70" style={{ width }} />
+            </div>
+            {item.description ? (
+              <p className="text-xs text-text-muted">{item.description}</p>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default BreakdownList;

--- a/src/frontend/src/components/panels/index.ts
+++ b/src/frontend/src/components/panels/index.ts
@@ -1,0 +1,2 @@
+export { default as BreakdownList } from './BreakdownList';
+export type { BreakdownListItem, BreakdownListProps } from './BreakdownList';

--- a/src/frontend/src/views/FinancesView.tsx
+++ b/src/frontend/src/views/FinancesView.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
+import { BreakdownList } from '@/components/panels';
 import { selectFinanceSummary, useZoneStore } from '@/store';
 import {
   Area,
@@ -24,12 +25,37 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
 
 const formatCurrency = (value: number | undefined) => currencyFormatter.format(value ?? 0);
 
+const TIME_RANGE_OPTIONS = [
+  { id: '24', label: '24 ticks', ticks: 24 },
+  { id: '72', label: '72 ticks', ticks: 72 },
+  { id: '168', label: '168 ticks', ticks: 168 },
+  { id: '720', label: '720 ticks', ticks: 720 },
+] as const;
+
 const FinancesView = () => {
   const financeSummary = useZoneStore(selectFinanceSummary);
   const financeHistory = useZoneStore((state) => state.financeHistory);
+  const devices = useZoneStore((state) => state.devices);
+  const [selectedRangeId, setSelectedRangeId] = useState<(typeof TIME_RANGE_OPTIONS)[number]['id']>(
+    TIME_RANGE_OPTIONS[0].id,
+  );
+
+  const selectedRange = useMemo(
+    () =>
+      TIME_RANGE_OPTIONS.find((option) => option.id === selectedRangeId) ?? TIME_RANGE_OPTIONS[0],
+    [selectedRangeId],
+  );
+
+  const rangeEntries = useMemo(() => {
+    if (!financeHistory.length) {
+      return [] as typeof financeHistory;
+    }
+    const limit = Math.max(selectedRange.ticks, 1);
+    return financeHistory.slice(-limit);
+  }, [financeHistory, selectedRange.ticks]);
 
   const chartData = useMemo(() => {
-    return financeHistory.slice(-24).map((entry) => ({
+    return rangeEntries.map((entry) => ({
       tick: entry.tick,
       ts: entry.ts,
       revenue: entry.revenue,
@@ -43,11 +69,126 @@ const FinancesView = () => {
       utilitiesWater: entry.utilities.water,
       utilitiesNutrients: entry.utilities.nutrients,
     }));
-  }, [financeHistory]);
+  }, [rangeEntries]);
 
   const hasHistory = chartData.length > 0;
   const recentEntries = useMemo(() => financeHistory.slice(-10).reverse(), [financeHistory]);
   const latestEntry = financeHistory.at(-1);
+
+  const rangeTotals = useMemo(() => {
+    const aggregates = {
+      revenue: 0,
+      expenses: 0,
+      netIncome: 0,
+      capex: 0,
+      opex: 0,
+      maintenance: 0,
+      labor: 0,
+      utilities: {
+        total: 0,
+        energy: 0,
+        water: 0,
+        nutrients: 0,
+      },
+      maintenanceByDevice: new Map<string, { total: number; blueprintId: string }>(),
+    };
+
+    for (const entry of rangeEntries) {
+      aggregates.revenue += entry.revenue;
+      aggregates.expenses += entry.expenses;
+      aggregates.netIncome += entry.netIncome;
+      aggregates.capex += entry.capex;
+      aggregates.opex += entry.opex;
+      aggregates.maintenance += entry.maintenanceTotal;
+
+      aggregates.utilities.energy += entry.utilities.energy;
+      aggregates.utilities.water += entry.utilities.water;
+      aggregates.utilities.nutrients += entry.utilities.nutrients;
+      const utilitiesTotal = entry.utilities.totalCost;
+      if (!Number.isNaN(utilitiesTotal)) {
+        aggregates.utilities.total += utilitiesTotal;
+      }
+
+      const labor = entry.opex - entry.maintenanceTotal - entry.utilities.totalCost;
+      if (Number.isFinite(labor) && labor > 0) {
+        aggregates.labor += labor;
+      }
+
+      for (const detail of entry.maintenanceDetails) {
+        if (!detail) {
+          continue;
+        }
+        const existing = aggregates.maintenanceByDevice.get(detail.deviceId);
+        const total = (existing?.total ?? 0) + detail.totalCost;
+        aggregates.maintenanceByDevice.set(detail.deviceId, {
+          blueprintId: detail.blueprintId,
+          total,
+        });
+      }
+    }
+
+    if (aggregates.utilities.total <= 0) {
+      aggregates.utilities.total =
+        aggregates.utilities.energy + aggregates.utilities.water + aggregates.utilities.nutrients;
+    }
+
+    const maintenanceBreakdown = Array.from(aggregates.maintenanceByDevice.entries())
+      .map(([deviceId, value]) => ({
+        deviceId,
+        blueprintId: value.blueprintId,
+        value: value.total,
+      }))
+      .filter((item) => item.value > 0)
+      .sort((a, b) => b.value - a.value);
+
+    return {
+      totalRevenue: aggregates.revenue,
+      totalExpenses: aggregates.expenses,
+      totalNetIncome: aggregates.netIncome,
+      totalCapex: aggregates.capex,
+      totalOpex: aggregates.opex,
+      totalMaintenance: aggregates.maintenance,
+      totalLabor: aggregates.labor,
+      utilities: aggregates.utilities,
+      maintenanceBreakdown,
+    };
+  }, [rangeEntries]);
+
+  const operatingExpenseItems = useMemo(
+    () =>
+      [
+        { id: 'labor', label: 'Labor', value: rangeTotals.totalLabor },
+        { id: 'maintenance', label: 'Maintenance', value: rangeTotals.totalMaintenance },
+        { id: 'utilities', label: 'Utilities', value: rangeTotals.utilities.total },
+      ].filter((item) => item.value > 0),
+    [rangeTotals.totalLabor, rangeTotals.totalMaintenance, rangeTotals.utilities.total],
+  );
+
+  const utilitiesItems = useMemo(
+    () =>
+      [
+        { id: 'energy', label: 'Energy', value: rangeTotals.utilities.energy },
+        { id: 'water', label: 'Water', value: rangeTotals.utilities.water },
+        { id: 'nutrients', label: 'Nutrients', value: rangeTotals.utilities.nutrients },
+      ].filter((item) => item.value > 0),
+    [rangeTotals.utilities.energy, rangeTotals.utilities.nutrients, rangeTotals.utilities.water],
+  );
+
+  const maintenanceItems = useMemo(
+    () =>
+      rangeTotals.maintenanceBreakdown.slice(0, 6).map((item) => {
+        const device = devices[item.deviceId];
+        const label = device?.name ?? device?.kind ?? item.deviceId;
+        const blueprintLabel = device?.blueprintId ?? item.blueprintId;
+        return {
+          id: item.deviceId,
+          label,
+          value: item.value,
+          description: blueprintLabel ? `Blueprint: ${blueprintLabel}` : undefined,
+        };
+      }),
+    [devices, rangeTotals.maintenanceBreakdown],
+  );
 
   const summaryMetrics = [
     {
@@ -101,6 +242,70 @@ const FinancesView = () => {
       />
 
       <MetricsBar metrics={summaryMetrics} layout="compact" />
+
+      <div className="space-y-3 rounded-lg border border-border/60 bg-surface/60 p-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              Time range
+            </p>
+            <p className="text-sm text-text-secondary">
+              Showing last {rangeEntries.length.toLocaleString()}{' '}
+              {rangeEntries.length === 1 ? 'tick' : 'ticks'}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {TIME_RANGE_OPTIONS.map((option) => {
+              const isActive = option.id === selectedRange.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setSelectedRangeId(option.id)}
+                  aria-pressed={isActive}
+                  className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                    isActive
+                      ? 'bg-surfaceElevated text-text-primary shadow-soft'
+                      : 'bg-surfaceAlt/70 text-text-muted hover:text-text-primary'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Revenue</p>
+            <p className="text-base font-semibold text-text-primary">
+              {formatCurrency(rangeTotals.totalRevenue)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Expenses</p>
+            <p className="text-base font-semibold text-text-primary">
+              {formatCurrency(rangeTotals.totalExpenses)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Net income</p>
+            <p
+              className={`text-base font-semibold ${
+                rangeTotals.totalNetIncome >= 0 ? 'text-positive' : 'text-warning'
+              }`}
+            >
+              {formatCurrency(rangeTotals.totalNetIncome)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Capital expenses</p>
+            <p className="text-base font-semibold text-text-primary">
+              {formatCurrency(rangeTotals.totalCapex)}
+            </p>
+          </div>
+        </div>
+      </div>
 
       <div className="grid gap-6 xl:grid-cols-[2fr,1fr]">
         <Panel title="Revenue vs expenses" padding="lg" variant="elevated">
@@ -224,6 +429,48 @@ const FinancesView = () => {
             )}
           </Panel>
         </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        <Panel
+          title="Operating expense breakdown"
+          description="Distribution of labor, maintenance, and utilities costs for the selected range."
+          padding="lg"
+          variant="elevated"
+        >
+          <BreakdownList
+            items={operatingExpenseItems}
+            total={rangeTotals.totalOpex}
+            valueFormatter={(value) => formatCurrency(value)}
+            emptyPlaceholder="No operating expense data yet."
+          />
+        </Panel>
+        <Panel
+          title="Utilities breakdown"
+          description="Energy, water, and nutrient spend across the time window."
+          padding="lg"
+          variant="elevated"
+        >
+          <BreakdownList
+            items={utilitiesItems}
+            total={rangeTotals.utilities.total}
+            valueFormatter={(value) => formatCurrency(value)}
+            emptyPlaceholder="Utilities costs have not been recorded for this range."
+          />
+        </Panel>
+        <Panel
+          title="Maintenance by device"
+          description="Top devices incurring maintenance during the selected ticks."
+          padding="lg"
+          variant="elevated"
+        >
+          <BreakdownList
+            items={maintenanceItems}
+            total={rangeTotals.totalMaintenance}
+            valueFormatter={(value) => formatCurrency(value)}
+            emptyPlaceholder="No maintenance spend tracked in this window."
+          />
+        </Panel>
       </div>
 
       <Panel


### PR DESCRIPTION
## Summary
- add a tick-driven time range switcher, range totals, and maintenance-aware cost breakdowns to `FinancesView`
- extract a reusable `BreakdownList` panel component for finance breakdowns
- document the completed migration step and refresh the frontend README and changelog

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ae093d788325a968336638e6565c