### PR TITLE
Ensure hot reload waits for staging completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ensured blueprint hot reload waits for the underlying staging promise so the
+  first commit after a file change applies the updated data even when reloads
+  take longer than a tick interval.
 - Unified difficulty preset usage across the engine: initial state creation and world.newGame now derive economics from `data/configs/difficulty.json` via injected config. Removed duplicated hard-coded tables and added tests to prevent regressions.
 - Accepted prefixed zone identifiers when toggling planting plans and added façade/socket gateway integration coverage to prevent regressions.
 

--- a/src/backend/src/data/blueprintRepository.ts
+++ b/src/backend/src/data/blueprintRepository.ts
@@ -12,6 +12,7 @@ export type HotReloadErrorHandler = (error: unknown) => void;
 
 export interface BlueprintRepositoryOptions {
   onHotReloadError?: HotReloadErrorHandler;
+  onReloadPending?: (promise: Promise<void>) => void;
 }
 
 export class BlueprintRepository {
@@ -129,7 +130,9 @@ export class BlueprintRepository {
       }
       reloading = true;
       try {
-        const result = await this.reload();
+        const reloadPromise = this.reload();
+        options.onReloadPending?.(reloadPromise.then(() => undefined));
+        const result = await reloadPromise;
         const disposition = await handler(result);
         if (disposition !== 'defer' && this.stagedResult) {
           this.commitReload();

--- a/src/backend/src/index.test.ts
+++ b/src/backend/src/index.test.ts
@@ -15,7 +15,10 @@ vi.mock('@/data/index.js', () => ({
 
 const createRepositoryStub = () => ({
   getSummary: () => ({ loadedFiles: 0, versions: {}, issues: [] }),
-  onHotReload: vi.fn(() => vi.fn(async () => {})),
+  onHotReload: vi.fn(async (_handler, options = {}) => {
+    void options;
+    return vi.fn(async () => {});
+  }),
 });
 
 describe('resolveDataDirectory', () => {


### PR DESCRIPTION
### **User description**
## Summary
- extend the blueprint repository hot reload callback to surface the staging promise and track it in the hot reload manager
- wait for any pending staging work before committing reloads and broaden the hot reload tests, including a slow staging integration case
- document the regression fix in the changelog

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm run check *(fails: frontend eslint requires @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d72d0376e88325b848b4e7ff580f71


___

### **PR Type**
Bug fix


___

### **Description**
- Fix hot reload race condition by tracking staging promises

- Ensure staged data commits even with slow reload operations

- Add comprehensive integration tests for slow staging scenarios

- Document regression fix in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File Change"] --> B["Blueprint Repository"]
  B --> C["onReloadPending Callback"]
  C --> D["Hot Reload Manager"]
  D --> E["Track Staging Promise"]
  E --> F["Await Pending Reload"]
  F --> G["Commit Staged Data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blueprintRepository.ts</strong><dd><code>Add staging promise tracking to repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/data/blueprintRepository.ts

<ul><li>Add <code>onReloadPending</code> callback to repository options<br> <li> Surface staging promise through callback during reload<br> <li> Track reload promise before awaiting completion</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-9ac2b5be03e203fab3ffaebf868ca08c27c7fca13c6a40c1ac52de35e08bd61b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Update repository stub for new callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/index.test.ts

<ul><li>Update repository stub to handle new <code>onReloadPending</code> option<br> <li> Modify mock to accept options parameter in <code>onHotReload</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-674b414a6457e03c50cadf38da453ecf9fefaf37cf696b289f307a926ac7d634">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotReload.integration.test.ts</strong><dd><code>Add slow staging integration test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/persistence/hotReload.integration.test.ts

<ul><li>Add comprehensive test for slow staging scenario<br> <li> Verify staged data commits even with delayed reload operations<br> <li> Test timing constraints and promise completion</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-8dc34bc78a76db6bb9b2c6815fe94fb7b9ad245c90c91b2923c1500d23e5a0e7">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotReload.test.ts</strong><dd><code>Update test mocks for promise tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/persistence/hotReload.test.ts

<ul><li>Add <code>pendingNotifier</code> property to fake repository<br> <li> Update <code>onHotReload</code> method to handle new callback option<br> <li> Simulate staging promise notification in <code>triggerReload</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-ddf0cc751a3ece6a1d9ee25577f31359c5ed134e001b8f064528fb4c30a4350e">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotReload.ts</strong><dd><code>Implement promise tracking in hot reload manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/persistence/hotReload.ts

<ul><li>Remove immediate staging promise creation in <code>start</code> method<br> <li> Add <code>onReloadPending</code> callback to track repository staging<br> <li> Implement <code>awaitPendingReload</code> method with retry logic<br> <li> Simplify commit hook to use new await method</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-62ae24de06aaa0a432b3af4bea44f7126bcd330104e57c75fe5e92c510bc6ac9">+19/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document hot reload fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document hot reload race condition fix<br> <li> Explain staging promise tracking improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/211/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

