### PR TITLE
Add regression tests for ModalHost world intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Registrierte typisierte Modal-Descriptoren für Infrastruktur- und Detail-Workflows und implementierte dedizierte Modal-Inhalte unter `views/world/modals` bzw. `views/zone/modals`, gerendert über den aktualisierten `ModalHost`.
 - Modularisierte die deterministischen Clickdummy-Fixtures unter `src/frontend/src/fixtures` (inklusive `createClickDummyFixture`, Jobrollen- und Kostenkonstanten) zur Wiederverwendung in Offline-Bootstrap, Tests und künftigen Previews.
 - Ergänzte `createOfflineBootstrapPayload` samt Vitest-Absicherung (`offlineBootstrap.test.ts`), sodass wiederholte Hydrationen mit gleichem Seed identische Snapshots liefern und RNG-Tausch-Regressionen früh auffallen.
+- Added `ModalHost.test.tsx` regression coverage to drive the facility management modals and assert that the zone store dispatches the expected façade intents.
 
 ### Changed
 

--- a/docs/system/ui-components-desciption.md
+++ b/docs/system/ui-components-desciption.md
@@ -20,7 +20,7 @@ The backend façade groups all write operations behind intent domains (`time`, `
 
 ### World Domain (Structures, Rooms, Zones)
 
-- Active flows: rent/create/duplicate/delete/rename actions (`world.rentStructure`, `world.createRoom`, `world.createZone`, `world.duplicateStructure`, `world.duplicateRoom`, `world.duplicateZone`, `world.renameStructure`, `world.updateRoom`, `world.updateZone`, `world.deleteStructure`, `world.deleteRoom`, `world.deleteZone`) are surfaced through `ModalHost` dialogs. Each modal now invokes the matching `useZoneStore` intent helper which emits the façade command so the backend processes geometry, costing, and duplication rules deterministically.【F:src/backend/src/facade/index.ts†L1168-L1233】【F:src/frontend/src/components/ModalHost.tsx†L157-L318】【F:src/frontend/src/store/zoneStore.ts†L240-L338】
+- Active flows: rent/create/duplicate/delete/rename actions (`world.rentStructure`, `world.createRoom`, `world.createZone`, `world.duplicateStructure`, `world.duplicateRoom`, `world.duplicateZone`, `world.renameStructure`, `world.updateRoom`, `world.updateZone`, `world.deleteStructure`, `world.deleteRoom`, `world.deleteZone`) are surfaced through `ModalHost` dialogs. Each modal now invokes the matching `useZoneStore` intent helper which emits the façade command so the backend processes geometry, costing, and duplication rules deterministically, and the regression suite drives these flows through `ModalHost.test.tsx` to assert both the dispatched intent and modal teardown.【F:src/backend/src/facade/index.ts†L1168-L1233】【F:src/frontend/src/components/ModalHost.tsx†L157-L318】【F:src/frontend/src/store/zoneStore.ts†L240-L338】【F:src/frontend/src/components/ModalHost.test.tsx†L80-L262】
 
 - `CreateRoomModal`, `CreateZoneModal`, `RentStructureModal`, and `DuplicateStructureModal` dispatch `useZoneStore.createRoom`, `useZoneStore.createZone`, `useZoneStore.rentStructure`, and `useZoneStore.duplicateStructure` respectively, wiring the previously inert forms to façade intents.【F:src/frontend/src/views/world/modals/CreateRoomModal.tsx†L9-L114】【F:src/frontend/src/views/world/modals/CreateZoneModal.tsx†L9-L132】【F:src/frontend/src/views/world/modals/RentStructureModal.tsx†L1-L71】【F:src/frontend/src/views/world/modals/DuplicateStructureModal.tsx†L1-L108】
 
@@ -268,25 +268,25 @@ These components define the content for various modals used for user input and i
 
 - **Purpose:** Collects a room name, purpose, footprint area, and height before dispatching `world.createRoom`. Geometry limits are enforced in the UI and the sanitized payload is sent via `useZoneStore.createRoom` on submit.【F:src/frontend/src/views/world/modals/CreateRoomModal.tsx†L9-L114】【F:src/frontend/src/components/ModalHost.tsx†L175-L197】
 - **Props:** `structure`, `existingRooms`, `onSubmit`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Shown when the user adds a room from structure-level actions; the modal pauses the sim (via `ModalHost`) and resumes after the command is dispatched.
+- **Usage Context:** Shown when the user adds a room from structure-level actions; the modal pauses the sim (via `ModalHost`) and resumes after the command is dispatched. Regression coverage exercises the default confirm path via `ModalHost.test.tsx` to ensure the zone store receives the create-room intent and the dialog closes.【F:src/frontend/src/components/ModalHost.test.tsx†L103-L142】
 
 ### `CreateZoneModal.tsx`
 
 - **Purpose:** Allocates footprint within a room, selects a cultivation method, and relays the intent to `world.createZone` with the trimmed name, method UUID, and optional plant count.【F:src/frontend/src/views/world/modals/CreateZoneModal.tsx†L9-L145】【F:src/frontend/src/components/ModalHost.tsx†L198-L222】
 - **Props:** `room`, `existingZones`, `availableMethods?`, `onSubmit`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Launched from room-level actions when expanding a grow area.
+- **Usage Context:** Launched from room-level actions when expanding a grow area. The ModalHost regression test submits the default form state to verify the `createZone` intent wiring and modal dismissal.【F:src/frontend/src/components/ModalHost.test.tsx†L144-L184】
 
 ### `RentStructureModal.tsx`
 
 - **Purpose:** Confirms structure rental and provides a summary of footprint, rooms/zones, and rent per tick before emitting `world.rentStructure` through `useZoneStore`.
 - **Props:** `structure`, `rooms?`, `zones?`, `onConfirm`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Triggered from structure catalog cards; the confirm button sends the rent intent and closes the modal once acknowledged.【F:src/frontend/src/views/world/modals/RentStructureModal.tsx†L1-L71】【F:src/frontend/src/components/ModalHost.tsx†L223-L246】
+- **Usage Context:** Triggered from structure catalog cards; the confirm button sends the rent intent and closes the modal once acknowledged. Automated coverage in `ModalHost.test.tsx` clicks the confirm action to assert the rent intent and modal teardown paths.【F:src/frontend/src/views/world/modals/RentStructureModal.tsx†L1-L71】【F:src/frontend/src/components/ModalHost.tsx†L223-L246】【F:src/frontend/src/components/ModalHost.test.tsx†L186-L218】
 
 ### `DuplicateStructureModal.tsx`
 
 - **Purpose:** Allows renaming and reviewing totals (rooms, zones, area, device count) before cloning a structure via `world.duplicateStructure`.
 - **Props:** `structure`, `rooms`, `zones`, `onConfirm`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Available from structure actions; after submission the façade handles geometry/cost validation while the UI awaits confirmation.【F:src/frontend/src/views/world/modals/DuplicateStructureModal.tsx†L1-L108】【F:src/frontend/src/components/ModalHost.tsx†L247-L270】
+- **Usage Context:** Available from structure actions; after submission the façade handles geometry/cost validation while the UI awaits confirmation. The ModalHost regression suite submits the dialog with its default copy name to prove the duplicate-structure intent is dispatched and the modal closes.【F:src/frontend/src/views/world/modals/DuplicateStructureModal.tsx†L1-L108】【F:src/frontend/src/components/ModalHost.tsx†L247-L270】【F:src/frontend/src/components/ModalHost.test.tsx†L220-L262】
 
 ### `DuplicateRoomModal.tsx`
 

--- a/src/frontend/src/components/ModalHost.test.tsx
+++ b/src/frontend/src/components/ModalHost.test.tsx
@@ -1,0 +1,263 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppStoreState, ZoneStoreState } from '@/store';
+import type { RoomSnapshot, StructureSnapshot, ZoneSnapshot } from '@/types/simulation';
+
+const buildStructure = (overrides: Partial<StructureSnapshot> = {}): StructureSnapshot => ({
+  id: 'structure-1',
+  name: 'North Facility',
+  status: 'active',
+  footprint: { length: 30, width: 15, height: 6, area: 450, volume: 2700 },
+  rentPerTick: 1250,
+  roomIds: [],
+  ...overrides,
+});
+
+const buildRoom = (overrides: Partial<RoomSnapshot> = {}): RoomSnapshot => ({
+  id: 'room-1',
+  name: 'Propagation room',
+  structureId: 'structure-1',
+  structureName: 'North Facility',
+  purposeId: 'purpose:growroom',
+  purposeKind: 'growroom',
+  purposeName: 'Grow room',
+  purposeFlags: {},
+  area: 120,
+  height: 6,
+  volume: 720,
+  cleanliness: 0.92,
+  maintenanceLevel: 0.88,
+  zoneIds: [],
+  ...overrides,
+});
+
+const buildZone = (overrides: Partial<ZoneSnapshot> = {}): ZoneSnapshot => ({
+  id: 'zone-1',
+  name: 'Propagation bench',
+  structureId: 'structure-1',
+  structureName: 'North Facility',
+  roomId: 'room-1',
+  roomName: 'Propagation room',
+  area: 40,
+  ceilingHeight: 6,
+  volume: 240,
+  cultivationMethodId: 'method:sea-of-green',
+  environment: {
+    temperature: 24,
+    relativeHumidity: 0.62,
+    co2: 980,
+    ppfd: 540,
+    vpd: 1.2,
+  },
+  resources: {
+    waterLiters: 120,
+    nutrientSolutionLiters: 80,
+    nutrientStrength: 1,
+    substrateHealth: 0.9,
+    reservoirLevel: 0.7,
+    lastTranspirationLiters: 2,
+  },
+  metrics: {
+    averageTemperature: 24,
+    averageHumidity: 0.62,
+    averageCo2: 980,
+    averagePpfd: 540,
+    stressLevel: 0.1,
+    lastUpdatedTick: 42,
+  },
+  devices: [],
+  plants: [],
+  health: {
+    diseases: 0,
+    pests: 0,
+    pendingTreatments: 0,
+    appliedTreatments: 0,
+  },
+  ...overrides,
+});
+
+describe('ModalHost world management flows', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const loadModalHost = async () => {
+    const [componentModule, storeModule] = await Promise.all([
+      import('./ModalHost'),
+      import('@/store'),
+    ]);
+
+    return {
+      ModalHost: componentModule.default,
+      useAppStore: storeModule.useAppStore,
+      useZoneStore: storeModule.useZoneStore,
+    };
+  };
+
+  it('dispatches createRoom intent when the CreateRoomModal form submits', async () => {
+    const { ModalHost, useAppStore, useZoneStore } = await loadModalHost();
+    const structure = buildStructure();
+    const createRoom = vi.fn<ZoneStoreState['createRoom']>();
+    const closeModal = vi.fn<AppStoreState['closeModal']>();
+
+    act(() => {
+      useZoneStore.setState({
+        structures: { [structure.id]: structure },
+        rooms: {},
+        zones: {},
+        plants: {},
+        createRoom,
+      });
+      useAppStore.setState({
+        activeModal: {
+          kind: 'createRoom',
+          title: 'Add room',
+          payload: { structureId: structure.id },
+        },
+        closeModal,
+      });
+    });
+
+    render(<ModalHost />);
+
+    const submitButton = screen.getByRole('button', { name: 'Create room' });
+
+    fireEvent.click(submitButton);
+
+    expect(createRoom).toHaveBeenCalledTimes(1);
+    const [structureId, options] = createRoom.mock.calls[0];
+    expect(structureId).toBe(structure.id);
+    expect(options).toMatchObject({
+      name: expect.any(String),
+      purposeId: expect.any(String),
+      area: expect.any(Number),
+    });
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches createZone intent when confirming the CreateZoneModal', async () => {
+    const { ModalHost, useAppStore, useZoneStore } = await loadModalHost();
+    const structure = buildStructure();
+    const room = buildRoom();
+    const createZone = vi.fn<ZoneStoreState['createZone']>();
+    const closeModal = vi.fn<AppStoreState['closeModal']>();
+
+    act(() => {
+      useZoneStore.setState({
+        structures: { [structure.id]: structure },
+        rooms: { [room.id]: room },
+        zones: {},
+        plants: {},
+        createZone,
+      });
+      useAppStore.setState({
+        activeModal: {
+          kind: 'createZone',
+          title: 'Add zone',
+          payload: { roomId: room.id },
+        },
+        closeModal,
+      });
+    });
+
+    render(<ModalHost />);
+
+    const submitButton = screen.getByRole('button', { name: 'Create zone' });
+
+    fireEvent.click(submitButton);
+
+    expect(createZone).toHaveBeenCalledTimes(1);
+    const [roomId, options] = createZone.mock.calls[0];
+    expect(roomId).toBe(room.id);
+    expect(options).toMatchObject({
+      name: expect.any(String),
+      area: expect.any(Number),
+    });
+    expect(options.methodId).toBeDefined();
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes rentStructure when confirming the RentStructureModal', async () => {
+    const { ModalHost, useAppStore, useZoneStore } = await loadModalHost();
+    const structure = buildStructure();
+    const rooms = [buildRoom({ id: 'room-2', name: 'Drying room' })];
+    const rentStructure = vi.fn<ZoneStoreState['rentStructure']>();
+    const closeModal = vi.fn<AppStoreState['closeModal']>();
+
+    act(() => {
+      useZoneStore.setState({
+        structures: { [structure.id]: { ...structure, roomIds: rooms.map((room) => room.id) } },
+        rooms: Object.fromEntries(rooms.map((room) => [room.id, room])),
+        zones: {},
+        plants: {},
+        rentStructure,
+      });
+      useAppStore.setState({
+        activeModal: {
+          kind: 'rentStructure',
+          title: 'Rent facility',
+          payload: { structureId: structure.id },
+        },
+        closeModal,
+      });
+    });
+
+    render(<ModalHost />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rent structure' }));
+
+    expect(rentStructure).toHaveBeenCalledTimes(1);
+    expect(rentStructure).toHaveBeenCalledWith(structure.id);
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches duplicateStructure with the default name when submitted', async () => {
+    const { ModalHost, useAppStore, useZoneStore } = await loadModalHost();
+    const structure = buildStructure();
+    const rooms = [buildRoom({ id: 'room-10', name: 'Flower room', zoneIds: ['zone-10'] })];
+    const zones = [
+      buildZone({
+        id: 'zone-10',
+        name: 'Flower bench',
+        structureId: structure.id,
+        roomId: rooms[0].id,
+      }),
+    ];
+    const duplicateStructure = vi.fn<ZoneStoreState['duplicateStructure']>();
+    const closeModal = vi.fn<AppStoreState['closeModal']>();
+
+    act(() => {
+      useZoneStore.setState({
+        structures: { [structure.id]: { ...structure, roomIds: rooms.map((room) => room.id) } },
+        rooms: Object.fromEntries(rooms.map((room) => [room.id, room])),
+        zones: Object.fromEntries(zones.map((zone) => [zone.id, zone])),
+        plants: {},
+        duplicateStructure,
+      });
+      useAppStore.setState({
+        activeModal: {
+          kind: 'duplicateStructure',
+          title: 'Duplicate structure',
+          payload: { structureId: structure.id },
+        },
+        closeModal,
+      });
+    });
+
+    render(<ModalHost />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate structure' }));
+
+    expect(duplicateStructure).toHaveBeenCalledTimes(1);
+    const [structureId, options] = duplicateStructure.mock.calls[0];
+    expect(structureId).toBe(structure.id);
+    expect(options).toEqual({ name: `${structure.name} copy` });
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest suite for ModalHost that covers the create room/zone, rent structure, and duplicate structure flows
- document the new regression coverage in the UI component description and changelog

## Testing
- pnpm --filter frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d3f79585d083258fbb37de1867e257