### PR TITLE
Handle offline controls without socket warnings

### DIFF
--- a/src/frontend/src/store/gameStore.test.ts
+++ b/src/frontend/src/store/gameStore.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadStore = async () => {
+  const module = await import('./gameStore');
+  return module.useGameStore;
+};
+
+describe('gameStore command handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('updates timing metadata locally when issuing play/pause commands without a live transport', async () => {
+    const useGameStore = await loadStore();
+
+    useGameStore.setState(() => ({
+      hasLiveTransport: false,
+      timeStatus: {
+        running: false,
+        paused: true,
+        speed: 0,
+        tick: 12,
+        targetTickRate: 1,
+      },
+      lastClockSnapshot: {
+        tick: 12,
+        isPaused: true,
+        targetTickRate: 1,
+        startedAt: '2025-01-01T00:00:00Z',
+        lastUpdatedAt: '2025-01-01T00:00:00Z',
+      },
+    }));
+
+    useGameStore.getState().issueControlCommand({ action: 'play', gameSpeed: 3 });
+
+    let state = useGameStore.getState();
+    expect(state.timeStatus).toMatchObject({
+      running: true,
+      paused: false,
+      speed: 3,
+      targetTickRate: 3,
+    });
+    expect(state.lastClockSnapshot).toMatchObject({ isPaused: false, targetTickRate: 3 });
+
+    useGameStore.getState().issueControlCommand({ action: 'pause' });
+
+    state = useGameStore.getState();
+    expect(state.timeStatus).toMatchObject({ running: false, paused: true, speed: 0 });
+    expect(state.lastClockSnapshot).toMatchObject({ isPaused: true });
+  });
+
+  it('increments the tick locally when stepping without a live transport', async () => {
+    const useGameStore = await loadStore();
+
+    useGameStore.setState(() => ({
+      hasLiveTransport: false,
+      timeStatus: {
+        running: false,
+        paused: true,
+        speed: 0,
+        tick: 5,
+        targetTickRate: 1,
+      },
+      lastClockSnapshot: {
+        tick: 5,
+        isPaused: true,
+        targetTickRate: 1,
+        startedAt: '2025-01-01T00:00:00Z',
+        lastUpdatedAt: '2025-01-01T00:00:00Z',
+      },
+    }));
+
+    useGameStore.getState().issueControlCommand({ action: 'step', ticks: 2 });
+
+    const state = useGameStore.getState();
+    expect(state.timeStatus).toMatchObject({ tick: 7, paused: true, running: false, speed: 0 });
+    expect(state.lastClockSnapshot).toMatchObject({ tick: 7 });
+  });
+
+  it('forwards control commands when a live transport is available', async () => {
+    const useGameStore = await loadStore();
+    const sendControlCommand = vi.fn();
+
+    useGameStore.setState(() => ({
+      hasLiveTransport: true,
+      sendControlCommand,
+    }));
+
+    const command = { action: 'resume' as const };
+    useGameStore.getState().issueControlCommand(command);
+
+    expect(sendControlCommand).toHaveBeenCalledTimes(1);
+    expect(sendControlCommand).toHaveBeenCalledWith(command);
+  });
+
+  it('does not forward config updates when offline but still tracks the last requested tick length', async () => {
+    const useGameStore = await loadStore();
+    const sendConfigUpdate = vi.fn();
+
+    useGameStore.setState(() => ({
+      hasLiveTransport: false,
+      sendConfigUpdate,
+    }));
+
+    useGameStore.getState().requestTickLength(42);
+
+    const state = useGameStore.getState();
+    expect(state.lastRequestedTickLength).toBe(42);
+    expect(sendConfigUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/store/gameStore.ts
+++ b/src/frontend/src/store/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type {
   SimulationControlCommand,
   SimulationTickEvent,
+  SimulationTimeStatus,
   SimulationUpdateEntry,
 } from '@/types/simulation';
 import { mergeEvents } from './utils/events';
@@ -9,9 +10,109 @@ import type { GameStoreState } from './types';
 
 const MAX_EVENTS = 250;
 
+const createLocalTimeStatus = (state: GameStoreState): SimulationTimeStatus | undefined => {
+  if (state.timeStatus) {
+    return { ...state.timeStatus };
+  }
+
+  const clock = state.lastClockSnapshot;
+  if (!clock) {
+    return undefined;
+  }
+
+  return {
+    running: !clock.isPaused,
+    paused: clock.isPaused,
+    speed: clock.isPaused ? 0 : clock.targetTickRate,
+    tick: clock.tick,
+    targetTickRate: clock.targetTickRate,
+  } satisfies SimulationTimeStatus;
+};
+
+const applyLocalControlCommand = (
+  state: GameStoreState,
+  command: SimulationControlCommand,
+): Partial<GameStoreState> => {
+  const currentStatus = createLocalTimeStatus(state);
+  if (!currentStatus) {
+    return {};
+  }
+
+  let nextStatus: SimulationTimeStatus = { ...currentStatus };
+  const nextClock = state.lastClockSnapshot ? { ...state.lastClockSnapshot } : undefined;
+
+  switch (command.action) {
+    case 'play': {
+      const target = command.gameSpeed ?? currentStatus.targetTickRate ?? 1;
+      nextStatus = {
+        ...nextStatus,
+        running: true,
+        paused: false,
+        speed: target,
+        targetTickRate: target,
+      };
+      break;
+    }
+    case 'resume': {
+      nextStatus = {
+        ...nextStatus,
+        running: true,
+        paused: false,
+        speed: nextStatus.targetTickRate,
+      };
+      break;
+    }
+    case 'pause': {
+      nextStatus = {
+        ...nextStatus,
+        running: false,
+        paused: true,
+        speed: 0,
+      };
+      break;
+    }
+    case 'fastForward': {
+      const multiplier = Math.max(0, command.multiplier);
+      nextStatus = {
+        ...nextStatus,
+        running: true,
+        paused: false,
+        speed: multiplier,
+        targetTickRate: multiplier,
+      };
+      break;
+    }
+    case 'step': {
+      const increment = Number.isFinite(command.ticks) ? Math.max(1, command.ticks ?? 1) : 1;
+      nextStatus = {
+        ...nextStatus,
+        running: false,
+        paused: true,
+        speed: 0,
+        tick: Math.max(0, nextStatus.tick + increment),
+      };
+      break;
+    }
+    default:
+      return {};
+  }
+
+  if (nextClock) {
+    nextClock.isPaused = nextStatus.paused;
+    nextClock.targetTickRate = nextStatus.targetTickRate;
+    nextClock.tick = nextStatus.tick;
+  }
+
+  return {
+    timeStatus: nextStatus,
+    lastClockSnapshot: nextClock ?? state.lastClockSnapshot,
+  } satisfies Partial<GameStoreState>;
+};
+
 export const useGameStore = create<GameStoreState>()((set) => ({
   connectionStatus: 'idle',
   events: [],
+  hasLiveTransport: false,
   setConnectionStatus: (status, errorMessage) =>
     set((state) => ({
       connectionStatus: status,
@@ -40,14 +141,24 @@ export const useGameStore = create<GameStoreState>()((set) => ({
       sendControlCommand: control,
       sendConfigUpdate: config,
     })),
+  setTransportAvailability: (available: boolean) =>
+    set(() => ({
+      hasLiveTransport: available,
+    })),
   issueControlCommand: (command: SimulationControlCommand) =>
     set((state) => {
-      state.sendControlCommand?.(command);
-      return {};
+      if (state.hasLiveTransport) {
+        state.sendControlCommand?.(command);
+        return {};
+      }
+
+      return applyLocalControlCommand(state, command);
     }),
   requestTickLength: (minutes: number) =>
     set((state) => {
-      state.sendConfigUpdate?.({ type: 'tickLength', minutes });
+      if (state.hasLiveTransport) {
+        state.sendConfigUpdate?.({ type: 'tickLength', minutes });
+      }
       return { lastRequestedTickLength: minutes };
     }),
   reset: () =>
@@ -59,6 +170,7 @@ export const useGameStore = create<GameStoreState>()((set) => ({
       lastSnapshotTimestamp: undefined,
       lastClockSnapshot: undefined,
       lastRequestedTickLength: undefined,
+      hasLiveTransport: false,
     })),
   sendControlCommand: undefined,
   sendConfigUpdate: undefined,

--- a/src/frontend/src/store/selectors.test.ts
+++ b/src/frontend/src/store/selectors.test.ts
@@ -38,11 +38,13 @@ import type {
 const createGameState = (overrides: Partial<GameStoreState> = {}): GameStoreState => ({
   connectionStatus: 'idle',
   events: overrides.events ?? [],
+  hasLiveTransport: overrides.hasLiveTransport ?? false,
   setConnectionStatus: vi.fn(),
   ingestUpdate: vi.fn(),
   appendEvents: vi.fn(),
   registerTickCompleted: vi.fn(),
   setCommandHandlers: vi.fn(),
+  setTransportAvailability: vi.fn(),
   issueControlCommand: vi.fn(),
   requestTickLength: vi.fn(),
   reset: vi.fn(),

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -106,6 +106,7 @@ export interface GameStoreState {
   lastSnapshotTimestamp?: number;
   lastClockSnapshot?: SimulationSnapshot['clock'];
   lastRequestedTickLength?: number;
+  hasLiveTransport: boolean;
   sendControlCommand?: (command: SimulationControlCommand) => void;
   sendConfigUpdate?: (update: SimulationConfigUpdate) => void;
   setConnectionStatus: (status: ConnectionStatus, errorMessage?: string) => void;
@@ -116,6 +117,7 @@ export interface GameStoreState {
     control: (command: SimulationControlCommand) => void,
     config: (update: SimulationConfigUpdate) => void,
   ) => void;
+  setTransportAvailability: (available: boolean) => void;
   issueControlCommand: (command: SimulationControlCommand) => void;
   requestTickLength: (minutes: number) => void;
   reset: () => void;

--- a/src/frontend/src/store/utils/events.ts
+++ b/src/frontend/src/store/utils/events.ts
@@ -1,6 +1,6 @@
 import type { SimulationEvent } from '@/types/simulation';
 
-const eventKey = (event: SimulationEvent): string => {
+export const getSimulationEventKey = (event: SimulationEvent): string => {
   return [
     event.type,
     event.tick ?? 'na',
@@ -21,11 +21,11 @@ export const mergeEvents = (
     return existing;
   }
 
-  const seen = new Set(existing.map(eventKey));
+  const seen = new Set(existing.map(getSimulationEventKey));
   const merged = [...existing];
 
   for (const event of incoming) {
-    const key = eventKey(event);
+    const key = getSimulationEventKey(event);
     if (seen.has(key)) {
       continue;
     }


### PR DESCRIPTION
## Summary
- track live transport availability in the game store and simulate timing updates locally when no socket is connected
- disable dashboard playback controls for the offline fixture and surface a clearer footer message
- guard simulation bridge emissions until the socket is connected and add tests covering the offline control flow

## Testing
- pnpm --filter frontend lint
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d3cf51d8f48325a9f0442a41c06f2a