### PR TITLE
Centralize physiology constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactored the simulation loop to delegate tick-state orchestration and accounting flows to dedicated modules with updated tests safeguarding the phase order.
+- Centralized shared plant physiology coefficients (Magnus, canopy conductance, photon conversions) in `@/constants/physiology` and documented the module.
 
 ### Fixed
 

--- a/docs/constants/physiology.md
+++ b/docs/constants/physiology.md
@@ -1,0 +1,33 @@
+# Plant Physiology Constants
+
+## Vapor Pressure & VPD
+
+`MAGNUS_COEFFICIENT_A = 17.27`
+Coefficient `a` in the Magnus saturation vapour pressure approximation used by `vaporPressureDeficit`.
+
+`MAGNUS_COEFFICIENT_B = 237.3`
+Coefficient `b` (°C) in the Magnus formulation defining the temperature offset for saturation vapour pressure.
+
+`MAGNUS_PRESSURE_COEFFICIENT = 0.6108`
+Coefficient `c` (kPa) that scales the Magnus exponential term to produce saturation vapour pressure in kilopascals.
+
+## Temperature Response Curves
+
+`GAUSSIAN_MIN_SIGMA = 0.05`
+Lower bound on Gaussian response spread to prevent zero-width stress curves in thermal and VPD drivers.
+
+## Transpiration & Canopy Conductance
+
+`BASE_CANOPY_CONDUCTANCE = 0.008`
+Baseline canopy conductance in mol·m⁻²·s⁻¹·kPa⁻¹ used before scaling transpiration by leaf area index.
+
+`WATER_MOLAR_VOLUME_LITERS = 0.018`
+Litres per mole of water used when converting molar fluxes from canopy conductance into litres transpired.
+
+`SECONDS_PER_HOUR = 3600`
+Seconds in a simulation hour used to accumulate molar fluxes over timestep durations.
+
+## Photobiology Conversion Factors
+
+`MICROMOL_TO_MOL = 1e-6`
+Conversion factor from micromoles to moles applied when integrating PPFD into daily light integrals.

--- a/src/backend/src/constants/physiology.ts
+++ b/src/backend/src/constants/physiology.ts
@@ -1,0 +1,23 @@
+/** Magnus equation coefficient `a` used to compute saturation vapour pressure as a function of temperature. */
+export const MAGNUS_COEFFICIENT_A = 17.27;
+
+/** Magnus equation coefficient `b` (°C) representing the temperature offset in the saturation vapour pressure formula. */
+export const MAGNUS_COEFFICIENT_B = 237.3;
+
+/** Magnus equation coefficient `c` (kPa) scaling the exponential saturation vapour pressure term. */
+export const MAGNUS_PRESSURE_COEFFICIENT = 0.6108;
+
+/** Minimum Gaussian spread (σ) enforced for response curves to avoid degenerate zero-width distributions. */
+export const GAUSSIAN_MIN_SIGMA = 0.05;
+
+/** Baseline canopy conductance (mol·m⁻²·s⁻¹·kPa⁻¹) applied before scaling by leaf area index. */
+export const BASE_CANOPY_CONDUCTANCE = 0.008;
+
+/** Molar volume of liquid water in litres per mole, used to convert transpiration flux into litres. */
+export const WATER_MOLAR_VOLUME_LITERS = 0.018;
+
+/** Number of seconds in a simulation hour, used for flux integrations over time. */
+export const SECONDS_PER_HOUR = 3600;
+
+/** Conversion factor from micromoles to moles for photon flux density integrals. */
+export const MICROMOL_TO_MOL = 1e-6;

--- a/src/backend/src/engine/physio/ppfd.ts
+++ b/src/backend/src/engine/physio/ppfd.ts
@@ -1,12 +1,11 @@
+import { MICROMOL_TO_MOL, SECONDS_PER_HOUR } from '@/constants/physiology.js';
+
 const clamp = (value: number, min: number, max: number): number => {
   if (!Number.isFinite(value)) {
     return min;
   }
   return Math.min(Math.max(value, min), max);
 };
-
-const SECONDS_PER_HOUR = 3600;
-const MICROMOL_TO_MOL = 1e-6;
 
 /**
  * Rectangular hyperbola response of photosynthesis to PPFD (µmol·m⁻²·s⁻¹).

--- a/src/backend/src/engine/physio/temp.ts
+++ b/src/backend/src/engine/physio/temp.ts
@@ -1,11 +1,11 @@
+import { GAUSSIAN_MIN_SIGMA } from '@/constants/physiology.js';
+
 const clamp = (value: number, min: number, max: number): number => {
   if (!Number.isFinite(value)) {
     return min;
   }
   return Math.min(Math.max(value, min), max);
 };
-
-const MIN_SIGMA = 0.05;
 
 /**
  * Exponential relaxation towards a target value.
@@ -61,7 +61,7 @@ export const gaussianResponse = (value: number, mean: number, sigma: number): nu
   if (!Number.isFinite(value) || !Number.isFinite(mean)) {
     return 0;
   }
-  const spread = Math.max(Math.abs(sigma), MIN_SIGMA);
+  const spread = Math.max(Math.abs(sigma), GAUSSIAN_MIN_SIGMA);
   const exponent = -0.5 * ((value - mean) / spread) ** 2;
   return clamp(Math.exp(exponent), 0, 1);
 };

--- a/src/backend/src/engine/physio/transpiration.ts
+++ b/src/backend/src/engine/physio/transpiration.ts
@@ -1,13 +1,15 @@
+import {
+  BASE_CANOPY_CONDUCTANCE,
+  SECONDS_PER_HOUR,
+  WATER_MOLAR_VOLUME_LITERS,
+} from '@/constants/physiology.js';
+
 const clamp = (value: number, min: number, max: number): number => {
   if (!Number.isFinite(value)) {
     return min;
   }
   return Math.min(Math.max(value, min), max);
 };
-
-const BASE_CANOPY_CONDUCTANCE = 0.008; // mol·m⁻²·s⁻¹·kPa⁻¹
-const WATER_MOLAR_VOLUME_LITERS = 0.018; // L per mol of water
-const SECONDS_PER_HOUR = 3600;
 
 export interface TranspirationInput {
   /** Vapour pressure deficit in kilopascals (kPa). */

--- a/src/backend/src/engine/physio/vpd.ts
+++ b/src/backend/src/engine/physio/vpd.ts
@@ -1,13 +1,15 @@
+import {
+  MAGNUS_COEFFICIENT_A,
+  MAGNUS_COEFFICIENT_B,
+  MAGNUS_PRESSURE_COEFFICIENT,
+} from '@/constants/physiology.js';
+
 const clamp = (value: number, min: number, max: number): number => {
   if (!Number.isFinite(value)) {
     return min;
   }
   return Math.min(Math.max(value, min), max);
 };
-
-const SATURATION_CONSTANT_A = 17.27;
-const SATURATION_CONSTANT_B = 237.3;
-const SATURATION_PRESSURE_COEFFICIENT = 0.6108;
 
 /**
  * Computes the saturation vapour pressure of air at a given temperature.
@@ -17,8 +19,8 @@ const SATURATION_PRESSURE_COEFFICIENT = 0.6108;
  */
 export const saturationVaporPressure = (temperatureC: number): number => {
   const temperature = clamp(temperatureC, -50, 60);
-  const exponent = (SATURATION_CONSTANT_A * temperature) / (temperature + SATURATION_CONSTANT_B);
-  return SATURATION_PRESSURE_COEFFICIENT * Math.exp(exponent);
+  const exponent = (MAGNUS_COEFFICIENT_A * temperature) / (temperature + MAGNUS_COEFFICIENT_B);
+  return MAGNUS_PRESSURE_COEFFICIENT * Math.exp(exponent);
 };
 
 /**

--- a/src/backend/src/engine/plants/growthModel.ts
+++ b/src/backend/src/engine/plants/growthModel.ts
@@ -24,6 +24,7 @@ import { gaussianResponse } from '@/engine/physio/temp.js';
 import { co2HalfSaturationResponse } from '@/engine/physio/co2.js';
 import { vaporPressureDeficit } from '@/engine/physio/vpd.js';
 import { estimateTranspirationLiters } from '@/engine/physio/transpiration.js';
+import { GAUSSIAN_MIN_SIGMA } from '@/constants/physiology.js';
 
 const clamp = (value: number, min: number, max: number): number => {
   return Math.min(Math.max(value, min), max);
@@ -31,8 +32,6 @@ const clamp = (value: number, min: number, max: number): number => {
 
 const DEFAULT_LIGHT_HALF_SAT = 350;
 const DEFAULT_CO2_HALF_SAT = 600;
-const MIN_SIGMA = 0.05;
-
 const HEALTH_ALERT_THRESHOLDS = [
   { threshold: 0.5, severity: 'warning' as const },
   { threshold: 0.3, severity: 'critical' as const },
@@ -87,7 +86,7 @@ const resolveVpdResponse = (
   const vpdLow = computeVpd(temperature, highRh);
   const vpdHigh = computeVpd(temperature, lowRh);
   const tolerance = Math.max(Math.abs(vpdHigh - vpdOpt), Math.abs(vpdOpt - vpdLow));
-  return gaussianResponse(vpd, vpdOpt, Math.max(tolerance / 2, MIN_SIGMA));
+  return gaussianResponse(vpd, vpdOpt, Math.max(tolerance / 2, GAUSSIAN_MIN_SIGMA));
 };
 
 const resolveCo2HalfSaturation = (strain: StrainBlueprint): number => {


### PR DESCRIPTION
### **User description**
## Summary
- add a shared `@/constants/physiology` module for Magnus, canopy, and photon conversion coefficients
- refactor VPD, PPFD, temperature, transpiration, and growth model helpers to consume the shared constants
- document the physiology constants in `docs/constants/physiology.md` and note the refactor in the changelog

## Testing
- pnpm run check *(fails: frontend eslint run exits with module resolution error in the existing tree)*

------
https://chatgpt.com/codex/tasks/task_e_68d72579b09883259877e7cec562a3e6


___

### **PR Type**
Enhancement


___

### **Description**
- Centralized plant physiology constants into shared module

- Refactored VPD, PPFD, temperature, and transpiration helpers

- Added comprehensive documentation for physiology constants

- Updated changelog to reflect the refactoring changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Individual modules with constants"] --> B["@/constants/physiology module"]
  B --> C["VPD calculations"]
  B --> D["PPFD responses"]
  B --> E["Temperature curves"]
  B --> F["Transpiration models"]
  B --> G["Growth calculations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>physiology.ts</strong><dd><code>Create centralized physiology constants module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/constants/physiology.ts

<ul><li>Created new shared constants module for plant physiology<br> <li> Defined Magnus equation coefficients for vapor pressure calculations<br> <li> Added canopy conductance, water conversion, and photon flux constants<br> <li> Included comprehensive JSDoc documentation for each constant</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-95cc97cf364bedffbbbdf1543ae50c4e3d7e27f10720e61af48b67b7ad4ce2de">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ppfd.ts</strong><dd><code>Refactor PPFD module to use shared constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/physio/ppfd.ts

<ul><li>Imported <code>MICROMOL_TO_MOL</code> and <code>SECONDS_PER_HOUR</code> from shared constants<br> <li> Removed local constant definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-364e90772da387f613e8079c05ab6d91fa77042689b2ed33ee186bc03be84e72">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>temp.ts</strong><dd><code>Update temperature module with shared constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/physio/temp.ts

<ul><li>Imported <code>GAUSSIAN_MIN_SIGMA</code> from shared constants module<br> <li> Replaced local <code>MIN_SIGMA</code> with shared constant</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-ab106a93d60d96218a6cbfa008a868f27da360586a32ca82d536d0c33bd2ae76">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transpiration.ts</strong><dd><code>Refactor transpiration to use centralized constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/physio/transpiration.ts

<ul><li>Imported transpiration-related constants from shared module<br> <li> Removed local definitions of canopy conductance and water volume <br>constants</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-3f2f779913784145649738cc293cf395698a3e744b537d9f22818c8676f3c8e2">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vpd.ts</strong><dd><code>Update VPD calculations with shared Magnus constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/physio/vpd.ts

<ul><li>Imported Magnus equation coefficients from shared constants<br> <li> Updated variable names to match new constant naming convention<br> <li> Removed local constant definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-acfe0407396d5979cc8b9358f98e8173bd554d3cf0faec9f100c9bbc6ffb437b">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>growthModel.ts</strong><dd><code>Update growth model with shared constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/plants/growthModel.ts

<ul><li>Imported <code>GAUSSIAN_MIN_SIGMA</code> from shared constants module<br> <li> Replaced local <code>MIN_SIGMA</code> usage in VPD response calculations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-65a068554a22ebbb2cd65100b58414fdf82cc6f3cebebf2545338bea25031dfe">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document physiology constants refactoring in changelog</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the physiology constants centralization<br> <li> Noted the refactoring of shared coefficients and documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>physiology.md</strong><dd><code>Add detailed physiology constants documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/constants/physiology.md

<ul><li>Created comprehensive documentation for all physiology constants<br> <li> Organized constants by functional categories (VPD, temperature, <br>transpiration, photobiology)<br> <li> Included units and usage context for each constant</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/207/files#diff-c5b0722d8460f6dd7229b6e9e0818697b23d9d7c0189d5914f320627411d0e7b">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

