### PR TITLE
Fix difficulty config hook mounting behaviour

### DIFF
--- a/src/frontend/src/hooks/useDifficultyConfig.test.tsx
+++ b/src/frontend/src/hooks/useDifficultyConfig.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import type { DifficultyConfig } from '@/types/difficulty';
+
+describe('useDifficultyConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  const setup = async (getDifficultyConfigMock: ReturnType<typeof vi.fn>) => {
+    vi.doMock('@/facade/systemFacade', () => ({
+      getSimulationBridge: () => ({
+        getDifficultyConfig: getDifficultyConfigMock,
+      }),
+    }));
+
+    const { useSimulationStore } = await import('@/store/simulation');
+    useSimulationStore.getState().reset();
+
+    const hookModule = await import('./useDifficultyConfig');
+
+    return {
+      useDifficultyConfig: hookModule.useDifficultyConfig,
+      useSimulationStore,
+    };
+  };
+
+  it('loads the difficulty presets once the connection is established', async () => {
+    const mockConfig: DifficultyConfig = {
+      easy: {
+        name: 'easy',
+        description: 'Chill run',
+        modifiers: {
+          plantStress: {
+            optimalRangeMultiplier: 1,
+            stressAccumulationMultiplier: 0.5,
+          },
+          deviceFailure: {
+            mtbfMultiplier: 2,
+          },
+          economics: {
+            initialCapital: 100000,
+            itemPriceMultiplier: 0.9,
+            harvestPriceMultiplier: 1.1,
+            rentPerSqmStructurePerTick: 0.2,
+            rentPerSqmRoomPerTick: 0.15,
+          },
+        },
+      },
+    };
+
+    const getDifficultyConfigMock = vi.fn().mockResolvedValue({
+      ok: true,
+      data: mockConfig,
+    });
+
+    const { useDifficultyConfig, useSimulationStore } = await setup(getDifficultyConfigMock);
+
+    useSimulationStore.getState().setConnectionStatus('connected');
+
+    const { result } = renderHook(() => useDifficultyConfig());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config).toEqual(mockConfig);
+    expect(result.current.error).toBeNull();
+    expect(getDifficultyConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger React state updates after the hook unmounts', async () => {
+    const mockConfig: DifficultyConfig = {
+      normal: {
+        name: 'normal',
+        description: 'Standard run',
+        modifiers: {
+          plantStress: {
+            optimalRangeMultiplier: 1,
+            stressAccumulationMultiplier: 1,
+          },
+          deviceFailure: {
+            mtbfMultiplier: 1,
+          },
+          economics: {
+            initialCapital: 50000,
+            itemPriceMultiplier: 1,
+            harvestPriceMultiplier: 1,
+            rentPerSqmStructurePerTick: 0.3,
+            rentPerSqmRoomPerTick: 0.25,
+          },
+        },
+      },
+    };
+
+    let resolveRequest: ((value: { ok: boolean; data: DifficultyConfig }) => void) | undefined;
+    const getDifficultyConfigMock = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ ok: boolean; data: DifficultyConfig }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const { useDifficultyConfig, useSimulationStore } = await setup(getDifficultyConfigMock);
+
+    useSimulationStore.getState().setConnectionStatus('connected');
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useDifficultyConfig());
+
+    expect(getDifficultyConfigMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    resolveRequest?.({ ok: true, data: mockConfig });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const hasUnmountWarning = consoleErrorSpy.mock.calls.some(
+      ([message]) => typeof message === 'string' && message.includes('unmounted component'),
+    );
+
+    expect(hasUnmountWarning).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/frontend/src/hooks/useDifficultyConfig.ts
+++ b/src/frontend/src/hooks/useDifficultyConfig.ts
@@ -49,6 +49,7 @@ export const useDifficultyConfig = (): UseDifficultyConfigResult => {
   const hasRequestedRef = useRef<boolean>(Boolean(cachedDifficultyConfig));
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig(({ mode }) => {
         '@': path.resolve(__dirname, 'src'),
       },
     },
+    test: {
+      environment: 'jsdom',
+      clearMocks: true,
+      restoreMocks: true,
+      testTimeout: 15000,
+    },
     server: {
       port: 5173,
       strictPort: true,


### PR DESCRIPTION
### **User description**
## Summary
- ensure the difficulty configuration hook flags itself as mounted before StrictMode cleanup runs so refresh logic executes while the component is alive
- add Vitest coverage that the hook loads presets once connected and avoids state updates after unmount, and configure Vitest to run under jsdom with a longer timeout so the new tests pass

## Testing
- pnpm --filter @weebbreed/frontend test
- CI=1 pnpm run check *(fails: backend resolveDataDirectory packaged data directory expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68d65df496a08325b339e60d08f208ee


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix React StrictMode unmount issue in difficulty config hook

- Add comprehensive test coverage for hook mounting behavior

- Configure Vitest with jsdom environment and extended timeout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useDifficultyConfig hook"] --> B["Set mountedRef.current = true"]
  B --> C["Prevent state updates after unmount"]
  C --> D["Add test coverage"]
  D --> E["Configure Vitest environment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDifficultyConfig.ts</strong><dd><code>Fix mounting flag initialization for StrictMode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/hooks/useDifficultyConfig.ts

<ul><li>Add explicit <code>mountedRef.current = true</code> in useEffect<br> <li> Ensure mount flag is set before StrictMode cleanup runs</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/197/files#diff-b98c85eb6c6abf74c639bcb6f3cb923dd546a5151ddd3ada3a5ada86593cd96d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Configure Vitest test environment settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/vite.config.ts

<ul><li>Configure Vitest to use jsdom environment<br> <li> Enable mock clearing and restoring<br> <li> Set test timeout to 15 seconds</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/197/files#diff-a901835df5a31bc664262008ce7000b12a1c811dca5f124df9bf129b9256588f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDifficultyConfig.test.tsx</strong><dd><code>Add comprehensive hook test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/hooks/useDifficultyConfig.test.tsx

<ul><li>Add test for loading difficulty presets on connection<br> <li> Add test preventing state updates after unmount<br> <li> Mock system facade and simulation store<br> <li> Verify no React warnings for unmounted components</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/197/files#diff-2e0137b1f111392aaa5214a4f3a2ba87d7d0d5d7ecf7a51300497ab78f7415db">+133/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

