### PR TITLE
Centralize plant health thresholds and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralized shared plant physiology coefficients (Magnus, canopy conductance, photon conversions) in `@/constants/physiology` and documented the module.
 - Consolidated plant growth defaults (light/CO₂ saturation, VPD tolerances, health alerts, yield multipliers) into `@/constants/plants` and documented the tuning guide for designers.
 - Promoted environment device coefficients, climate controller gains, and transpiration feedback defaults into `@/constants/environment` with updated references and documentation.
+- Extracted disease/pest detection and spread thresholds plus treatment defaults into `@/constants/health` with supporting documentation.
 
 ### Fixed
 

--- a/docs/constants/health.md
+++ b/docs/constants/health.md
@@ -1,0 +1,27 @@
+# Plant Health Constants
+
+## Detection Thresholds
+
+`DISEASE_DETECTION_THRESHOLD = 0.18`
+Disease severity fraction that guarantees an infection is flagged once symptoms appear, ensuring consistent detection timing.
+`PEST_DETECTION_THRESHOLD = 0.22`
+Pest population fraction that triggers detection after observation delays, marking when infestations become noticeable.
+
+## Spread Gates
+
+`DISEASE_SPREAD_THRESHOLD = 0.60`
+Minimum infection intensity required before a disease can jump to neighbouring plants, suppressing low-grade spread.
+`PEST_SPREAD_THRESHOLD = 0.60`
+Population level pests must exceed before propagating to other plants, aligning pest spread with disease logic.
+
+## Treatment Defaults
+
+`DEFAULT_TREATMENT_DURATION_DAYS = 1`
+Fallback treatment duration applied when an option omits explicit effect or cooldown lengths.
+
+## Treatment Efficacy Bounds
+
+`MIN_EFFECTIVE_RATE = 0`
+Lower multiplier clamp to prevent negative infection or degeneration rates when combining treatments.
+`MAX_EFFECTIVE_RATE = 10`
+Upper multiplier clamp to cap stacked treatment boosts and keep simulation values stable.

--- a/src/backend/src/constants/health.ts
+++ b/src/backend/src/constants/health.ts
@@ -1,0 +1,42 @@
+/**
+ * Disease severity threshold (0–1) above which an infection is guaranteed to be
+ * detected once symptoms manifest. Keeps detection logic consistent across the
+ * simulation and test fixtures.
+ */
+export const DISEASE_DETECTION_THRESHOLD = 0.18;
+
+/**
+ * Pest population threshold (0–1) that triggers detection once observation
+ * delays expire. Encodes when pests become noticeable to staff.
+ */
+export const PEST_DETECTION_THRESHOLD = 0.22;
+
+/**
+ * Infection level (0–1) required before a disease is allowed to spread to
+ * neighbouring plants. Prevents low-grade infections from propagating.
+ */
+export const DISEASE_SPREAD_THRESHOLD = 0.6;
+
+/**
+ * Pest population fraction (0–1) that must be exceeded before an infestation
+ * can jump to another plant. Mirrors the disease spread gate.
+ */
+export const PEST_SPREAD_THRESHOLD = 0.6;
+
+/**
+ * Default duration in days applied to plant treatments when a blueprint omits
+ * explicit effect or cooldown durations.
+ */
+export const DEFAULT_TREATMENT_DURATION_DAYS = 1;
+
+/**
+ * Minimum multiplier applied to treatment efficacy values to guard against
+ * negative rates when stacking modifiers.
+ */
+export const MIN_EFFECTIVE_RATE = 0;
+
+/**
+ * Maximum multiplier applied to treatment efficacy values, preventing stacked
+ * boosts from growing without bound.
+ */
+export const MAX_EFFECTIVE_RATE = 10;

--- a/src/backend/src/engine/health/healthEngine.ts
+++ b/src/backend/src/engine/health/healthEngine.ts
@@ -23,11 +23,15 @@ import {
   type TreatmentOptionIndex,
 } from './models.js';
 import { PLANT_DISEASE_IMPACT } from '@/constants/balance.js';
-
-const DISEASE_DETECTION_THRESHOLD = 0.18;
-const PEST_DETECTION_THRESHOLD = 0.22;
-const DISEASE_SPREAD_THRESHOLD = 0.6;
-const PEST_SPREAD_THRESHOLD = 0.6;
+import {
+  DEFAULT_TREATMENT_DURATION_DAYS,
+  DISEASE_DETECTION_THRESHOLD,
+  DISEASE_SPREAD_THRESHOLD,
+  MAX_EFFECTIVE_RATE,
+  MIN_EFFECTIVE_RATE,
+  PEST_DETECTION_THRESHOLD,
+  PEST_SPREAD_THRESHOLD,
+} from '@/constants/health.js';
 
 interface CombinedDiseaseTreatmentEffect {
   infection: number;
@@ -68,10 +72,6 @@ const DEFAULT_PEST_PHASE: Record<
   lateFlower: { reproduction: 1, mortality: 1, damage: 1 },
   ripening: { reproduction: 1, mortality: 1, damage: 1 },
 };
-
-const DEFAULT_TREATMENT_DURATION_DAYS = 1;
-const MIN_EFFECTIVE_RATE = 0;
-const MAX_EFFECTIVE_RATE = 10;
 
 const ensureOptionsIndex = (
   options: TreatmentOption[] | TreatmentOptionIndex,


### PR DESCRIPTION
### **User description**
## Summary
- add a dedicated `@/constants/health` module containing detection/spread thresholds and treatment defaults used by the health engine
- update the health engine and regression test to import the shared constants instead of redefining local values
- document the health constants for designers and reference the extraction in the changelog

## Testing
- pnpm run check *(fails: frontend lint currently errors with an ESM resolver failure prior to code changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d72cebe7a88325b61a38df4ed4c72b


___

### **PR Type**
Enhancement


___

### **Description**
- Centralized plant health constants into dedicated module

- Replaced hardcoded thresholds with imported constants

- Added comprehensive documentation for health parameters

- Updated test fixtures to use shared constants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Constants"] --> B["@/constants/health.ts"]
  B --> C["Health Engine"]
  B --> D["Test Files"]
  B --> E["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health.ts</strong><dd><code>New health constants module with thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/constants/health.ts

<ul><li>Created new module with disease/pest detection thresholds<br> <li> Added spread thresholds and treatment duration constants<br> <li> Included efficacy rate bounds with comprehensive documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/210/files#diff-ef2219819d01beba0f0141c783eb03e593731d321a256b047f1b4febbcfb471d">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>healthEngine.ts</strong><dd><code>Refactored to use imported health constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/health/healthEngine.ts

<ul><li>Removed local constant definitions<br> <li> Imported all health thresholds from constants module<br> <li> Cleaned up duplicate constant declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/210/files#diff-88c0481a73882f646aff4381a9acfc9591776f26117559b763ecb445aa51e163">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>healthEngine.test.ts</strong><dd><code>Updated tests to use centralized constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/health/healthEngine.test.ts

<ul><li>Imported health constants from new module<br> <li> Replaced hardcoded values with named constants<br> <li> Updated test assertions to use dynamic thresholds</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/210/files#diff-42dc15709c6127b08c1d39b4f8ddb23b6733189925ed5e75b04a56a4388c010b">+18/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Documented health constants centralization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting health constants extraction<br> <li> Listed new <code>@/constants/health</code> module creation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/210/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health.md</strong><dd><code>New health constants documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/constants/health.md

<ul><li>Created comprehensive documentation for health constants<br> <li> Explained detection thresholds, spread gates, and treatment defaults<br> <li> Provided context for each constant's purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/210/files#diff-7c7606ae513526dadcd658f700dafc2d13f6d4647fd081db25de1ba221ad3435">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

