### PR TITLE
Fix facade intent socket channel mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   difficulty presets in the New Game setup flow by deferring the fetch until
   the Socket.IO bridge reports an active connection, so presets appear without
   manual retries once the UI connects to the server.
+- **Facade intent channel alignment**: Socket gateway now emits all facade
+  intent responses on the shared `facade.intent.result` channel expected by the
+  frontend bridge, ensuring difficulty presets and other facade intents resolve
+  correctly.
 - **Facade difficulty config intent**: Fixed `config.getDifficultyConfig`
   responses being rejected because the request metadata leaked into the intent
   payload validation. The backend now strips the transport `requestId` before

--- a/src/backend/src/server/socketGateway.ts
+++ b/src/backend/src/server/socketGateway.ts
@@ -409,7 +409,7 @@ export class SocketGateway {
 
     this.emitCommandResponse(
       socket,
-      `${command.domain}.intent.result`,
+      'facade.intent.result',
       {
         requestId,
         ...result,


### PR DESCRIPTION
## Summary
- align the socket gateway facade intent response channel with the frontend listener
- document the fix in the changelog

## Testing
- pnpm run check *(fails: @weebbreed/frontend lint currently failing in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68d6452e7f68832581667a1584f32990