### PR TITLE
Fix duplicate keys in event ticker

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
   useZoneStore,
   type NavigationView,
 } from '@/store';
+import { getSimulationEventKey } from '@/store/utils/events';
 import { formatInGameTime } from '@/store/utils/time';
 
 const EVENT_LEVEL_CLASS: Record<string, string> = {
@@ -620,11 +621,9 @@ const App = () => {
                       {tickerEvents.map((event, index) => {
                         const toneClass =
                           EVENT_LEVEL_CLASS[event.level ?? 'info'] ?? EVENT_LEVEL_CLASS.info;
+                        const eventKey = getSimulationEventKey(event) || `${index}`;
                         return (
-                          <li
-                            key={`${event.ts ?? index}-ticker`}
-                            className="flex items-center gap-2"
-                          >
+                          <li key={`${eventKey}-ticker`} className="flex items-center gap-2">
                             <span
                               className={`text-xs font-semibold uppercase tracking-wide ${toneClass}`}
                             >

--- a/src/frontend/src/store/utils/events.ts
+++ b/src/frontend/src/store/utils/events.ts
@@ -1,6 +1,6 @@
 import type { SimulationEvent } from '@/types/simulation';
 
-const eventKey = (event: SimulationEvent): string => {
+export const getSimulationEventKey = (event: SimulationEvent): string => {
   return [
     event.type,
     event.tick ?? 'na',
@@ -21,11 +21,11 @@ export const mergeEvents = (
     return existing;
   }
 
-  const seen = new Set(existing.map(eventKey));
+  const seen = new Set(existing.map(getSimulationEventKey));
   const merged = [...existing];
 
   for (const event of incoming) {
-    const key = eventKey(event);
+    const key = getSimulationEventKey(event);
     if (seen.has(key)) {
       continue;
     }


### PR DESCRIPTION
## Summary
- expose a helper to build stable simulation event keys
- render the dashboard ticker items with the shared helper to avoid duplicate React keys

## Testing
- pnpm --filter frontend lint
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68d3cf51d8f48325a9f0442a41c06f2a