### PR TITLE
Document difficulty preset facade event mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Alliteration Support**: Optional alliteration preference with soft upweighting for cohesive naming
   - **Quality Constraints**: Length limits, score thresholds, and blacklist enforcement for consistent output
 
+- **Difficulty Presets Facade Investigation**: Documented how `config.getDifficultyConfig` travels from `difficulty.json` through the backend facade to the frontend socket bridge, and identified the socket channel mismatch (`config.intent.result` vs. `facade.intent.result`) that prevents the UI from receiving the presets.
+
 ### Fixed
 
 - **New Game Difficulty Presets**: Restored automatic loading of backend

--- a/docs/tasks/difficulty-presets-analysis.md
+++ b/docs/tasks/difficulty-presets-analysis.md
@@ -1,0 +1,46 @@
+# Difficulty Presets Facade Investigation
+
+## Overview
+
+Difficulty presets are defined in `data/configs/difficulty.json`. The backend loads this file during server startup via `loadDifficultyConfig` and exposes it through the simulation facade's config service. The frontend requests the presets via the socket bridge using the `config.getDifficultyConfig` intent.
+
+## Data Flow
+
+1. **Static configuration** – The preset values live in `data/configs/difficulty.json` and match the Zod schema enforced by `loadDifficultyConfig` in `src/backend/src/data/configs/difficulty.ts`.
+2. **Server bootstrap** – `startServer` loads the configuration and wires `facade.updateServices({ config: { getDifficultyConfig: () => ({ ok: true, data: difficultyConfig }) } })`, making the presets available to the facade's `config` domain (`src/backend/src/server/startServer.ts`).
+3. **Facade command** – `SimulationFacade` registers the `config.getDifficultyConfig` intent and exposes it through the socket gateway (`src/backend/src/facade/index.ts`).
+4. **Socket request** – The frontend bridge calls `sendIntent` with `{ domain: 'config', action: 'getDifficultyConfig' }` via `SocketSystemFacade.getDifficultyConfig` (`src/frontend/src/facade/systemFacade.ts`).
+
+## Observed Problem
+
+When the gateway handles a `facade.intent` payload, it resolves the command and emits the response on a **domain-specific channel**:
+
+```ts
+this.emitCommandResponse(
+  socket,
+  `${command.domain}.intent.result`,
+  {
+    requestId,
+    ...result,
+  },
+  ack,
+);
+```
+
+_Source: `src/backend/src/server/socketGateway.ts`_
+
+However, the frontend bridge only subscribes to the **generic** `facade.intent.result` channel and uses it (together with the ack handler) to settle pending promises:
+
+```ts
+socket.on('facade.intent.result', (response) => {
+  this.resolvePending('facade.intent.result', response);
+});
+```
+
+_Source: `src/frontend/src/facade/systemFacade.ts`_
+
+Because the broadcast is published as `config.intent.result`, the listener never fires. The ack callback also guards on the same channel name via `resolvePending`, so a response that lacks the matching channel will leave the `getDifficultyConfig` request unresolved. In practice the hook keeps waiting, and the Difficulty Presets panel remains in the loading state.
+
+## Conclusion
+
+The backend and frontend disagree on the socket channel for facade intent responses. Align the channel names (either emit `facade.intent.result` on the backend or listen for domain-specific channels on the frontend) so that the difficulty configuration response reaches the UI.


### PR DESCRIPTION
## Summary
- add a task note that follows the difficulty preset data from difficulty.json through the backend facade to the frontend socket bridge
- highlight the socket channel mismatch (config.intent.result vs. facade.intent.result) that stops the presets from reaching the UI
- record the investigation in the changelog under the Added section

## Testing
- pnpm exec prettier --write docs/tasks/difficulty-presets-analysis.md CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68d6401edcfc8325811754838d94650c