### PR TITLE
test: verify offline bootstrap determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ergänzte das Finanzdashboard um einen tick-basierten Zeitbereichs-Umschalter samt Aufschlüsselungslisten für OpEx, Utilities und Wartungsgeräte. Die Listen basieren auf dem neuen `components/panels/BreakdownList`.
 - Registrierte typisierte Modal-Descriptoren für Infrastruktur- und Detail-Workflows und implementierte dedizierte Modal-Inhalte unter `views/world/modals` bzw. `views/zone/modals`, gerendert über den aktualisierten `ModalHost`.
 - Modularisierte die deterministischen Clickdummy-Fixtures unter `src/frontend/src/fixtures` (inklusive `createClickDummyFixture`, Jobrollen- und Kostenkonstanten) zur Wiederverwendung in Offline-Bootstrap, Tests und künftigen Previews.
+- Ergänzte `createOfflineBootstrapPayload` samt Vitest-Absicherung (`offlineBootstrap.test.ts`), sodass wiederholte Hydrationen mit gleichem Seed identische Snapshots liefern und RNG-Tausch-Regressionen früh auffallen.
 
 ### Changed
 

--- a/docs/addendum/clickdummy/migration_steps.md
+++ b/docs/addendum/clickdummy/migration_steps.md
@@ -153,4 +153,6 @@
     - Neue fixturespezifische Tests (`src/frontend/src/fixtures/deterministic.test.ts`) prüfen Sequenz- und Manager-Funktionalität, Clones, Scope-Reset sowie die globalen Helper (`getSharedSequence`, `nextSharedId`).
     - UI-Komponenten besitzen Snapshot- und Verhaltenstests: `StructureSummaryCard.test.tsx` verifiziert Metrik-Rendering und Selection-Callbacks, `Navigation.test.tsx` prüft aktive Zustände, Badge-Anzeige, Disabled-Verhalten und erzeugt ein vertikales Layout-Snapshot.
 
-20. Determinismus verifizieren: Führe wiederholte Hydrationen mit gleichem Seed aus, um identische Snapshot-Ergebnisse zu bestätigen und Regressionen beim RNG-Austausch auszuschließen.
+20. ✅ Determinismus verifizieren: Wiederholte Hydrationen mit identischem Seed liefern jetzt bytegleiche Ergebnisse.
+    - `createOfflineBootstrapPayload` kapselt die Fixture-Hydration und erzeugt `OFFLINE_BOOTSTRAP`-kompatible Updates.
+    - `offlineBootstrap.test.ts` hydratisiert den Snapshot zweimal mit demselben Seed und vergleicht Snapshot, Events und Finance-Historie, um RNG-Regressionsrisiken früh zu erkennen.

--- a/src/frontend/src/fixtures/offlineBootstrap.test.ts
+++ b/src/frontend/src/fixtures/offlineBootstrap.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { CLICKDUMMY_SEED } from './deterministic';
+import { createOfflineBootstrapPayload, type OfflineBootstrapOptions } from './offlineBootstrap';
+
+const BASE_OPTIONS: OfflineBootstrapOptions = {
+  seed: CLICKDUMMY_SEED,
+  tickLengthMinutes: 60,
+  startDate: '2025-01-01T00:00:00.000Z',
+  isPaused: true,
+  targetTickRate: 1,
+};
+
+describe('createOfflineBootstrapPayload', () => {
+  it('produces identical payloads for repeated hydrations with the same seed', () => {
+    const first = createOfflineBootstrapPayload(BASE_OPTIONS);
+    const second = createOfflineBootstrapPayload(BASE_OPTIONS);
+
+    expect(second).toEqual(first);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `createOfflineBootstrapPayload` so offline fixtures can be rebuilt deterministically for tests and docs
- add `offlineBootstrap.test.ts` to assert repeated hydrations with the same seed stay byte-identical
- document the completed determinism verification step in the migration guide and changelog

## Testing
- pnpm --filter frontend lint
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d3cb9f49248325a1f78db37acb0512