### PR TITLE
feat(frontend): add typed modal descriptors and world modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Erweiterte die clickdummy-Fixtures um strain-/Stadium-Metadaten, Geräte-Blueprint-Kennungen und deterministische `financeHistory`-Einträge, sodass Frontend-Stores vollständige Snapshot-Typen erhalten.
 - Ergänzte ZoneDetail um interaktive Setpoint-Steuerungen, Pflanzenaktionen und Gerätegruppenlisten, nutzt dafür neue Form-Komponenten unter `components/forms` sowie die bestehenden Setpoint- und Intent-Dispatches des Zone-Stores.
 - Ergänzte das Finanzdashboard um einen tick-basierten Zeitbereichs-Umschalter samt Aufschlüsselungslisten für OpEx, Utilities und Wartungsgeräte. Die Listen basieren auf dem neuen `components/panels/BreakdownList`.
+- Registrierte typisierte Modal-Descriptoren für Infrastruktur- und Detail-Workflows und implementierte dedizierte Modal-Inhalte unter `views/world/modals` bzw. `views/zone/modals`, gerendert über den aktualisierten `ModalHost`.
 
 ### Changed
 

--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -113,9 +113,10 @@
    - `ZoneDetail` wurde in eine hierarchische Detailansicht für Strukturen, Räume und Zonen erweitert, inklusive verdichteter Kennzahlenleisten, Raum-/Zonenlisten mit Drilldown und erweiterter Status-Panels für Geometrie, Ressourcen und Gesundheitsdaten.
 
 10. ✅ Zonenansicht erweitern: Ergänze ZoneDetail um Steuer-Widgets, Pflanzenaktionen und Gerätelisten; nutze useZoneStore().sendSetpoint für Setpoint-Dispatch und extrahiere Form-Controls in components/forms.
-   - `ZoneDetail` stellt jetzt ein Panel „Environment controls“ bereit, das Temperatur-, Feuchte-, VPD-, CO₂- und PPFD-Setpoints über die neuen `components/forms`-Slider visualisiert und per `useZoneStore().sendSetpoint` an die Fassade sendet.
-   - Ein neues Pflanzenaktions-Panel bündelt Bewässerungs- und Nährstoffbefehle, Harvest-Batch-Kommandos sowie das Umschalten aktiver Pflanzpläne über die bestehenden `applyWater`/`applyNutrients`/`harvestPlantings`/`togglePlantingPlan`-Intents.
-   - Gerätegruppen werden als Automation-Panel mit Toggles dargestellt, während die Geräteinventur detaillierte Wartungs-, Laufzeit- und Settings-Metadaten pro Gerät ausgibt.
+
+- `ZoneDetail` stellt jetzt ein Panel „Environment controls“ bereit, das Temperatur-, Feuchte-, VPD-, CO₂- und PPFD-Setpoints über die neuen `components/forms`-Slider visualisiert und per `useZoneStore().sendSetpoint` an die Fassade sendet.
+- Ein neues Pflanzenaktions-Panel bündelt Bewässerungs- und Nährstoffbefehle, Harvest-Batch-Kommandos sowie das Umschalten aktiver Pflanzpläne über die bestehenden `applyWater`/`applyNutrients`/`harvestPlantings`/`togglePlantingPlan`-Intents.
+- Gerätegruppen werden als Automation-Panel mit Toggles dargestellt, während die Geräteinventur detaillierte Wartungs-, Laufzeit- und Settings-Metadaten pro Gerät ausgibt.
 
 11. ✅ Personalbereich neu aufbauen: Spiegle Bewerber- und Mitarbeiterdarstellungen im PersonnelView, verdrahte Hire/Fire-Intents und verlagere Modale in den globalen Modal-Slice.
     - Das Frontend rendert nun symmetrische Karten für Mitarbeitende und Bewerber:innen, inklusive Skill-/Trait-Details sowie Morale-/Energy-Balken.
@@ -128,7 +129,7 @@
 
 ### Modale und Workflows
 
-13. Modal-Descriptoren registrieren: Definiere typsichere Descriptoren für CRUD-, Duplizier-, Detail- und Bestätigungsmodale im Modal-Slice und implementiere zugehörige Inhaltskomponenten in den jeweiligen View-Ordnern.
+13. ✅ Modal-Descriptoren registrieren: Der Modal-Slice exportiert jetzt eine strikt typisierte `ModalDescriptor`-Union mit eigenen Payloads für Anlegen-, Umbenennen-, Duplizier-, Detail- und Löschflows. `ModalHost` rendert die neuen Inhaltskomponenten (`views/world/modals` sowie `views/zone/modals`) für Räume/Zonen/Strukturen und Pflanzen-Details und pausiert weiterhin deterministisch bei aktiven Dialogen.
 
 14. Fassade-Intents anbinden: Route Modale-Aktionen (z. B. duplicateRoom/duplicateZone) durch vorhandene Fassade-Intents, inklusive deterministischer Kosten-/Bestandsupdates.
 

--- a/src/frontend/src/components/ModalHost.tsx
+++ b/src/frontend/src/components/ModalHost.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo } from 'react';
 import HireEmployeeModal from '@/views/personnel/modals/HireEmployeeModal';
 import FireEmployeeModal from '@/views/personnel/modals/FireEmployeeModal';
+import CreateRoomModal from '@/views/world/modals/CreateRoomModal';
+import CreateZoneModal from '@/views/world/modals/CreateZoneModal';
+import DuplicateRoomModal from '@/views/world/modals/DuplicateRoomModal';
+import DuplicateZoneModal from '@/views/world/modals/DuplicateZoneModal';
+import RenameEntityModal from '@/views/world/modals/RenameEntityModal';
+import ConfirmDeletionModal from '@/views/world/modals/ConfirmDeletionModal';
+import PlantDetailModal from '@/views/zone/modals/PlantDetailModal';
 import {
   selectIsPaused,
   useAppStore,
@@ -22,24 +29,53 @@ const ModalHost = () => {
   const hireCandidate = usePersonnelStore((state) => state.hireCandidate);
   const fireEmployee = usePersonnelStore((state) => state.fireEmployee);
 
-  const structures = useZoneStore((state) => state.structures);
+  const {
+    structures,
+    rooms,
+    zones,
+    plants,
+    duplicateRoom,
+    duplicateZone,
+    updateStructureName,
+    updateRoomName,
+    updateZoneName,
+    removeStructure,
+    removeRoom,
+    removeZone,
+  } = useZoneStore((state) => ({
+    structures: state.structures,
+    rooms: state.rooms,
+    zones: state.zones,
+    plants: state.plants,
+    duplicateRoom: state.duplicateRoom,
+    duplicateZone: state.duplicateZone,
+    updateStructureName: state.updateStructureName,
+    updateRoomName: state.updateRoomName,
+    updateZoneName: state.updateZoneName,
+    removeStructure: state.removeStructure,
+    removeRoom: state.removeRoom,
+    removeZone: state.removeZone,
+  }));
 
   const candidateId = useMemo(() => {
-    if (!activeModal || activeModal.kind !== 'hireEmployee') {
+    if (activeModal?.kind !== 'hireEmployee') {
       return undefined;
     }
-    const payload = activeModal.payload as { candidateId?: unknown } | undefined;
-    const raw = payload?.candidateId;
-    return typeof raw === 'string' ? raw : undefined;
+    return activeModal.payload.candidateId;
   }, [activeModal]);
 
   const employeeId = useMemo(() => {
-    if (!activeModal || activeModal.kind !== 'fireEmployee') {
+    if (activeModal?.kind !== 'fireEmployee') {
       return undefined;
     }
-    const payload = activeModal.payload as { employeeId?: unknown } | undefined;
-    const raw = payload?.employeeId;
-    return typeof raw === 'string' ? raw : undefined;
+    return activeModal.payload.employeeId;
+  }, [activeModal]);
+
+  const plantId = useMemo(() => {
+    if (activeModal?.kind !== 'plantDetails') {
+      return undefined;
+    }
+    return activeModal.payload.plantId;
   }, [activeModal]);
 
   const candidate = useMemo(() => {
@@ -55,6 +91,16 @@ const ModalHost = () => {
     }
     return personnel?.employees?.find((item) => item.id === employeeId);
   }, [employeeId, personnel?.employees]);
+
+  const plant = useMemo(() => {
+    if (!plantId) {
+      return undefined;
+    }
+    return plants[plantId];
+  }, [plantId, plants]);
+
+  const roomList = useMemo(() => Object.values(rooms), [rooms]);
+  const zoneList = useMemo(() => Object.values(zones), [zones]);
 
   useEffect(() => {
     if (!activeModal) {
@@ -85,7 +131,10 @@ const ModalHost = () => {
     if (activeModal.kind === 'fireEmployee' && employeeId && !employee) {
       closeModal();
     }
-  }, [activeModal, candidate, candidateId, closeModal, employee, employeeId]);
+    if (activeModal.kind === 'plantDetails' && plantId && !plant) {
+      closeModal();
+    }
+  }, [activeModal, candidate, candidateId, closeModal, employee, employeeId, plant, plantId]);
 
   if (!activeModal) {
     return null;
@@ -127,6 +176,256 @@ const ModalHost = () => {
             fireEmployee(employee.id);
             closeModal();
           }}
+        />
+      );
+    case 'createRoom': {
+      const { structureId } = activeModal.payload;
+      const structure = structures[structureId];
+      if (!structure) {
+        closeModal();
+        return null;
+      }
+      const structureRooms = roomList.filter((room) => room.structureId === structureId);
+      return (
+        <CreateRoomModal
+          structure={structure}
+          existingRooms={structureRooms}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onSubmit={() => {
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'createZone': {
+      const { roomId } = activeModal.payload;
+      const room = rooms[roomId];
+      if (!room) {
+        closeModal();
+        return null;
+      }
+      const roomZones = zoneList.filter((zone) => zone.roomId === roomId);
+      return (
+        <CreateZoneModal
+          room={room}
+          existingZones={roomZones}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onSubmit={() => {
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'duplicateRoom': {
+      const { roomId } = activeModal.payload;
+      const room = rooms[roomId];
+      if (!room) {
+        closeModal();
+        return null;
+      }
+      const structure = structures[room.structureId];
+      if (!structure) {
+        closeModal();
+        return null;
+      }
+      const structureRooms = roomList.filter((item) => item.structureId === structure.id);
+      const structureZones = zoneList.filter((zone) => zone.structureId === structure.id);
+      const roomZones = structureZones.filter((zone) => zone.roomId === room.id);
+      const usedArea = structureRooms.reduce((sum, item) => sum + Math.max(item.area, 0), 0);
+      const availableArea = Math.max(structure.footprint.area - usedArea, 0);
+      const deviceCount = roomZones.reduce((sum, zone) => sum + zone.devices.length, 0);
+      return (
+        <DuplicateRoomModal
+          room={room}
+          structure={structure}
+          zones={roomZones}
+          availableArea={availableArea}
+          deviceCount={deviceCount}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={() => {
+            duplicateRoom(room.id);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'duplicateZone': {
+      const { zoneId } = activeModal.payload;
+      const zone = zones[zoneId];
+      if (!zone) {
+        closeModal();
+        return null;
+      }
+      const room = rooms[zone.roomId];
+      if (!room) {
+        closeModal();
+        return null;
+      }
+      const roomZones = zoneList.filter((item) => item.roomId === room.id);
+      const usedArea = roomZones.reduce((sum, item) => sum + Math.max(item.area, 0), 0);
+      const availableArea = Math.max(room.area - usedArea, 0);
+      const deviceCount = zone.devices.length;
+      return (
+        <DuplicateZoneModal
+          zone={zone}
+          room={room}
+          availableArea={availableArea}
+          deviceCount={deviceCount}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={() => {
+            duplicateZone(zone.id);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'renameStructure': {
+      const { structureId } = activeModal.payload;
+      const structure = structures[structureId];
+      if (!structure) {
+        closeModal();
+        return null;
+      }
+      return (
+        <RenameEntityModal
+          entityLabel="Structure"
+          currentName={structure.name}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={(name) => {
+            updateStructureName(structure.id, name);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'renameRoom': {
+      const { roomId } = activeModal.payload;
+      const room = rooms[roomId];
+      if (!room) {
+        closeModal();
+        return null;
+      }
+      return (
+        <RenameEntityModal
+          entityLabel="Room"
+          currentName={room.name}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={(name) => {
+            updateRoomName(room.id, name);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'renameZone': {
+      const { zoneId } = activeModal.payload;
+      const zone = zones[zoneId];
+      if (!zone) {
+        closeModal();
+        return null;
+      }
+      return (
+        <RenameEntityModal
+          entityLabel="Zone"
+          currentName={zone.name}
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={(name) => {
+            updateZoneName(zone.id, name);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'deleteStructure': {
+      const { structureId } = activeModal.payload;
+      const structure = structures[structureId];
+      if (!structure) {
+        closeModal();
+        return null;
+      }
+      return (
+        <ConfirmDeletionModal
+          entityLabel="Structure"
+          entityName={structure.name}
+          impactDescription="All rooms and zones within the structure will be scheduled for teardown by the simulation facade."
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={() => {
+            removeStructure(structure.id);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'deleteRoom': {
+      const { roomId } = activeModal.payload;
+      const room = rooms[roomId];
+      if (!room) {
+        closeModal();
+        return null;
+      }
+      return (
+        <ConfirmDeletionModal
+          entityLabel="Room"
+          entityName={room.name}
+          impactDescription="Zones and devices in this room will be cleaned up deterministically by the facade."
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={() => {
+            removeRoom(room.id);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'deleteZone': {
+      const { zoneId } = activeModal.payload;
+      const zone = zones[zoneId];
+      if (!zone) {
+        closeModal();
+        return null;
+      }
+      return (
+        <ConfirmDeletionModal
+          entityLabel="Zone"
+          entityName={zone.name}
+          impactDescription="Plantings, devices, and automation assigned to this zone will be removed."
+          title={activeModal.title}
+          description={activeModal.description}
+          onCancel={closeModal}
+          onConfirm={() => {
+            removeZone(zone.id);
+            closeModal();
+          }}
+        />
+      );
+    }
+    case 'plantDetails':
+      if (!plant) {
+        return null;
+      }
+      return (
+        <PlantDetailModal
+          plant={plant}
+          title={activeModal.title}
+          description={activeModal.description}
+          onClose={closeModal}
         />
       );
     default:

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -191,27 +191,70 @@ export interface NavigationSlice {
   resetSelection: () => void;
 }
 
-export type ModalKind =
-  | 'settings'
-  | 'installDevice'
-  | 'planting'
-  | 'automationPlan'
-  | 'treatment'
-  | 'createEntity'
-  | 'updateEntity'
-  | 'deleteEntity'
-  | 'hireEmployee'
-  | 'fireEmployee'
-  | 'custom';
+export type ModalSize = 'sm' | 'md' | 'lg';
 
-export interface ModalDescriptor {
-  kind: ModalKind;
+type ModalDescriptorBase<TKind extends string, TPayload = undefined> = {
+  kind: TKind;
   title?: string;
   description?: string;
-  payload?: Record<string, unknown>;
   autoPause?: boolean;
-  size?: 'sm' | 'md' | 'lg';
-}
+  size?: ModalSize;
+} & (TPayload extends undefined ? { payload?: undefined } : { payload: TPayload });
+
+export type HireEmployeeModalDescriptor = ModalDescriptorBase<
+  'hireEmployee',
+  { candidateId: string }
+>;
+
+export type FireEmployeeModalDescriptor = ModalDescriptorBase<
+  'fireEmployee',
+  { employeeId: string }
+>;
+
+export type CreateRoomModalDescriptor = ModalDescriptorBase<'createRoom', { structureId: string }>;
+
+export type CreateZoneModalDescriptor = ModalDescriptorBase<'createZone', { roomId: string }>;
+
+export type DuplicateRoomModalDescriptor = ModalDescriptorBase<'duplicateRoom', { roomId: string }>;
+
+export type DuplicateZoneModalDescriptor = ModalDescriptorBase<'duplicateZone', { zoneId: string }>;
+
+export type RenameStructureModalDescriptor = ModalDescriptorBase<
+  'renameStructure',
+  { structureId: string }
+>;
+
+export type RenameRoomModalDescriptor = ModalDescriptorBase<'renameRoom', { roomId: string }>;
+
+export type RenameZoneModalDescriptor = ModalDescriptorBase<'renameZone', { zoneId: string }>;
+
+export type DeleteStructureModalDescriptor = ModalDescriptorBase<
+  'deleteStructure',
+  { structureId: string }
+>;
+
+export type DeleteRoomModalDescriptor = ModalDescriptorBase<'deleteRoom', { roomId: string }>;
+
+export type DeleteZoneModalDescriptor = ModalDescriptorBase<'deleteZone', { zoneId: string }>;
+
+export type PlantDetailModalDescriptor = ModalDescriptorBase<'plantDetails', { plantId: string }>;
+
+export type ModalDescriptor =
+  | HireEmployeeModalDescriptor
+  | FireEmployeeModalDescriptor
+  | CreateRoomModalDescriptor
+  | CreateZoneModalDescriptor
+  | DuplicateRoomModalDescriptor
+  | DuplicateZoneModalDescriptor
+  | RenameStructureModalDescriptor
+  | RenameRoomModalDescriptor
+  | RenameZoneModalDescriptor
+  | DeleteStructureModalDescriptor
+  | DeleteRoomModalDescriptor
+  | DeleteZoneModalDescriptor
+  | PlantDetailModalDescriptor;
+
+export type ModalKind = ModalDescriptor['kind'];
 
 export interface ModalSlice {
   activeModal: ModalDescriptor | null;

--- a/src/frontend/src/views/world/modals/ConfirmDeletionModal.tsx
+++ b/src/frontend/src/views/world/modals/ConfirmDeletionModal.tsx
@@ -1,0 +1,64 @@
+import Modal from '@/components/Modal';
+
+type ConfirmDeletionModalProps = {
+  entityLabel: string;
+  entityName?: string;
+  impactDescription?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const ConfirmDeletionModal = ({
+  entityLabel,
+  entityName,
+  impactDescription,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+}: ConfirmDeletionModalProps) => {
+  const effectiveTitle = title ?? `Delete ${entityLabel}?`;
+  const effectiveDescription =
+    description ??
+    `This ${entityLabel.toLowerCase()} will be removed from the simulation snapshot. Related telemetry and assignments will be updated by the facade.`;
+
+  return (
+    <Modal
+      isOpen
+      title={effectiveTitle}
+      description={effectiveDescription}
+      onClose={onCancel}
+      size="sm"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: `Delete ${entityLabel.toLowerCase()}`,
+          onClick: onConfirm,
+          variant: 'danger',
+        },
+      ]}
+    >
+      <div className="space-y-3 text-sm text-text-secondary">
+        {entityName ? (
+          <p>
+            <span className="font-medium text-text-primary">{entityName}</span> will be removed.
+          </p>
+        ) : null}
+        {impactDescription ? <p>{impactDescription}</p> : null}
+        <p className="text-xs text-text-muted">
+          Deletion requests are processed deterministically. Any CapEx reversals or cleanup actions
+          are handled by the simulation facade.
+        </p>
+      </div>
+    </Modal>
+  );
+};
+
+export type { ConfirmDeletionModalProps };
+export default ConfirmDeletionModal;

--- a/src/frontend/src/views/world/modals/CreateRoomModal.tsx
+++ b/src/frontend/src/views/world/modals/CreateRoomModal.tsx
@@ -1,0 +1,174 @@
+import { FormEvent, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import NumberInputField from '@/components/forms/NumberInputField';
+import type { RoomSnapshot, StructureSnapshot } from '@/types/simulation';
+
+type CreateRoomModalProps = {
+  structure: StructureSnapshot;
+  existingRooms: RoomSnapshot[];
+  onSubmit: (options: { name: string; purposeId: string; area: number; height: number }) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const DEFAULT_PURPOSE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'purpose:growroom', label: 'Grow room' },
+  { value: 'purpose:drying', label: 'Drying room' },
+  { value: 'purpose:processing', label: 'Processing room' },
+  { value: 'purpose:curing', label: 'Curing room' },
+  { value: 'purpose:breakroom', label: 'Break room' },
+];
+
+const CreateRoomModal = ({
+  structure,
+  existingRooms,
+  onSubmit,
+  onCancel,
+  title,
+  description,
+}: CreateRoomModalProps) => {
+  const usedArea = useMemo(
+    () => existingRooms.reduce((sum, room) => sum + Math.max(room.area, 0), 0),
+    [existingRooms],
+  );
+
+  const availableArea = Math.max(structure.footprint.area - usedArea, 0);
+
+  const [name, setName] = useState(() => `${structure.name} room ${existingRooms.length + 1}`);
+  const [purposeId, setPurposeId] = useState(
+    () => DEFAULT_PURPOSE_OPTIONS[0]?.value ?? 'purpose:growroom',
+  );
+  const [area, setArea] = useState(() =>
+    availableArea > 0 ? Math.min(Math.round(Math.max(availableArea / 2, 10)), availableArea) : 0,
+  );
+  const [height, setHeight] = useState(() => Math.round(structure.footprint.height));
+
+  const purposeOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: { value: string; label: string }[] = [];
+
+    for (const option of DEFAULT_PURPOSE_OPTIONS) {
+      if (!seen.has(option.value)) {
+        seen.add(option.value);
+        options.push(option);
+      }
+    }
+
+    for (const room of existingRooms) {
+      const value = room.purposeId || `purpose:${room.purposeKind}`;
+      const label = room.purposeName || room.purposeKind || 'Custom purpose';
+      if (!value || seen.has(value)) {
+        continue;
+      }
+      seen.add(value);
+      options.push({ value, label });
+    }
+
+    return options;
+  }, [existingRooms]);
+
+  const isNameValid = name.trim().length > 0;
+  const isAreaValid = area > 0 && area <= availableArea;
+  const isHeightValid = height > 0;
+  const canSubmit = isNameValid && isAreaValid && isHeightValid;
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!canSubmit) {
+      return;
+    }
+    onSubmit({
+      name: name.trim(),
+      purposeId,
+      area,
+      height,
+    });
+  };
+
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Create room in ${structure.name}`}
+      description={
+        description ??
+        'Allocate footprint and select a room purpose to expand the structure. Geometry is validated by the simulation facade.'
+      }
+      onClose={onCancel}
+      size="lg"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Create room',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !canSubmit,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="Room name" secondaryLabel={name.trim() || undefined}>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            placeholder="e.g. Flowering wing"
+            autoFocus
+          />
+        </FormField>
+
+        <FormField label="Room purpose">
+          <select
+            value={purposeId}
+            onChange={(event) => setPurposeId(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+          >
+            {purposeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <NumberInputField
+          label="Footprint area"
+          value={area}
+          onChange={setArea}
+          min={1}
+          max={availableArea}
+          unit="m²"
+          description={`Available footprint: ${availableArea.toLocaleString()} m²`}
+          footer={
+            !isAreaValid ? (
+              <p className="text-xs text-danger">
+                Area must be positive and within the remaining footprint.
+              </p>
+            ) : null
+          }
+        />
+
+        <NumberInputField
+          label="Ceiling height"
+          value={height}
+          onChange={setHeight}
+          min={2}
+          step={1}
+          unit="m"
+          description="Used for derived volume and HVAC capacity checks."
+        />
+      </form>
+    </Modal>
+  );
+};
+
+export type { CreateRoomModalProps };
+export default CreateRoomModal;

--- a/src/frontend/src/views/world/modals/CreateZoneModal.tsx
+++ b/src/frontend/src/views/world/modals/CreateZoneModal.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import NumberInputField from '@/components/forms/NumberInputField';
+import type { RoomSnapshot, ZoneSnapshot } from '@/types/simulation';
+
+type CultivationMethodOption = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
+type CreateZoneModalProps = {
+  room: RoomSnapshot;
+  existingZones: ZoneSnapshot[];
+  availableMethods?: CultivationMethodOption[];
+  onSubmit: (options: {
+    name: string;
+    area: number;
+    methodId?: string;
+    targetPlantCount?: number;
+  }) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const DEFAULT_METHOD_OPTIONS: CultivationMethodOption[] = [
+  { id: 'method:sea-of-green', name: 'Sea of Green' },
+  { id: 'method:screen-of-green', name: 'SCROG (Screen of Green)' },
+  { id: 'method:vertical-stack', name: 'Vertical stack' },
+  { id: 'method:empty', name: 'Empty (no automation)' },
+];
+
+const CreateZoneModal = ({
+  room,
+  existingZones,
+  availableMethods,
+  onSubmit,
+  onCancel,
+  title,
+  description,
+}: CreateZoneModalProps) => {
+  const usedArea = useMemo(
+    () => existingZones.reduce((sum, zone) => sum + Math.max(zone.area, 0), 0),
+    [existingZones],
+  );
+
+  const availableArea = Math.max(room.area - usedArea, 0);
+  const defaultArea =
+    availableArea > 0 ? Math.min(Math.round(Math.max(availableArea / 3, 10)), availableArea) : 0;
+
+  const methodOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: CultivationMethodOption[] = [];
+
+    for (const method of DEFAULT_METHOD_OPTIONS) {
+      if (!seen.has(method.id)) {
+        seen.add(method.id);
+        options.push(method);
+      }
+    }
+
+    if (availableMethods) {
+      for (const method of availableMethods) {
+        if (!method.id || seen.has(method.id)) {
+          continue;
+        }
+        seen.add(method.id);
+        options.push(method);
+      }
+    }
+
+    for (const zone of existingZones) {
+      if (!zone.cultivationMethodId) {
+        continue;
+      }
+      if (seen.has(zone.cultivationMethodId)) {
+        continue;
+      }
+      seen.add(zone.cultivationMethodId);
+      options.push({ id: zone.cultivationMethodId, name: `Reuse ${zone.cultivationMethodId}` });
+    }
+
+    return options;
+  }, [availableMethods, existingZones]);
+
+  const [name, setName] = useState(() => `${room.name} zone ${existingZones.length + 1}`);
+  const [area, setArea] = useState(defaultArea);
+  const [methodId, setMethodId] = useState(() => methodOptions[0]?.id);
+  const [targetPlantCount, setTargetPlantCount] = useState(24);
+
+  const isNameValid = name.trim().length > 0;
+  const isAreaValid = area > 0 && area <= availableArea;
+  const canSubmit = isNameValid && isAreaValid;
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!canSubmit) {
+      return;
+    }
+    onSubmit({
+      name: name.trim(),
+      area,
+      methodId: methodId || undefined,
+      targetPlantCount: Number.isFinite(targetPlantCount)
+        ? Math.max(0, targetPlantCount)
+        : undefined,
+    });
+  };
+
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Create zone in ${room.name}`}
+      description={
+        description ??
+        'Zones inherit HVAC and staffing requirements from their parent room. Choose a cultivation method and target footprint ' +
+          'to allocate space deterministically.'
+      }
+      onClose={onCancel}
+      size="lg"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Create zone',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !canSubmit,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="Zone name" secondaryLabel={name.trim() || undefined}>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            placeholder="e.g. Flower bench"
+            autoFocus
+          />
+        </FormField>
+
+        <NumberInputField
+          label="Allocated area"
+          value={area}
+          onChange={setArea}
+          min={1}
+          max={availableArea}
+          unit="m²"
+          description={`Available room area: ${availableArea.toLocaleString()} m²`}
+          footer={
+            !isAreaValid ? (
+              <p className="text-xs text-danger">
+                Area must fit within the remaining room capacity.
+              </p>
+            ) : null
+          }
+        />
+
+        <FormField label="Cultivation method">
+          <select
+            value={methodId ?? ''}
+            onChange={(event) => setMethodId(event.target.value || undefined)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+          >
+            {methodOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <NumberInputField
+          label="Target plant count"
+          value={targetPlantCount}
+          onChange={setTargetPlantCount}
+          min={0}
+          step={4}
+          description="Optional planning hint for automation and labour scheduling."
+        />
+      </form>
+    </Modal>
+  );
+};
+
+export type { CultivationMethodOption, CreateZoneModalProps };
+export default CreateZoneModal;

--- a/src/frontend/src/views/world/modals/DuplicateRoomModal.tsx
+++ b/src/frontend/src/views/world/modals/DuplicateRoomModal.tsx
@@ -1,0 +1,149 @@
+import { FormEvent, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import type { RoomSnapshot, StructureSnapshot, ZoneSnapshot } from '@/types/simulation';
+
+type DuplicateRoomModalProps = {
+  room: RoomSnapshot;
+  structure: StructureSnapshot;
+  zones: ZoneSnapshot[];
+  availableArea: number;
+  deviceCount: number;
+  estimatedDeviceCapex?: number;
+  onConfirm: (options: { name: string }) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const DuplicateRoomModal = ({
+  room,
+  structure,
+  zones,
+  availableArea,
+  deviceCount,
+  estimatedDeviceCapex,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+}: DuplicateRoomModalProps) => {
+  const [name, setName] = useState(() => `${room.name} copy`);
+
+  const zoneArea = useMemo(
+    () => zones.reduce((sum, zone) => sum + Math.max(zone.area, 0), 0),
+    [zones],
+  );
+
+  const canAffordFootprint = room.area <= availableArea;
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!name.trim()) {
+      return;
+    }
+    onConfirm({ name: name.trim() });
+  };
+
+  const formattedCapex =
+    estimatedDeviceCapex !== undefined
+      ? `${estimatedDeviceCapex.toLocaleString()} €`
+      : 'Calculated by facade';
+
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Duplicate ${room.name}`}
+      description={
+        description ??
+        'Duplicating a room recreates its zones, cultivation methods, and eligible devices. The backend validates footprint ' +
+          'availability and charges CapEx for any re-purchased devices.'
+      }
+      onClose={onCancel}
+      size="md"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Duplicate room',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !name.trim() || !canAffordFootprint,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="New room name" secondaryLabel={name.trim() || undefined}>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            placeholder={`${room.name} copy`}
+            autoFocus
+          />
+        </FormField>
+
+        <div className="grid grid-cols-1 gap-3 rounded-lg border border-border/60 bg-surfaceAlt/50 p-4 text-sm text-text-secondary">
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">
+              Structure footprint
+            </span>
+            <span className="font-medium text-text-primary">
+              {structure.footprint.area.toLocaleString()} m²
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Required area</span>
+            <span className="font-medium text-text-primary">{room.area.toLocaleString()} m²</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Available area</span>
+            <span
+              className={
+                canAffordFootprint ? 'font-medium text-positive' : 'font-medium text-danger'
+              }
+            >
+              {availableArea.toLocaleString()} m²
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Zones to copy</span>
+            <span className="font-medium text-text-primary">{zones.length.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Zone footprint</span>
+            <span className="font-medium text-text-primary">{zoneArea.toLocaleString()} m²</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">
+              Devices to re-purchase
+            </span>
+            <span className="font-medium text-text-primary">{deviceCount.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">
+              Estimated device CapEx
+            </span>
+            <span className="font-medium text-text-primary">{formattedCapex}</span>
+          </div>
+        </div>
+
+        {!canAffordFootprint ? (
+          <p className="text-xs text-danger">
+            Insufficient available footprint. Consider expanding the structure or adjusting the
+            duplication target.
+          </p>
+        ) : null}
+      </form>
+    </Modal>
+  );
+};
+
+export type { DuplicateRoomModalProps };
+export default DuplicateRoomModal;

--- a/src/frontend/src/views/world/modals/DuplicateZoneModal.tsx
+++ b/src/frontend/src/views/world/modals/DuplicateZoneModal.tsx
@@ -1,0 +1,153 @@
+import { FormEvent, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import type { RoomSnapshot, ZoneSnapshot } from '@/types/simulation';
+
+type DuplicateZoneModalProps = {
+  zone: ZoneSnapshot;
+  room: RoomSnapshot;
+  availableArea: number;
+  deviceCount: number;
+  onConfirm: (options: { name: string; includeDevices: boolean; includeMethod: boolean }) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const DuplicateZoneModal = ({
+  zone,
+  room,
+  availableArea,
+  deviceCount,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+}: DuplicateZoneModalProps) => {
+  const [name, setName] = useState(() => `${zone.name} copy`);
+  const [includeDevices, setIncludeDevices] = useState(true);
+  const [includeMethod, setIncludeMethod] = useState(Boolean(zone.cultivationMethodId));
+
+  const canDuplicate = zone.area <= availableArea;
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!name.trim()) {
+      return;
+    }
+    onConfirm({ name: name.trim(), includeDevices, includeMethod });
+  };
+
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Duplicate ${zone.name}`}
+      description={
+        description ??
+        'Cloning a zone recreates its cultivation footprint and optionally reuses automation and device setup. The facade ' +
+          'validates room capacity and charges for newly purchased hardware.'
+      }
+      onClose={onCancel}
+      size="md"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Duplicate zone',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !name.trim() || !canDuplicate,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="New zone name" secondaryLabel={name.trim() || undefined}>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            placeholder={`${zone.name} copy`}
+            autoFocus
+          />
+        </FormField>
+
+        <div className="grid grid-cols-1 gap-3 rounded-lg border border-border/60 bg-surfaceAlt/50 p-4 text-sm text-text-secondary">
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Room capacity</span>
+            <span className="font-medium text-text-primary">{room.area.toLocaleString()} m²</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Required area</span>
+            <span className="font-medium text-text-primary">{zone.area.toLocaleString()} m²</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Available area</span>
+            <span
+              className={canDuplicate ? 'font-medium text-positive' : 'font-medium text-danger'}
+            >
+              {availableArea.toLocaleString()} m²
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-text-muted">
+              Devices to duplicate
+            </span>
+            <span className="font-medium text-text-primary">{deviceCount.toLocaleString()}</span>
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-border/60 bg-surfaceAlt/50 p-4 text-sm text-text-secondary">
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={includeMethod}
+              onChange={(event) => setIncludeMethod(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border border-border/60 bg-surface text-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            />
+            <span>
+              <span className="block font-medium text-text-primary">
+                Duplicate cultivation method
+              </span>
+              <span className="text-xs text-text-muted">
+                Reuses the source zone’s automation plan, planting targets, and method metadata when
+                available.
+              </span>
+            </span>
+          </label>
+
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={includeDevices}
+              onChange={(event) => setIncludeDevices(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border border-border/60 bg-surface text-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            />
+            <span>
+              <span className="block font-medium text-text-primary">Duplicate devices</span>
+              <span className="text-xs text-text-muted">
+                Purchases new device instances for the duplicate zone. Costs and placement checks
+                are enforced by the facade.
+              </span>
+            </span>
+          </label>
+        </div>
+
+        {!canDuplicate ? (
+          <p className="text-xs text-danger">
+            The target room lacks sufficient free area. Adjust the room footprint before duplicating
+            this zone.
+          </p>
+        ) : null}
+      </form>
+    </Modal>
+  );
+};
+
+export type { DuplicateZoneModalProps };
+export default DuplicateZoneModal;

--- a/src/frontend/src/views/world/modals/RenameEntityModal.tsx
+++ b/src/frontend/src/views/world/modals/RenameEntityModal.tsx
@@ -1,0 +1,77 @@
+import { FormEvent, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+
+type RenameEntityModalProps = {
+  entityLabel: string;
+  currentName: string;
+  onConfirm: (name: string) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const RenameEntityModal = ({
+  entityLabel,
+  currentName,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+}: RenameEntityModalProps) => {
+  const [name, setName] = useState(currentName);
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && trimmed !== currentName.trim();
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!canSubmit) {
+      return;
+    }
+    onConfirm(trimmed);
+  };
+
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Rename ${entityLabel}`}
+      description={
+        description ??
+        `Update the ${entityLabel.toLowerCase()} label. The simulation facade validates naming rules and propagates the change to dependent records.`
+      }
+      onClose={onCancel}
+      size="sm"
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Save name',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !canSubmit,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label={`${entityLabel} name`} secondaryLabel={trimmed || undefined}>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
+            placeholder={`New ${entityLabel.toLowerCase()} name`}
+            autoFocus
+          />
+        </FormField>
+      </form>
+    </Modal>
+  );
+};
+
+export type { RenameEntityModalProps };
+export default RenameEntityModal;

--- a/src/frontend/src/views/zone/modals/PlantDetailModal.tsx
+++ b/src/frontend/src/views/zone/modals/PlantDetailModal.tsx
@@ -1,0 +1,100 @@
+import Modal from '@/components/Modal';
+import type { PlantSnapshot } from '@/types/simulation';
+
+type PlantDetailModalProps = {
+  plant: PlantSnapshot;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+};
+
+const percentage = (value: number | undefined) => {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  const normalized = Math.max(0, Math.min(value ?? 0, 1));
+  return `${Math.round(normalized * 100)}%`;
+};
+
+const grams = (value: number | undefined) => {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return `${value?.toFixed(1)} g`;
+};
+
+const PlantDetailModal = ({ plant, onClose, title, description }: PlantDetailModalProps) => {
+  return (
+    <Modal
+      isOpen
+      title={title ?? `Plant ${plant.id}`}
+      description={
+        description ??
+        'Read-only snapshot of the plant state. Lifecycle updates, health changes, and harvesting are orchestrated by the simulation facade.'
+      }
+      onClose={onClose}
+      size="md"
+      actions={[
+        {
+          label: 'Close',
+          onClick: onClose,
+          variant: 'secondary',
+        },
+      ]}
+    >
+      <section className="grid gap-4 text-sm text-text-secondary md:grid-cols-2">
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">Strain</h3>
+          <p className="font-medium text-text-primary">{plant.strainId}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">Stage</h3>
+          <p className="font-medium text-text-primary">{plant.stage}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">Health</h3>
+          <p className="font-medium text-text-primary">{percentage(plant.health)}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">Stress</h3>
+          <p className="font-medium text-text-primary">{percentage(plant.stress)}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+            Biomass (dry)
+          </h3>
+          <p className="font-medium text-text-primary">{grams(plant.biomassDryGrams)}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+            Yield (dry)
+          </h3>
+          <p className="font-medium text-text-primary">{grams(plant.yieldDryGrams)}</p>
+        </div>
+      </section>
+
+      <section className="space-y-2 rounded-lg border border-border/60 bg-surfaceAlt/60 p-4 text-xs text-text-muted">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          Assignments
+        </h3>
+        <ul className="space-y-1 text-sm text-text-secondary">
+          <li>
+            <span className="text-text-muted">Structure:</span>{' '}
+            <span className="font-medium text-text-primary">{plant.structureId ?? '—'}</span>
+          </li>
+          <li>
+            <span className="text-text-muted">Room:</span>{' '}
+            <span className="font-medium text-text-primary">{plant.roomId ?? '—'}</span>
+          </li>
+          <li>
+            <span className="text-text-muted">Zone:</span>{' '}
+            <span className="font-medium text-text-primary">{plant.zoneId ?? '—'}</span>
+          </li>
+        </ul>
+      </section>
+    </Modal>
+  );
+};
+
+export type { PlantDetailModalProps };
+export default PlantDetailModal;


### PR DESCRIPTION
## Summary
- add a typed ModalDescriptor union covering CRUD, duplication, detail and confirmation flows
- render new world/zone modal bodies through ModalHost with deterministic pause handling
- document the migration progress for modal descriptors and update the changelog

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b01903488325bc69d3cbf4d11c52