### PR TITLE
Align frontend inputs with design system primitives

### DIFF
--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -135,7 +135,7 @@
 
 ### Gemeinsame Komponenten & Utilities
 
-15. UI-Primitiven angleichen: Ersetze Klickdummy-Schaltflächen, Formulare und Icon-Hüllen durch existierende Design-System-Komponenten, ergänze fehlende Inline-Edit-/Icon-Wrapper unter components/inputs.
+15. ✅ UI-Primitiven angleichen: Schaltflächen, Formularfelder und Icon-Hüllen nutzen jetzt die neuen Design-System-Komponenten unter `components/inputs` (`Button`, `IconButton`, `TextInput`, `Select`, `RangeInput`, `InlineEdit`). Bestehende Klickdummy-Markup-Styles wurden entfernt.
 
 16. Fixtures/Mocks modularisieren: Verschiebe deterministische Mock-Fabriken und Rollen-/Kostenkonstanten in src/frontend/fixtures und stelle sicher, dass sie die Store-Hydration bedienen.
 

--- a/docs/system/ui_elements.md
+++ b/docs/system/ui_elements.md
@@ -2,6 +2,13 @@
 
 If Icons are used the Google Material Icon name is shown in brackets like `... icon (search) ...`
 
+## Design-System-Primitiven
+
+- **Buttons & IconButtons** leben unter `src/frontend/src/components/inputs` und ersetzen alle ad-hoc CSS-Buttons aus dem Klickdummy. Varianten (`variant`, `tone`, `size`, `isActive`) decken primäre/sekundäre, Gefahr- und Link-Stile ab.
+- **Formularfelder** (`TextInput`, `Select`, `RangeInput`) kapseln Tailwind-Styling für Text-, Auswahl- und Slider-Steuerelemente und werden von `FormField`, `NumberInputField` sowie den Modalen verwendet.
+- **InlineEdit** kombiniert Anzeige- und Bearbeitungsmodus inklusive Bestätigen/Abbrechen-Tasten.
+- Konsumenten verwenden ausschließlich diese Komponenten; individuelle Klassen aus der Klickdummy-Migration wurden entfernt, sodass Theme- und Fokus-Styles zentral gepflegt werden.
+
 ## 1. Start Screen
 
 This is the first screen a new user sees. It is a simple, centered layout.

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -23,6 +23,15 @@ Run these from the repository root unless noted otherwise:
 The workspace-level scripts (e.g. `pnpm dev`) still work; they simply execute
 the same commands for both backend and frontend packages in parallel.
 
+## Design system components
+
+Reusable UI primitives live in `src/frontend/src/components/inputs` and provide
+consistent styling for buttons, icon buttons, inline editing and form
+controls. Components such as `Button`, `IconButton`, `TextInput`, `Select`,
+`RangeInput`, and `InlineEdit` replace the former clickdummy-specific markup.
+Feature code should import these primitives instead of hand-rolling Tailwind
+classes so states (hover, focus, disabled) stay aligned with the global theme.
+
 The Socket.IO bridge imports `SOCKET_URL` from
 `src/frontend/src/config/socket.ts`. The helper inspects
 `import.meta.env.VITE_SOCKET_URL` (set via a `.env` file alongside this

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ModalHost from '@/components/ModalHost';
 import Navigation from '@/components/Navigation';
 import Panel from '@/components/Panel';
 import TimeDisplay from '@/components/TimeDisplay';
+import { Button } from '@/components/inputs';
 import { useSimulationBridge } from '@/hooks/useSimulationBridge';
 import { OFFLINE_BOOTSTRAP } from '@/fixtures/offlineBootstrap';
 import DashboardOverview from '@/views/DashboardOverview';
@@ -375,22 +376,27 @@ const App = () => {
 
       return (
         <div key={structure.id} className="space-y-2">
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            tone="default"
+            size="sm"
             onClick={() => selectStructure(structure.id)}
             className={[
-              'flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm font-medium transition',
+              'w-full justify-between',
               isStructureSelected
-                ? 'border-accent bg-accent/20 text-text-primary shadow-soft'
-                : 'border-transparent text-text-muted hover:border-border/50 hover:bg-surfaceAlt/80 hover:text-text-primary',
-            ].join(' ')}
+                ? undefined
+                : 'border-transparent bg-transparent text-text-muted hover:border-border/50 hover:bg-surfaceAlt/80 hover:text-text-primary',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            isActive={isStructureSelected}
             aria-pressed={isStructureSelected}
           >
             <span className="truncate">{structure.name}</span>
             <span className="ml-3 inline-flex items-center justify-center rounded-full border border-border/50 px-2 py-0.5 text-xs text-text-secondary">
               {structure.zoneCount} zones
             </span>
-          </button>
+          </Button>
           {isExpanded ? (
             <div className="ml-3 space-y-1 border-l border-border/40 pl-3">
               {structure.rooms.length ? (
@@ -404,42 +410,52 @@ const App = () => {
 
                   return (
                     <div key={room.id} className="space-y-1">
-                      <button
-                        type="button"
+                      <Button
+                        variant="outline"
+                        tone="default"
+                        size="sm"
                         onClick={() => selectRoom(room.id)}
                         className={[
-                          'flex w-full items-center justify-between rounded-md border px-3 py-1.5 text-sm transition',
+                          'w-full justify-between',
                           isRoomSelected
-                            ? 'border-accent bg-accent/10 text-text-primary shadow-soft'
-                            : 'border-transparent text-text-secondary hover-border-border/40 hover:bg-surfaceAlt/70 hover:text-text-primary',
-                        ].join(' ')}
+                            ? undefined
+                            : 'border-transparent bg-transparent text-text-secondary hover:border-border/40 hover:bg-surfaceAlt/70 hover:text-text-primary',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                        isActive={isRoomSelected}
                         aria-pressed={isRoomSelected}
                       >
                         <span className="truncate">{room.name}</span>
                         <span className="ml-2 text-xs text-text-muted">{room.zoneCount} zones</span>
-                      </button>
+                      </Button>
                       {roomZones.length && roomExpanded ? (
                         <ul className="ml-3 space-y-1 border-l border-border/30 pl-3">
                           {roomZones.map((zone) => {
                             const isZoneSelected = selectedZoneId === zone.id;
                             return (
                               <li key={zone.id}>
-                                <button
-                                  type="button"
+                                <Button
+                                  variant="outline"
+                                  tone="default"
+                                  size="xs"
                                   onClick={() => selectZone(zone.id)}
                                   className={[
-                                    'flex w-full items-center justify-between rounded-md border px-3 py-1 text-xs transition',
+                                    'w-full justify-between',
                                     isZoneSelected
-                                      ? 'border-accent bg-accent/10 text-text-primary shadow-soft'
-                                      : 'border-transparent text-text-muted hover:border-border/30 hover:bg-surfaceAlt/60 hover:text-text-primary',
-                                  ].join(' ')}
+                                      ? undefined
+                                      : 'border-transparent bg-transparent text-text-muted hover:border-border/30 hover:bg-surfaceAlt/60 hover:text-text-primary',
+                                  ]
+                                    .filter(Boolean)
+                                    .join(' ')}
+                                  isActive={isZoneSelected}
                                   aria-pressed={isZoneSelected}
                                 >
                                   <span className="truncate">{zone.name}</span>
                                   <span className="ml-2 text-[0.65rem] uppercase tracking-wide text-text-muted">
                                     {zone.temperature.toFixed(0)}°C
                                   </span>
-                                </button>
+                                </Button>
                               </li>
                             );
                           })}
@@ -477,16 +493,17 @@ const App = () => {
                   <h2 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
                     Facility
                   </h2>
-                  <button
-                    type="button"
+                  <Button
+                    variant="link"
+                    tone="accent"
                     onClick={() => {
                       setCurrentView('world');
                       resetSelection();
                     }}
-                    className="text-xs font-medium text-accent transition hover:text-accent/80"
+                    className="text-xs"
                   >
                     All structures
-                  </button>
+                  </Button>
                 </div>
                 <div className="space-y-4 overflow-y-auto pr-1 text-sm text-text-secondary">
                   {structureTree}
@@ -537,15 +554,17 @@ const App = () => {
 
                 <div className="space-y-3">
                   <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
+                    <Button
+                      variant="outline"
+                      tone="default"
+                      size="xs"
+                      leadingIcon="←"
                       onClick={navigateUp}
                       disabled={!canNavigateUp}
-                      className="inline-flex items-center gap-2 rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-text-secondary transition disabled:opacity-40 hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                      className="text-text-secondary"
                     >
-                      <span aria-hidden="true">←</span>
                       Up one level
-                    </button>
+                    </Button>
                     <nav
                       className="flex flex-wrap items-center gap-2 text-sm text-text-secondary"
                       aria-label="Breadcrumb"
@@ -553,13 +572,14 @@ const App = () => {
                       {breadcrumbItems.map((item, index) => (
                         <div key={item.id} className="flex items-center gap-2">
                           {item.onClick ? (
-                            <button
-                              type="button"
+                            <Button
+                              variant="link"
+                              tone="accent"
                               onClick={item.onClick}
-                              className="text-sm font-medium text-accent transition hover:text-accent/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                              className="text-sm"
                             >
                               {item.label}
-                            </button>
+                            </Button>
                           ) : (
                             <span
                               className={`text-sm font-medium ${item.current ? 'text-text-primary' : 'text-text-secondary'}`}
@@ -660,20 +680,24 @@ const App = () => {
                       </div>
                     </dl>
                     <div className="flex flex-wrap gap-3">
-                      <button
-                        type="button"
+                      <Button
+                        variant="solid"
+                        tone="accent"
+                        size="sm"
                         onClick={connect}
-                        className="inline-flex flex-1 items-center justify-center rounded-md border border-accent/70 bg-accent/90 px-3 py-2 text-sm font-medium text-surface shadow-soft transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                        className="flex-1"
                       >
                         Connect
-                      </button>
-                      <button
-                        type="button"
+                      </Button>
+                      <Button
+                        variant="solid"
+                        tone="default"
+                        size="sm"
                         onClick={disconnect}
-                        className="inline-flex flex-1 items-center justify-center rounded-md border border-border/70 bg-surfaceAlt px-3 py-2 text-sm font-medium text-text-secondary transition hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                        className="flex-1"
                       >
                         Disconnect
-                      </button>
+                      </Button>
                     </div>
                   </Panel>
 

--- a/src/frontend/src/components/DashboardControls.tsx
+++ b/src/frontend/src/components/DashboardControls.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, ReactNode } from 'react';
+import { Button, RangeInput } from '@/components/inputs';
 
 type SimulationRunState = 'running' | 'paused' | 'fastForward';
 
@@ -54,43 +55,6 @@ const DashboardControls = ({
     onTickLengthChange(Number(event.target.value));
   };
 
-  const renderButton = (
-    label: string,
-    onClick: () => void,
-    options?: {
-      icon?: ReactNode;
-      intent?: 'primary' | 'secondary';
-      isActive?: boolean;
-      isDisabled?: boolean;
-    },
-  ) => {
-    const icon = options?.icon;
-    const intent = options?.intent ?? 'secondary';
-    const isActive = options?.isActive;
-    const isDisabled = disabled || options?.isDisabled;
-
-    const baseClass =
-      'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2';
-    const intentClass =
-      intent === 'primary'
-        ? 'border border-accent/70 bg-accent/90 text-surface shadow-strong hover:bg-accent focus-visible:outline-accent'
-        : 'border border-border/70 bg-surfaceAlt text-text-secondary hover:border-accent/60 hover:text-text-primary focus-visible:outline-accent';
-
-    const activeClass = isActive ? 'border-accent text-accent shadow-soft' : '';
-
-    return (
-      <button
-        type="button"
-        className={[baseClass, intentClass, activeClass].filter(Boolean).join(' ')}
-        onClick={onClick}
-        disabled={isDisabled}
-      >
-        {icon}
-        <span>{label}</span>
-      </button>
-    );
-  };
-
   return (
     <section className={containerClass} aria-label="Simulation controls">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -99,39 +63,63 @@ const DashboardControls = ({
             {stateLabel[state]}
           </p>
           <div className="flex flex-wrap gap-3">
-            {renderButton('Play', onPlay, {
-              icon: <span aria-hidden="true">▶</span>,
-              intent: 'primary',
-              isDisabled: state === 'running',
-            })}
-            {renderButton('Pause', onPause, {
-              icon: <span aria-hidden="true">⏸</span>,
-              isActive: state === 'paused',
-            })}
-            {renderButton('Step', onStep, {
-              icon: <span aria-hidden="true">⏭</span>,
-            })}
-            {onFastForward
-              ? renderButton('Fast forward', onFastForward, {
-                  icon: <span aria-hidden="true">⏩</span>,
-                  isActive: state === 'fastForward',
-                })
-              : null}
+            <Button
+              variant="solid"
+              tone="accent"
+              size="sm"
+              leadingIcon="▶"
+              onClick={onPlay}
+              disabled={disabled || state === 'running'}
+            >
+              Play
+            </Button>
+            <Button
+              variant="outline"
+              tone="default"
+              size="sm"
+              leadingIcon="⏸"
+              onClick={onPause}
+              disabled={disabled}
+              isActive={state === 'paused'}
+            >
+              Pause
+            </Button>
+            <Button
+              variant="outline"
+              tone="default"
+              size="sm"
+              leadingIcon="⏭"
+              onClick={onStep}
+              disabled={disabled}
+            >
+              Step
+            </Button>
+            {onFastForward ? (
+              <Button
+                variant="outline"
+                tone="default"
+                size="sm"
+                leadingIcon="⏩"
+                onClick={onFastForward}
+                disabled={disabled}
+                isActive={state === 'fastForward'}
+              >
+                Fast forward
+              </Button>
+            ) : null}
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-3">
           <label className="flex flex-col gap-2 text-sm text-text-secondary">
             <span className="font-medium text-text-primary">Tick length</span>
             <div className="flex items-center gap-3">
-              <input
-                type="range"
+              <RangeInput
                 min={minTickLength}
                 max={maxTickLength}
                 step={1}
                 value={tickLengthMinutes}
                 onChange={handleTickLengthChange}
                 disabled={disabled || !onTickLengthChange}
-                className="h-2 w-full cursor-pointer appearance-none rounded-full bg-border/60 accent-accent/70"
               />
               <span className="w-20 text-right font-mono text-sm text-text-muted">
                 {tickLengthMinutes.toFixed(0)}m

--- a/src/frontend/src/components/Modal.tsx
+++ b/src/frontend/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect } from 'react';
+import { Button, IconButton } from '@/components/inputs';
 
 type ModalAction = {
   label: string;
@@ -19,19 +20,21 @@ type ModalProps = {
   className?: string;
 };
 
-const actionClassName: Record<NonNullable<ModalAction['variant']>, string> = {
-  primary:
-    'inline-flex items-center justify-center rounded-md border border-accent/80 bg-accent/90 px-4 py-2 text-sm font-medium text-surface shadow-strong transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-  secondary:
-    'inline-flex items-center justify-center rounded-md border border-border/60 bg-surfaceAlt px-4 py-2 text-sm font-medium text-text-secondary transition hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-  danger:
-    'inline-flex items-center justify-center rounded-md border border-danger/60 bg-danger/20 px-4 py-2 text-sm font-medium text-danger transition hover:bg-danger/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger',
-};
-
 const sizeClassName = {
   sm: 'max-w-md',
   md: 'max-w-2xl',
   lg: 'max-w-4xl',
+};
+
+const mapActionToButton = (variant: NonNullable<ModalAction['variant']>) => {
+  switch (variant) {
+    case 'primary':
+      return { variant: 'solid' as const, tone: 'accent' as const };
+    case 'danger':
+      return { variant: 'solid' as const, tone: 'danger' as const };
+    default:
+      return { variant: 'outline' as const, tone: 'default' as const };
+  }
 };
 
 const Modal = ({
@@ -93,30 +96,33 @@ const Modal = ({
             </h2>
             {description ? <p className="text-sm text-text-secondary">{description}</p> : null}
           </div>
-          <button
-            type="button"
+          <IconButton
             onClick={onClose}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/40 text-lg text-text-muted transition hover:border-accent hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             aria-label="Close dialog"
+            variant="ghost"
+            tone="default"
+            size="md"
           >
             ×
-          </button>
+          </IconButton>
         </header>
         <div className="space-y-4 text-sm text-text-secondary">{children}</div>
         {actions && actions.length > 0 ? (
           <div className="mt-6 flex flex-wrap justify-end gap-3">
             {actions.map((action) => {
               const variant = action.variant ?? 'secondary';
+              const buttonConfig = mapActionToButton(variant);
               return (
-                <button
+                <Button
                   key={action.label}
-                  type="button"
                   onClick={action.onClick}
-                  className={actionClassName[variant]}
+                  variant={buttonConfig.variant}
+                  tone={buttonConfig.tone}
+                  size="md"
                   disabled={action.disabled}
                 >
                   {action.label}
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/src/frontend/src/components/TimeDisplay.tsx
+++ b/src/frontend/src/components/TimeDisplay.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Button } from '@/components/inputs';
 
 type SimulationStatus = 'live' | 'paused' | 'fastForward';
 
@@ -90,14 +91,9 @@ const TimeDisplay = ({
           </dl>
         ) : null}
         {onSync ? (
-          <button
-            type="button"
-            onClick={onSync}
-            className="inline-flex items-center gap-2 rounded-md border border-accent/60 px-3 py-1.5 text-xs font-medium text-accent transition hover:border-accent hover:bg-accent/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-          >
-            <span aria-hidden="true">⟳</span>
+          <Button onClick={onSync} variant="outline" tone="accent" size="xs" leadingIcon="⟳">
             {syncLabel}
-          </button>
+          </Button>
         ) : null}
       </div>
     </section>

--- a/src/frontend/src/components/forms/NumberInputField.tsx
+++ b/src/frontend/src/components/forms/NumberInputField.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react';
+import { TextInput } from '@/components/inputs';
 import FormField from './FormField';
 
 export type NumberInputFieldProps = {
@@ -57,17 +58,16 @@ const NumberInputField = ({
   return (
     <FormField label={label} secondaryLabel={secondaryLabel} description={description}>
       <div className="flex items-center gap-2">
-        <input
+        <TextInput
           id={id}
           type="number"
           min={min}
           max={max}
           step={step}
-          value={Number.isFinite(value) ? value : 0}
+          value={Number.isFinite(value) ? value : ''}
           onChange={handleChange}
           placeholder={placeholder}
           disabled={disabled}
-          className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60 disabled:cursor-not-allowed disabled:opacity-60"
         />
         {suffix ? <span className="text-sm font-medium text-text-secondary">{suffix}</span> : null}
       </div>

--- a/src/frontend/src/components/forms/RangeField.tsx
+++ b/src/frontend/src/components/forms/RangeField.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react';
+import { RangeInput } from '@/components/inputs';
 import FormField from './FormField';
 
 export type RangeFieldProps = {
@@ -43,16 +44,14 @@ const RangeField = ({
 
   return (
     <FormField label={label} secondaryLabel={secondaryLabel} description={description}>
-      <input
+      <RangeInput
         id={id}
-        type="range"
         min={min}
         max={max}
         step={step}
         value={value}
         onChange={handleChange}
         disabled={disabled}
-        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-border/60 accent-accent/70 disabled:cursor-not-allowed disabled:opacity-60"
       />
       {footer}
     </FormField>

--- a/src/frontend/src/components/inputs/Button.tsx
+++ b/src/frontend/src/components/inputs/Button.tsx
@@ -1,0 +1,156 @@
+import { ButtonHTMLAttributes, ReactNode, forwardRef } from 'react';
+
+type ButtonVariant = 'solid' | 'outline' | 'ghost' | 'link';
+type ButtonTone = 'default' | 'accent' | 'danger';
+type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
+
+type ButtonProps = {
+  variant?: ButtonVariant;
+  tone?: ButtonTone;
+  size?: ButtonSize;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  fullWidth?: boolean;
+  isActive?: boolean;
+  className?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const sizeClassName: Record<ButtonSize, string> = {
+  xs: 'px-2.5 py-1 text-xs',
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
+};
+
+const variantToneClassName: Record<ButtonVariant, Record<ButtonTone, string>> = {
+  solid: {
+    accent:
+      'border border-accent/70 bg-accent/90 text-surface shadow-soft hover:bg-accent focus-visible:outline-accent',
+    default:
+      'border border-border/60 bg-surfaceAlt text-text-secondary hover:border-accent/60 hover:text-text-primary focus-visible:outline-accent',
+    danger:
+      'border border-danger/60 bg-danger/15 text-danger hover:bg-danger/25 focus-visible:outline-danger',
+  },
+  outline: {
+    accent:
+      'border border-accent/60 bg-transparent text-accent hover:bg-accent/10 focus-visible:outline-accent',
+    default:
+      'border border-border/60 bg-surfaceAlt/70 text-text-secondary hover:border-accent hover:text-text-primary focus-visible:outline-accent',
+    danger:
+      'border border-danger/60 bg-transparent text-danger hover:bg-danger/10 focus-visible:outline-danger',
+  },
+  ghost: {
+    accent:
+      'bg-transparent text-accent hover:text-accent/80 focus-visible:outline focus-visible:outline-accent',
+    default:
+      'bg-transparent text-text-secondary hover:text-text-primary focus-visible:outline focus-visible:outline-accent',
+    danger:
+      'bg-transparent text-danger hover:text-danger/80 focus-visible:outline focus-visible:outline-danger',
+  },
+  link: {
+    accent:
+      'bg-transparent px-0 py-0 text-sm font-medium text-accent underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-accent',
+    default:
+      'bg-transparent px-0 py-0 text-sm font-medium text-text-secondary underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-accent',
+    danger:
+      'bg-transparent px-0 py-0 text-sm font-medium text-danger underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-danger',
+  },
+};
+
+const activeVariantClassName: Partial<Record<ButtonVariant, Partial<Record<ButtonTone, string>>>> =
+  {
+    solid: {
+      accent: 'border-accent bg-accent text-surface shadow-strong',
+      default: 'border-accent text-text-primary shadow-soft',
+      danger: 'border-danger text-danger shadow-soft',
+    },
+    outline: {
+      accent: 'border-accent bg-accent/15 text-accent shadow-soft',
+      default: 'border-accent bg-surfaceElevated text-text-primary shadow-soft',
+      danger: 'border-danger bg-danger/10 text-danger shadow-soft',
+    },
+    ghost: {
+      accent: 'text-accent',
+      default: 'text-text-primary',
+      danger: 'text-danger',
+    },
+    link: {
+      accent: 'underline',
+      default: 'underline',
+      danger: 'underline',
+    },
+  };
+
+const resolveIconClassName = (size: ButtonSize) => {
+  switch (size) {
+    case 'xs':
+      return 'text-xs';
+    case 'lg':
+      return 'text-lg';
+    case 'md':
+      return 'text-base';
+    default:
+      return 'text-sm';
+  }
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = 'solid',
+      tone = 'accent',
+      size = 'sm',
+      leadingIcon,
+      trailingIcon,
+      fullWidth = false,
+      isActive = false,
+      className,
+      type = 'button',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const baseClass =
+      'inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+
+    const resolvedSizeClass = variant === 'link' ? 'text-sm' : sizeClassName[size];
+    const variantClass = variantToneClassName[variant][tone];
+    const activeClass = isActive ? activeVariantClassName[variant]?.[tone] : undefined;
+    const widthClass = fullWidth ? 'w-full' : undefined;
+
+    const finalClass = [
+      baseClass,
+      resolvedSizeClass,
+      variantClass,
+      activeClass,
+      widthClass,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const iconClass = resolveIconClassName(size);
+
+    return (
+      <button ref={ref} type={type} className={finalClass} {...props}>
+        {leadingIcon ? (
+          <span aria-hidden="true" className={['flex items-center', iconClass].join(' ')}>
+            {leadingIcon}
+          </span>
+        ) : null}
+        {children}
+        {trailingIcon ? (
+          <span aria-hidden="true" className={['flex items-center', iconClass].join(' ')}>
+            {trailingIcon}
+          </span>
+        ) : null}
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+
+export type { ButtonProps, ButtonSize, ButtonTone, ButtonVariant };
+export default Button;

--- a/src/frontend/src/components/inputs/IconButton.tsx
+++ b/src/frontend/src/components/inputs/IconButton.tsx
@@ -1,0 +1,83 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+
+type IconButtonVariant = 'solid' | 'outline' | 'ghost';
+type IconButtonTone = 'default' | 'accent' | 'danger';
+type IconButtonSize = 'sm' | 'md' | 'lg';
+
+type IconButtonProps = {
+  variant?: IconButtonVariant;
+  tone?: IconButtonTone;
+  size?: IconButtonSize;
+  className?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const sizeClassName: Record<IconButtonSize, string> = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-9 w-9 text-base',
+  lg: 'h-10 w-10 text-lg',
+};
+
+const variantToneClassName: Record<IconButtonVariant, Record<IconButtonTone, string>> = {
+  solid: {
+    accent:
+      'border border-accent/60 bg-accent/90 text-surface shadow-soft hover:bg-accent focus-visible:outline-accent',
+    default:
+      'border border-border/60 bg-surfaceAlt text-text-secondary hover:border-accent/60 hover:text-text-primary focus-visible:outline-accent',
+    danger:
+      'border border-danger/60 bg-danger/15 text-danger hover:bg-danger/25 focus-visible:outline-danger',
+  },
+  outline: {
+    accent:
+      'border border-accent/60 bg-transparent text-accent hover:bg-accent/10 focus-visible:outline-accent',
+    default:
+      'border border-border/60 bg-transparent text-text-secondary hover:border-accent hover:text-text-primary focus-visible:outline-accent',
+    danger:
+      'border border-danger/60 bg-transparent text-danger hover:bg-danger/10 focus-visible:outline-danger',
+  },
+  ghost: {
+    accent:
+      'bg-transparent text-accent hover:text-accent/80 focus-visible:outline focus-visible:outline-accent',
+    default:
+      'bg-transparent text-text-muted hover:text-text-primary focus-visible:outline focus-visible:outline-accent',
+    danger:
+      'bg-transparent text-danger hover:text-danger/80 focus-visible:outline focus-visible:outline-danger',
+  },
+};
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      variant = 'ghost',
+      tone = 'default',
+      size = 'md',
+      className,
+      type = 'button',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const baseClass =
+      'inline-flex items-center justify-center rounded-full transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+
+    const finalClass = [
+      baseClass,
+      sizeClassName[size],
+      variantToneClassName[variant][tone],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <button ref={ref} type={type} className={finalClass} {...props}>
+        {children}
+      </button>
+    );
+  },
+);
+
+IconButton.displayName = 'IconButton';
+
+export type { IconButtonProps, IconButtonSize, IconButtonTone, IconButtonVariant };
+export default IconButton;

--- a/src/frontend/src/components/inputs/InlineEdit.tsx
+++ b/src/frontend/src/components/inputs/InlineEdit.tsx
@@ -1,0 +1,127 @@
+import { FormEvent, KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import Button from './Button';
+import IconButton from './IconButton';
+import TextInput from './TextInput';
+
+type InlineEditSize = 'sm' | 'md';
+
+type InlineEditProps = {
+  value: string;
+  onSubmit: (nextValue: string) => void;
+  onCancel?: () => void;
+  placeholder?: string;
+  editLabel?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  size?: InlineEditSize;
+  leadingIcon?: ReactNode;
+  className?: string;
+  inputClassName?: string;
+};
+
+const InlineEdit = ({
+  value,
+  onSubmit,
+  onCancel,
+  placeholder = 'Enter value',
+  editLabel = 'Edit value',
+  confirmLabel = 'Save',
+  cancelLabel = 'Cancel',
+  size = 'sm',
+  leadingIcon,
+  className,
+  inputClassName,
+}: InlineEditProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(value);
+    }
+  }, [isEditing, value]);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const handleSubmit = (next: string) => {
+    onSubmit(next);
+    setIsEditing(false);
+  };
+
+  const handleConfirm = () => {
+    handleSubmit(draft);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setIsEditing(false);
+    onCancel?.();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleConfirm();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      handleCancel();
+    }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleConfirm();
+  };
+
+  if (isEditing) {
+    return (
+      <form
+        className={['flex items-center gap-2', className].filter(Boolean).join(' ')}
+        onSubmit={handleFormSubmit}
+      >
+        {leadingIcon ? <span aria-hidden="true">{leadingIcon}</span> : null}
+        <TextInput
+          ref={inputRef}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          size={size === 'sm' ? 'sm' : 'md'}
+          className={inputClassName}
+        />
+        <Button variant="solid" tone="accent" size={size} type="submit">
+          {confirmLabel}
+        </Button>
+        <Button variant="ghost" tone="default" size={size} type="button" onClick={handleCancel}>
+          {cancelLabel}
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <div className={['inline-flex items-center gap-2', className].filter(Boolean).join(' ')}>
+      {leadingIcon ? <span aria-hidden="true">{leadingIcon}</span> : null}
+      <span className="text-sm font-medium text-text-primary">{value || placeholder}</span>
+      <IconButton
+        variant="ghost"
+        tone="default"
+        size={size === 'sm' ? 'sm' : 'md'}
+        aria-label={editLabel}
+        onClick={() => setIsEditing(true)}
+      >
+        ✎
+      </IconButton>
+    </div>
+  );
+};
+
+export type { InlineEditProps, InlineEditSize };
+export default InlineEdit;

--- a/src/frontend/src/components/inputs/RangeInput.tsx
+++ b/src/frontend/src/components/inputs/RangeInput.tsx
@@ -1,0 +1,17 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+
+type RangeInputProps = InputHTMLAttributes<HTMLInputElement>;
+
+const RangeInput = forwardRef<HTMLInputElement, RangeInputProps>(({ className, ...props }, ref) => {
+  const baseClass =
+    'h-2 w-full cursor-pointer appearance-none rounded-full bg-border/60 accent-accent/70 disabled:cursor-not-allowed disabled:opacity-60';
+
+  const finalClass = [baseClass, className].filter(Boolean).join(' ');
+
+  return <input ref={ref} type="range" className={finalClass} {...props} />;
+});
+
+RangeInput.displayName = 'RangeInput';
+
+export type { RangeInputProps };
+export default RangeInput;

--- a/src/frontend/src/components/inputs/Select.tsx
+++ b/src/frontend/src/components/inputs/Select.tsx
@@ -1,0 +1,29 @@
+import { SelectHTMLAttributes, forwardRef } from 'react';
+
+type SelectSize = 'sm' | 'md';
+
+type SelectProps = {
+  size?: SelectSize;
+  className?: string;
+} & SelectHTMLAttributes<HTMLSelectElement>;
+
+const sizeClassName: Record<SelectSize, string> = {
+  sm: 'px-2.5 py-1.5 text-sm',
+  md: 'px-3 py-2 text-sm',
+};
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ size = 'md', className, ...props }, ref) => {
+    const baseClass =
+      'w-full rounded-md border border-border/60 bg-surface text-text-primary shadow-inner focus:outline-none focus:ring-1 focus:ring-accent/60 disabled:cursor-not-allowed disabled:opacity-60';
+
+    const finalClass = [baseClass, sizeClassName[size], className].filter(Boolean).join(' ');
+
+    return <select ref={ref} className={finalClass} {...props} />;
+  },
+);
+
+Select.displayName = 'Select';
+
+export type { SelectProps, SelectSize };
+export default Select;

--- a/src/frontend/src/components/inputs/TextInput.tsx
+++ b/src/frontend/src/components/inputs/TextInput.tsx
@@ -1,0 +1,35 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+
+type TextInputSize = 'sm' | 'md';
+
+type TextInputProps = {
+  size?: TextInputSize;
+  invalid?: boolean;
+  className?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+const sizeClassName: Record<TextInputSize, string> = {
+  sm: 'px-2.5 py-1.5 text-sm',
+  md: 'px-3 py-2 text-sm',
+};
+
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  ({ size = 'md', invalid = false, className, type = 'text', ...props }, ref) => {
+    const baseClass =
+      'w-full rounded-md border border-border/60 bg-surface text-text-primary shadow-inner focus:outline-none focus:ring-1 focus:ring-accent/60 disabled:cursor-not-allowed disabled:opacity-60 placeholder:text-text-muted/60';
+    const invalidClass = invalid
+      ? 'border-danger/70 focus:border-danger focus:ring-danger/40'
+      : undefined;
+
+    const finalClass = [baseClass, sizeClassName[size], invalidClass, className]
+      .filter(Boolean)
+      .join(' ');
+
+    return <input ref={ref} type={type} className={finalClass} {...props} />;
+  },
+);
+
+TextInput.displayName = 'TextInput';
+
+export type { TextInputProps, TextInputSize };
+export default TextInput;

--- a/src/frontend/src/components/inputs/index.ts
+++ b/src/frontend/src/components/inputs/index.ts
@@ -1,0 +1,17 @@
+export { default as Button } from './Button';
+export type { ButtonProps, ButtonSize, ButtonTone, ButtonVariant } from './Button';
+export { default as IconButton } from './IconButton';
+export type {
+  IconButtonProps,
+  IconButtonSize,
+  IconButtonTone,
+  IconButtonVariant,
+} from './IconButton';
+export { default as InlineEdit } from './InlineEdit';
+export type { InlineEditProps, InlineEditSize } from './InlineEdit';
+export { default as TextInput } from './TextInput';
+export type { TextInputProps, TextInputSize } from './TextInput';
+export { default as Select } from './Select';
+export type { SelectProps, SelectSize } from './Select';
+export { default as RangeInput } from './RangeInput';
+export type { RangeInputProps } from './RangeInput';

--- a/src/frontend/src/views/FinancesView.tsx
+++ b/src/frontend/src/views/FinancesView.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
+import { Button } from '@/components/inputs';
 import { BreakdownList } from '@/components/panels';
 import { selectFinanceSummary, useZoneStore } from '@/store';
 import {
@@ -258,19 +259,17 @@ const FinancesView = () => {
             {TIME_RANGE_OPTIONS.map((option) => {
               const isActive = option.id === selectedRange.id;
               return (
-                <button
+                <Button
                   key={option.id}
-                  type="button"
+                  variant="outline"
+                  tone="default"
+                  size="sm"
                   onClick={() => setSelectedRangeId(option.id)}
-                  aria-pressed={isActive}
-                  className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                    isActive
-                      ? 'bg-surfaceElevated text-text-primary shadow-soft'
-                      : 'bg-surfaceAlt/70 text-text-muted hover:text-text-primary'
-                  }`}
+                  isActive={isActive}
+                  className={isActive ? undefined : 'text-text-muted'}
                 >
                   {option.label}
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/src/frontend/src/views/PersonnelView.tsx
+++ b/src/frontend/src/views/PersonnelView.tsx
@@ -3,6 +3,7 @@ import Card from '@/components/Card';
 import DashboardHeader from '@/components/DashboardHeader';
 import MetricsBar from '@/components/MetricsBar';
 import Panel from '@/components/Panel';
+import { Button } from '@/components/inputs';
 import { useAppStore, usePersonnelStore, useZoneStore } from '@/store';
 
 const percentageFormatter = new Intl.NumberFormat('en-US', {
@@ -268,13 +269,14 @@ const PersonnelView = () => {
                     ]}
                     footer={
                       <div className="flex items-center justify-end">
-                        <button
-                          type="button"
+                        <Button
+                          variant="solid"
+                          tone="danger"
+                          size="sm"
                           onClick={() => handleFire(employee.id, employee.name)}
-                          className="inline-flex items-center rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5 text-sm font-medium text-danger transition hover:bg-danger/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger"
                         >
                           Fire employee
-                        </button>
+                        </Button>
                       </div>
                     }
                   >
@@ -296,13 +298,9 @@ const PersonnelView = () => {
             padding="lg"
             variant="elevated"
             action={
-              <button
-                type="button"
-                onClick={refreshCandidates}
-                className="inline-flex items-center rounded-md border border-accent/70 bg-accent/90 px-3 py-1.5 text-sm font-medium text-surface shadow-soft transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-              >
+              <Button variant="solid" tone="accent" size="sm" onClick={refreshCandidates}>
                 Refresh candidates
-              </button>
+              </Button>
             }
           >
             {applicants.length === 0 ? (
@@ -330,13 +328,14 @@ const PersonnelView = () => {
                       ]}
                       footer={
                         <div className="flex items-center justify-end">
-                          <button
-                            type="button"
+                          <Button
+                            variant="solid"
+                            tone="accent"
+                            size="sm"
                             onClick={() => handleHire(applicant.id, applicant.name)}
-                            className="inline-flex items-center rounded-md border border-accent/70 bg-accent/90 px-3 py-1.5 text-sm font-medium text-surface shadow-soft transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                           >
                             Hire candidate
-                          </button>
+                          </Button>
                         </div>
                       }
                     >

--- a/src/frontend/src/views/ZoneDetail.tsx
+++ b/src/frontend/src/views/ZoneDetail.tsx
@@ -6,6 +6,7 @@ import Panel from '@/components/Panel';
 import { RoomSummaryCard, ZoneSummaryCard } from '@/components/cards';
 import ToggleSwitch from '@/components/ToggleSwitch';
 import { FormField, NumberInputField, RangeField } from '@/components/forms';
+import { Button, TextInput } from '@/components/inputs';
 import { selectCurrentTick, useAppStore, useGameStore, useZoneStore } from '@/store';
 import { computeZoneAggregateMetrics } from '@/views/utils/zoneAggregates';
 
@@ -520,13 +521,15 @@ const ZoneDetail = () => {
                             {lastValue ? <span>Last command: {lastValue}</span> : null}
                           </div>
                           <div className="flex justify-end">
-                            <button
-                              type="button"
+                            <Button
+                              variant="solid"
+                              tone="accent"
+                              size="xs"
+                              className="font-semibold"
                               onClick={() => handleSetpointDispatch(config.metric)}
-                              className="inline-flex items-center rounded-md border border-accent/70 bg-accent/90 px-3 py-1.5 text-xs font-semibold text-surface transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                             >
                               Dispatch
-                            </button>
+                            </Button>
                           </div>
                         </div>
                       }
@@ -628,14 +631,16 @@ const ZoneDetail = () => {
                   formatValue={(value) => value.toFixed(1)}
                   footer={
                     <div className="mt-3 flex justify-end">
-                      <button
-                        type="button"
+                      <Button
+                        variant="solid"
+                        tone="accent"
+                        size="xs"
+                        className="font-semibold"
                         onClick={handleApplyWater}
                         disabled={waterCommandLiters <= 0}
-                        className="inline-flex items-center rounded-md border border-accent/70 bg-accent/90 px-3 py-1.5 text-xs font-semibold text-surface transition hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         Apply water
-                      </button>
+                      </Button>
                     </div>
                   }
                 />
@@ -651,10 +656,11 @@ const ZoneDetail = () => {
                         <span className="font-semibold uppercase tracking-wide text-text-secondary">
                           {key}
                         </span>
-                        <input
+                        <TextInput
                           type="number"
                           min={0}
                           step={0.5}
+                          size="sm"
                           value={nutrientDraft[key]}
                           onChange={(event) => {
                             const parsed = Number(event.target.value);
@@ -666,22 +672,23 @@ const ZoneDetail = () => {
                               [key]: Math.max(0, parsed),
                             }));
                           }}
-                          className="w-full rounded-md border border-border/60 bg-surface px-2 py-1 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
                         />
                       </label>
                     ))}
                   </div>
                   <div className="mt-3 flex justify-end">
-                    <button
-                      type="button"
+                    <Button
+                      variant="solid"
+                      tone="default"
+                      size="xs"
+                      className="font-semibold"
                       onClick={handleApplyNutrients}
                       disabled={
                         nutrientDraft.N <= 0 && nutrientDraft.P <= 0 && nutrientDraft.K <= 0
                       }
-                      className="inline-flex items-center rounded-md border border-border/60 bg-surfaceAlt px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent/60 hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Apply nutrients
-                    </button>
+                    </Button>
                   </div>
                 </FormField>
               </div>
@@ -721,14 +728,16 @@ const ZoneDetail = () => {
                       : 'No harvest-ready planting groups detected.'}
                   </p>
                   <div className="mt-3 flex justify-end">
-                    <button
-                      type="button"
+                    <Button
+                      variant="solid"
+                      tone="default"
+                      size="xs"
+                      className="font-semibold"
                       onClick={handleHarvestReady}
                       disabled={harvestablePlantingIds.length === 0}
-                      className="inline-flex items-center rounded-md border border-border/60 bg-surfaceAlt px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent/60 hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Harvest ready groups
-                    </button>
+                    </Button>
                   </div>
                 </FormField>
               </div>

--- a/src/frontend/src/views/world/modals/CreateRoomModal.tsx
+++ b/src/frontend/src/views/world/modals/CreateRoomModal.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useMemo, useState } from 'react';
 import Modal from '@/components/Modal';
 import FormField from '@/components/forms/FormField';
 import NumberInputField from '@/components/forms/NumberInputField';
+import { Select, TextInput } from '@/components/inputs';
 import type { RoomSnapshot, StructureSnapshot } from '@/types/simulation';
 
 type CreateRoomModalProps = {
@@ -115,28 +116,22 @@ const CreateRoomModal = ({
     >
       <form className="space-y-4" onSubmit={handleSubmit}>
         <FormField label="Room name" secondaryLabel={name.trim() || undefined}>
-          <input
-            type="text"
+          <TextInput
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
             placeholder="e.g. Flowering wing"
             autoFocus
           />
         </FormField>
 
         <FormField label="Room purpose">
-          <select
-            value={purposeId}
-            onChange={(event) => setPurposeId(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
-          >
+          <Select value={purposeId} onChange={(event) => setPurposeId(event.target.value)}>
             {purposeOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
             ))}
-          </select>
+          </Select>
         </FormField>
 
         <NumberInputField

--- a/src/frontend/src/views/world/modals/CreateZoneModal.tsx
+++ b/src/frontend/src/views/world/modals/CreateZoneModal.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useMemo, useState } from 'react';
 import Modal from '@/components/Modal';
 import FormField from '@/components/forms/FormField';
 import NumberInputField from '@/components/forms/NumberInputField';
+import { Select, TextInput } from '@/components/inputs';
 import type { RoomSnapshot, ZoneSnapshot } from '@/types/simulation';
 
 type CultivationMethodOption = {
@@ -138,11 +139,9 @@ const CreateZoneModal = ({
     >
       <form className="space-y-4" onSubmit={handleSubmit}>
         <FormField label="Zone name" secondaryLabel={name.trim() || undefined}>
-          <input
-            type="text"
+          <TextInput
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
             placeholder="e.g. Flower bench"
             autoFocus
           />
@@ -166,17 +165,16 @@ const CreateZoneModal = ({
         />
 
         <FormField label="Cultivation method">
-          <select
+          <Select
             value={methodId ?? ''}
             onChange={(event) => setMethodId(event.target.value || undefined)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
           >
             {methodOptions.map((option) => (
               <option key={option.id} value={option.id}>
                 {option.name}
               </option>
             ))}
-          </select>
+          </Select>
         </FormField>
 
         <NumberInputField

--- a/src/frontend/src/views/world/modals/DuplicateRoomModal.tsx
+++ b/src/frontend/src/views/world/modals/DuplicateRoomModal.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useMemo, useState } from 'react';
 import Modal from '@/components/Modal';
 import FormField from '@/components/forms/FormField';
+import { TextInput } from '@/components/inputs';
 import type { RoomSnapshot, StructureSnapshot, ZoneSnapshot } from '@/types/simulation';
 
 type DuplicateRoomModalProps = {
@@ -79,11 +80,9 @@ const DuplicateRoomModal = ({
     >
       <form className="space-y-4" onSubmit={handleSubmit}>
         <FormField label="New room name" secondaryLabel={name.trim() || undefined}>
-          <input
-            type="text"
+          <TextInput
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
             placeholder={`${room.name} copy`}
             autoFocus
           />

--- a/src/frontend/src/views/world/modals/DuplicateZoneModal.tsx
+++ b/src/frontend/src/views/world/modals/DuplicateZoneModal.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react';
 import Modal from '@/components/Modal';
 import FormField from '@/components/forms/FormField';
+import { TextInput } from '@/components/inputs';
 import type { RoomSnapshot, ZoneSnapshot } from '@/types/simulation';
 
 type DuplicateZoneModalProps = {
@@ -67,11 +68,9 @@ const DuplicateZoneModal = ({
     >
       <form className="space-y-4" onSubmit={handleSubmit}>
         <FormField label="New zone name" secondaryLabel={name.trim() || undefined}>
-          <input
-            type="text"
+          <TextInput
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
             placeholder={`${zone.name} copy`}
             autoFocus
           />

--- a/src/frontend/src/views/world/modals/RenameEntityModal.tsx
+++ b/src/frontend/src/views/world/modals/RenameEntityModal.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react';
 import Modal from '@/components/Modal';
 import FormField from '@/components/forms/FormField';
+import { TextInput } from '@/components/inputs';
 
 type RenameEntityModalProps = {
   entityLabel: string;
@@ -59,11 +60,9 @@ const RenameEntityModal = ({
     >
       <form className="space-y-4" onSubmit={handleSubmit}>
         <FormField label={`${entityLabel} name`} secondaryLabel={trimmed || undefined}>
-          <input
-            type="text"
+          <TextInput
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60"
             placeholder={`New ${entityLabel.toLowerCase()} name`}
             autoFocus
           />


### PR DESCRIPTION
## Summary
- add shared input primitives (Button, IconButton, InlineEdit, TextInput, Select, RangeInput) under `components/inputs`
- replace clickdummy button/form markup across zone, personnel, finance, and shell views with the new components
- update design system documentation to describe the new primitives and mark the migration step as complete

## Testing
- `pnpm --filter frontend lint` *(fails: missing @eslint/js package in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d3b7d320248325883d4adfe6c3feba