### PR TITLE
Fix difficulty presets loading in new game view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **New Game Difficulty Presets**: Restored automatic loading of backend
+  difficulty presets in the New Game setup flow by deferring the fetch until
+  the Socket.IO bridge reports an active connection, so presets appear without
+  manual retries once the UI connects to the server.
 - **Game Menu Reset Session Button**: Implemented functionality for the "Reset Session" button in the game menu modal, which previously did nothing. The button now properly stops the simulation (if running) and returns the user to the start screen, clearing the current session state and allowing them to start fresh or load a different game.
 - **Finance View Data Access**: Corrected data access in FinanceView to use `snapshot.finance` instead of `snapshot.finances` to properly display financial data
 - **ExpenseBreakdown Component**: Simplified ExpenseBreakdown to work with available snapshot data instead of relying on detailed ledger entries not present in frontend


### PR DESCRIPTION
## Summary
- wait for an active Socket.IO connection before requesting the difficulty configuration so the presets hydrate reliably in the New Game UI
- track connection status transitions to retry once after reconnects while avoiding duplicate fetches
- document the fix in the changelog

## Testing
- pnpm run check *(fails: backend tests require packaged data directory and device schema expectations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62df7966483258eb8f7b2b5399b87