### PR TITLE
feat(ui): wire device lifecycle commands

### DIFF
--- a/docs/ui/ui_interactions_spec.md
+++ b/docs/ui/ui_interactions_spec.md
@@ -126,7 +126,7 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 - **RentModal** → `facade.world.rentStructure({ structureId })`.
 - **AddRoomModal** → `facade.world.createRoom({ structureId, room: { name, purpose, area, height? } })`.
 - **AddZoneModal** → `facade.world.createZone({ roomId, zone: { name, area, methodId, targetPlantCount? } })`.
-- **AddDeviceModal** → `facade.devices.installDevice({ targetId, deviceId, settings })` (enforces `allowedRoomPurposes`).
+- **InstallDeviceModal** → `facade.devices.installDevice({ targetId, deviceId, settings })` (enforces `allowedRoomPurposes`).
 - **AddSupplyModal** → `facade.plants.applyIrrigation({ zoneId, liters })` / `facade.plants.applyFertilizer({ zoneId, nutrients })`.
 - **PlantStrainModal** → `facade.plants.addPlanting({ zoneId, strainId, count })`.
 - **BreedStrainModal** → select two parent strains by **UUID `id`** to create a new strain (lineage stores parent UUIDs; empty parents ⇒ ur‑plant).
@@ -135,7 +135,9 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 
 - **RenameModal** → `facade.world.renameStructure({ structureId, name })` or equivalent room/zone updates.
 - **DeleteModal** → generic delete (contextual warnings, e.g., severance on firing employees).
-- **EditDeviceModal** → batch adjust device settings via `facade.devices.updateDevice({ instanceId, settings })`.
+- **UpdateDeviceModal** → batch adjust device settings via `facade.devices.updateDevice({ instanceId, settings })`.
+- **MoveDeviceModal** → relocate an instance with `facade.devices.moveDevice({ instanceId, targetZoneId })` while the façade validates placement rules.
+- **Device removal confirmation** → reuse `ConfirmDeletionModal` to emit `facade.devices.removeDevice({ instanceId })`.
 - **EditLightCycleModal** → zone light hours; UI does not compute growth—engine does.
 - **PlantingPlanModal** → define automation plan (strain/quantity, **Auto‑Replant** toggle) with `facade.plants.togglePlantingPlan({ zoneId, enabled })`.
 

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -171,6 +171,14 @@ export interface ZoneStoreState {
   applyWater: (zoneId: string, liters: number) => void;
   applyNutrients: (zoneId: string, nutrients: { N: number; P: number; K: number }) => void;
   toggleDeviceGroup: (zoneId: string, deviceKind: string, enabled: boolean) => void;
+  installDevice: (
+    zoneId: string,
+    deviceId: string,
+    options?: { settings?: Record<string, unknown> },
+  ) => void;
+  updateDevice: (deviceId: string, settings: Record<string, unknown>) => void;
+  moveDevice: (deviceId: string, targetZoneId: string) => void;
+  removeDevice: (deviceId: string) => void;
   harvestPlanting: (plantingId: string) => void;
   harvestPlantings: (plantingIds: string[]) => void;
   togglePlantingPlan: (zoneId: string, enabled: boolean) => void;
@@ -264,6 +272,14 @@ export type DeleteZoneModalDescriptor = ModalDescriptorBase<'deleteZone', { zone
 
 export type PlantDetailModalDescriptor = ModalDescriptorBase<'plantDetails', { plantId: string }>;
 
+export type InstallDeviceModalDescriptor = ModalDescriptorBase<'installDevice', { zoneId: string }>;
+
+export type UpdateDeviceModalDescriptor = ModalDescriptorBase<'updateDevice', { deviceId: string }>;
+
+export type MoveDeviceModalDescriptor = ModalDescriptorBase<'moveDevice', { deviceId: string }>;
+
+export type RemoveDeviceModalDescriptor = ModalDescriptorBase<'removeDevice', { deviceId: string }>;
+
 export type ModalDescriptor =
   | HireEmployeeModalDescriptor
   | FireEmployeeModalDescriptor
@@ -279,7 +295,11 @@ export type ModalDescriptor =
   | DeleteStructureModalDescriptor
   | DeleteRoomModalDescriptor
   | DeleteZoneModalDescriptor
-  | PlantDetailModalDescriptor;
+  | PlantDetailModalDescriptor
+  | InstallDeviceModalDescriptor
+  | UpdateDeviceModalDescriptor
+  | MoveDeviceModalDescriptor
+  | RemoveDeviceModalDescriptor;
 
 export type ModalKind = ModalDescriptor['kind'];
 

--- a/src/frontend/src/store/zoneStore.ts
+++ b/src/frontend/src/store/zoneStore.ts
@@ -499,6 +499,69 @@ export const useZoneStore = create<ZoneStoreState>()((set) => ({
       });
       return {};
     }),
+  installDevice: (zoneId, deviceId, options) =>
+    set((state) => {
+      const trimmedDeviceId = deviceId.trim();
+      if (!zoneId || !trimmedDeviceId) {
+        return {};
+      }
+
+      const payload: Record<string, unknown> = {
+        targetId: zoneId,
+        deviceId: trimmedDeviceId,
+      };
+
+      const settings = options?.settings;
+      if (settings && Object.keys(settings).length > 0) {
+        payload.settings = settings;
+      }
+
+      state.sendFacadeIntent?.({
+        domain: 'devices',
+        action: 'installDevice',
+        payload,
+      });
+      return {};
+    }),
+  updateDevice: (deviceId, settings) =>
+    set((state) => {
+      if (!deviceId || !settings || Object.keys(settings).length === 0) {
+        return {};
+      }
+
+      state.sendFacadeIntent?.({
+        domain: 'devices',
+        action: 'updateDevice',
+        payload: { instanceId: deviceId, settings },
+      });
+      return {};
+    }),
+  moveDevice: (deviceId, targetZoneId) =>
+    set((state) => {
+      if (!deviceId || !targetZoneId) {
+        return {};
+      }
+
+      state.sendFacadeIntent?.({
+        domain: 'devices',
+        action: 'moveDevice',
+        payload: { instanceId: deviceId, targetZoneId },
+      });
+      return {};
+    }),
+  removeDevice: (deviceId) =>
+    set((state) => {
+      if (!deviceId) {
+        return {};
+      }
+
+      state.sendFacadeIntent?.({
+        domain: 'devices',
+        action: 'removeDevice',
+        payload: { instanceId: deviceId },
+      });
+      return {};
+    }),
   harvestPlanting: (plantingId) =>
     set((state) => {
       state.sendFacadeIntent?.({

--- a/src/frontend/src/views/ZoneDetail.tsx
+++ b/src/frontend/src/views/ZoneDetail.tsx
@@ -134,6 +134,7 @@ const ZoneDetail = () => {
   const selectedZoneId = useAppStore((state) => state.selectedZoneId);
   const selectRoom = useAppStore((state) => state.selectRoom);
   const selectZone = useAppStore((state) => state.selectZone);
+  const openModal = useAppStore((state) => state.openModal);
   const currentTick = useGameStore(selectCurrentTick);
 
   const timeline = useZoneStore((state) => state.timeline);
@@ -1016,7 +1017,27 @@ const ZoneDetail = () => {
               )}
             </Panel>
 
-            <Panel title="Device inventory" padding="lg" variant="elevated">
+            <Panel
+              title="Device inventory"
+              padding="lg"
+              variant="elevated"
+              action={
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    openModal({
+                      kind: 'installDevice',
+                      title: `Install device in ${zone.name}`,
+                      description:
+                        'Select a device blueprint and optional settings to dispatch through the simulation facade.',
+                      payload: { zoneId: zone.id },
+                    })
+                  }
+                >
+                  Install device
+                </Button>
+              }
+            >
               {zone.devices.length === 0 ? (
                 <p className="text-sm text-text-muted">No devices assigned to this zone.</p>
               ) : (
@@ -1102,6 +1123,54 @@ const ZoneDetail = () => {
                             ))}
                           </div>
                         ) : null}
+                        <div className="flex flex-wrap gap-2 pt-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              openModal({
+                                kind: 'updateDevice',
+                                title: `Adjust ${device.name}`,
+                                description:
+                                  'Provide a JSON patch to tweak runtime settings. The facade validates ranges before applying.',
+                                payload: { deviceId: device.id },
+                              })
+                            }
+                          >
+                            Adjust settings
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              openModal({
+                                kind: 'moveDevice',
+                                title: `Move ${device.name}`,
+                                description:
+                                  'Select a destination zone. Placement rules and room purposes are validated by the facade.',
+                                payload: { deviceId: device.id },
+                              })
+                            }
+                          >
+                            Move
+                          </Button>
+                          <Button
+                            variant="outline"
+                            tone="danger"
+                            size="sm"
+                            onClick={() =>
+                              openModal({
+                                kind: 'removeDevice',
+                                title: `Remove ${device.name}?`,
+                                description:
+                                  'Detach the device from this zone. Automation groups and inventory are reconciled by the facade.',
+                                payload: { deviceId: device.id },
+                              })
+                            }
+                          >
+                            Remove
+                          </Button>
+                        </div>
                       </li>
                     );
                   })}

--- a/src/frontend/src/views/zone/modals/InstallDeviceModal.tsx
+++ b/src/frontend/src/views/zone/modals/InstallDeviceModal.tsx
@@ -1,0 +1,179 @@
+import { FormEvent, useId, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import { TextInput } from '@/components/inputs';
+import type { ZoneSnapshot } from '@/types/simulation';
+
+type DeviceBlueprintOption = {
+  id: string;
+  label?: string;
+  kind?: string;
+};
+
+type InstallDeviceModalProps = {
+  zone: ZoneSnapshot;
+  blueprintOptions?: DeviceBlueprintOption[];
+  onSubmit: (options: { deviceId: string; settings?: Record<string, unknown> }) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const baseTextareaClass =
+  'min-h-[120px] w-full rounded-md border border-border/60 bg-surface p-3 font-mono text-sm text-text-primary shadow-inner focus:outline-none focus:ring-1 focus:ring-accent/60';
+
+const InstallDeviceModal = ({
+  zone,
+  blueprintOptions,
+  onSubmit,
+  onCancel,
+  title,
+  description,
+}: InstallDeviceModalProps) => {
+  const suggestions = useMemo(() => {
+    if (!blueprintOptions?.length) {
+      return [] as DeviceBlueprintOption[];
+    }
+    const seen = new Set<string>();
+    const entries: DeviceBlueprintOption[] = [];
+    for (const option of blueprintOptions) {
+      if (!option.id || seen.has(option.id)) {
+        continue;
+      }
+      seen.add(option.id);
+      entries.push(option);
+    }
+    return entries;
+  }, [blueprintOptions]);
+
+  const [deviceId, setDeviceId] = useState(() => suggestions[0]?.id ?? '');
+  const [settingsText, setSettingsText] = useState('');
+  const [settingsError, setSettingsError] = useState<string | undefined>();
+
+  const datalistId = useId();
+
+  const isDeviceIdValid = deviceId.trim().length > 0;
+
+  const parseSettings = () => {
+    const trimmed = settingsText.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setSettingsError('Settings must be provided as a JSON object.');
+        return undefined;
+      }
+      setSettingsError(undefined);
+      return parsed as Record<string, unknown>;
+    } catch (error) {
+      console.error('Failed to parse device settings', error);
+      setSettingsError('Settings must be valid JSON.');
+      return undefined;
+    }
+  };
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!isDeviceIdValid) {
+      return;
+    }
+    const parsedSettings = parseSettings();
+    if (settingsText.trim() && !parsedSettings) {
+      return;
+    }
+    onSubmit({
+      deviceId: deviceId.trim(),
+      settings: parsedSettings,
+    });
+  };
+
+  return (
+    <Modal
+      isOpen
+      size="lg"
+      title={title ?? `Install device in ${zone.name}`}
+      description={
+        description ??
+        'Select a device blueprint to dispatch an installation request. The simulation facade validates placement rules ' +
+          'for the chosen zone.'
+      }
+      onClose={onCancel}
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Install device',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !isDeviceIdValid,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField
+          label="Device blueprint"
+          secondaryLabel={deviceId.trim() || undefined}
+          description="Provide the blueprint identifier to install. Suggestions are populated from devices already known in the snapshot."
+        >
+          <TextInput
+            value={deviceId}
+            onChange={(event) => setDeviceId(event.target.value)}
+            placeholder="device:lighting:sunstream-pro-led"
+            list={suggestions.length ? datalistId : undefined}
+            autoFocus
+          />
+          {suggestions.length ? (
+            <datalist id={datalistId}>
+              {suggestions.map((option) => (
+                <option
+                  key={option.id}
+                  value={option.id}
+                  label={option.label ?? (option.kind ? `${option.kind}` : undefined)}
+                />
+              ))}
+            </datalist>
+          ) : null}
+        </FormField>
+
+        <FormField
+          label="Settings (JSON)"
+          description="Optional override payload. Leave empty to use blueprint defaults."
+        >
+          <textarea
+            className={[
+              baseTextareaClass,
+              settingsError ? 'border-danger focus:ring-danger/40' : undefined,
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            value={settingsText}
+            onChange={(event) => {
+              setSettingsText(event.target.value);
+              if (settingsError) {
+                setSettingsError(undefined);
+              }
+            }}
+            placeholder={'{ "power": 0.8, "ppfd": 550 }'}
+          />
+          {settingsError ? <p className="text-xs text-danger">{settingsError}</p> : null}
+        </FormField>
+
+        <p className="text-xs text-text-muted">
+          The request forwards to <code>facade.devices.installDevice</code> with the provided
+          blueprint identifier and optional settings.
+        </p>
+      </form>
+    </Modal>
+  );
+};
+
+export type { DeviceBlueprintOption, InstallDeviceModalProps };
+export default InstallDeviceModal;

--- a/src/frontend/src/views/zone/modals/MoveDeviceModal.tsx
+++ b/src/frontend/src/views/zone/modals/MoveDeviceModal.tsx
@@ -1,0 +1,127 @@
+import { FormEvent, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import { Select, TextInput } from '@/components/inputs';
+import type { DeviceSnapshot, ZoneSnapshot } from '@/types/simulation';
+
+type ZoneOption = {
+  id: string;
+  name: string;
+  roomName?: string;
+  structureName?: string;
+};
+
+type MoveDeviceModalProps = {
+  device: DeviceSnapshot;
+  currentZone: ZoneSnapshot;
+  availableZones: ZoneOption[];
+  onSubmit: (targetZoneId: string) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const MoveDeviceModal = ({
+  device,
+  currentZone,
+  availableZones,
+  onSubmit,
+  onCancel,
+  title,
+  description,
+}: MoveDeviceModalProps) => {
+  const orderedZones = useMemo(() => {
+    return availableZones
+      .filter((zone) => zone.id !== currentZone.id)
+      .sort((a, b) => {
+        const structureCompare = (a.structureName ?? '').localeCompare(b.structureName ?? '');
+        if (structureCompare !== 0) {
+          return structureCompare;
+        }
+        const roomCompare = (a.roomName ?? '').localeCompare(b.roomName ?? '');
+        if (roomCompare !== 0) {
+          return roomCompare;
+        }
+        return a.name.localeCompare(b.name);
+      });
+  }, [availableZones, currentZone.id]);
+
+  const [targetZoneId, setTargetZoneId] = useState(() => orderedZones[0]?.id ?? '');
+
+  const hasTargets = orderedZones.length > 0;
+  const canSubmit = hasTargets && targetZoneId && targetZoneId !== currentZone.id;
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!canSubmit) {
+      return;
+    }
+    onSubmit(targetZoneId);
+  };
+
+  return (
+    <Modal
+      isOpen
+      size="lg"
+      title={title ?? `Relocate ${device.name}`}
+      description={
+        description ??
+        'Select the destination zone for this device. The facade validates coverage constraints and allowed room purposes.'
+      }
+      onClose={onCancel}
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Move device',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+          disabled: !canSubmit,
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="Current zone" secondaryLabel={currentZone.id}>
+          <TextInput value={currentZone.name} readOnly />
+        </FormField>
+
+        <FormField
+          label="Target zone"
+          description={
+            hasTargets
+              ? 'Eligible zones are listed alphabetically by structure and room.'
+              : 'No other eligible zones are currently available for this device.'
+          }
+        >
+          <Select
+            value={targetZoneId}
+            onChange={(event) => setTargetZoneId(event.target.value)}
+            disabled={!hasTargets}
+          >
+            {orderedZones.map((zone) => {
+              const labelParts = [zone.structureName, zone.roomName, zone.name].filter(Boolean);
+              return (
+                <option key={zone.id} value={zone.id}>
+                  {labelParts.join(' • ')}
+                </option>
+              );
+            })}
+          </Select>
+        </FormField>
+
+        <p className="text-xs text-text-muted">
+          The command forwards to <code>facade.devices.moveDevice</code> with the selected target
+          zone. Placement failures are surfaced via the domain event stream.
+        </p>
+      </form>
+    </Modal>
+  );
+};
+
+export type { MoveDeviceModalProps, ZoneOption };
+export default MoveDeviceModal;

--- a/src/frontend/src/views/zone/modals/UpdateDeviceModal.tsx
+++ b/src/frontend/src/views/zone/modals/UpdateDeviceModal.tsx
@@ -1,0 +1,138 @@
+import { FormEvent, useMemo, useState } from 'react';
+import Modal from '@/components/Modal';
+import FormField from '@/components/forms/FormField';
+import { TextInput } from '@/components/inputs';
+import type { DeviceSnapshot } from '@/types/simulation';
+
+type UpdateDeviceModalProps = {
+  device: DeviceSnapshot;
+  onSubmit: (settings: Record<string, unknown>) => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+};
+
+const baseTextareaClass =
+  'min-h-[140px] w-full rounded-md border border-border/60 bg-surface p-3 font-mono text-sm text-text-primary shadow-inner focus:outline-none focus:ring-1 focus:ring-accent/60';
+
+const UpdateDeviceModal = ({
+  device,
+  onSubmit,
+  onCancel,
+  title,
+  description,
+}: UpdateDeviceModalProps) => {
+  const initialText = useMemo(() => {
+    if (device.settings && Object.keys(device.settings).length > 0) {
+      try {
+        return JSON.stringify(device.settings, null, 2);
+      } catch (error) {
+        console.warn('Failed to stringify device settings for modal bootstrap', error);
+      }
+    }
+    return '';
+  }, [device.settings]);
+
+  const [settingsText, setSettingsText] = useState(initialText);
+  const [settingsError, setSettingsError] = useState<string | undefined>();
+
+  const parseSettings = () => {
+    const trimmed = settingsText.trim();
+    if (!trimmed) {
+      setSettingsError('Provide at least one key to update.');
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setSettingsError('Settings patch must be a JSON object.');
+        return undefined;
+      }
+      if (Object.keys(parsed).length === 0) {
+        setSettingsError('Provide at least one setting to update.');
+        return undefined;
+      }
+      setSettingsError(undefined);
+      return parsed as Record<string, unknown>;
+    } catch (error) {
+      console.error('Failed to parse device settings patch', error);
+      setSettingsError('Settings must be valid JSON.');
+      return undefined;
+    }
+  };
+
+  const handleSubmit = (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    const parsedSettings = parseSettings();
+    if (!parsedSettings) {
+      return;
+    }
+    onSubmit(parsedSettings);
+  };
+
+  return (
+    <Modal
+      isOpen
+      size="lg"
+      title={title ?? `Update ${device.name}`}
+      description={
+        description ??
+        'Provide a JSON patch for the device configuration. Keys left out remain unchanged; the facade validates numeric ranges and compatibility.'
+      }
+      onClose={onCancel}
+      actions={[
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'secondary',
+        },
+        {
+          label: 'Apply changes',
+          onClick: () => handleSubmit(),
+          variant: 'primary',
+        },
+      ]}
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <FormField label="Device instance" secondaryLabel={device.id}>
+          <TextInput value={device.name} readOnly />
+        </FormField>
+
+        <FormField
+          label="Settings patch (JSON)"
+          description="Only the provided keys are forwarded to facade.devices.updateDevice."
+        >
+          <textarea
+            className={[
+              baseTextareaClass,
+              settingsError ? 'border-danger focus:ring-danger/40' : undefined,
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            value={settingsText}
+            onChange={(event) => {
+              setSettingsText(event.target.value);
+              if (settingsError) {
+                setSettingsError(undefined);
+              }
+            }}
+            placeholder={'{ "power": 0.75 }'}
+          />
+          {settingsError ? <p className="text-xs text-danger">{settingsError}</p> : null}
+        </FormField>
+
+        <p className="text-xs text-text-muted">
+          The command targets <code>facade.devices.updateDevice</code> with{' '}
+          <code>{'{ instanceId, settings }'}</code>. Validation errors are surfaced by the facade
+          and shown in the event log.
+        </p>
+      </form>
+    </Modal>
+  );
+};
+
+export type { UpdateDeviceModalProps };
+export default UpdateDeviceModal;


### PR DESCRIPTION
## Summary
- add device installation, update, move, and removal actions to the zone detail inventory and route them through ModalHost/store helpers
- introduce dedicated InstallDeviceModal, UpdateDeviceModal, and MoveDeviceModal components for collecting façade intent payloads
- document the new UI flows in the device domain sections of the UI component description and interaction spec

## Testing
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d4143307a08325abb82e64edfc0d09