### PR TITLE
Centralize world-state defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated plant growth defaults (light/CO₂ saturation, VPD tolerances, health alerts, yield multipliers) into `@/constants/plants` and documented the tuning guide for designers.
 - Promoted environment device coefficients, climate controller gains, and transpiration feedback defaults into `@/constants/environment` with updated references and documentation.
 - Extracted disease/pest detection and spread thresholds plus treatment defaults into `@/constants/health` with supporting documentation.
+- Shared world-state resource and maintenance defaults through `@/constants/world` and extended the constants documentation with rationale for each value.
 
 ### Fixed
 

--- a/docs/constants/world.md
+++ b/docs/constants/world.md
@@ -1,0 +1,16 @@
+# World Defaults
+
+The world module exposes shared defaults for the resources stocked into a new
+zone and the recurring maintenance cadence. These values align engine behaviours
+(`stateFactory`, `WorldService`) and prevent drift between initialization and
+runtime management flows.
+
+| Constant                             | Default         | Rationale                                                                                                                                                                    |
+| ------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_ZONE_RESERVOIR_LEVEL`       | `0.75`          | New reservoirs launch three-quarters full so irrigation controllers have working volume while still leaving headroom for rapid top-offs or rain events triggered by devices. |
+| `DEFAULT_ZONE_WATER_LITERS`          | `800` litres    | Provides roughly a week of transpiration supply for a mid-vegetative canopy before automated refills need to trigger.                                                        |
+| `DEFAULT_ZONE_NUTRIENT_LITERS`       | `400` litres    | Mirrors the water allocation while assuming a 50 % nutrient dilution plan, allowing alternating water/feed cycles without immediate mixing.                                  |
+| `DEFAULT_MAINTENANCE_INTERVAL_TICKS` | `24 * 30` ticks | Schedules routine device servicing every in-game month (24 hourly ticks per day × 30 days), matching the finance model's maintenance accrual cadence.                        |
+
+Referencing these constants ensures all world management flows respect the same
+default resource budgets and maintenance timeline.

--- a/src/backend/src/constants/world.ts
+++ b/src/backend/src/constants/world.ts
@@ -1,0 +1,24 @@
+/**
+ * Fractional fill level (0–1) applied to freshly provisioned zone reservoirs.
+ * Keeps irrigation controllers within their nominal operating range while
+ * leaving headroom for overfill events.
+ */
+export const DEFAULT_ZONE_RESERVOIR_LEVEL = 0.75;
+
+/**
+ * Litres of plain water stocked into a new zone's reservoir. Sized for roughly
+ * one week of transpiration at mid-vegetative demand before refills.
+ */
+export const DEFAULT_ZONE_WATER_LITERS = 800;
+
+/**
+ * Litres of nutrient solution charged at strength 1. Mirrors the default water
+ * allocation so irrigation can alternate between water and feed cycles.
+ */
+export const DEFAULT_ZONE_NUTRIENT_LITERS = 400;
+
+/**
+ * Number of simulation ticks between routine device maintenance windows.
+ * Based on one tick per hour, giving a monthly service cadence.
+ */
+export const DEFAULT_MAINTENANCE_INTERVAL_TICKS = 24 * 30;

--- a/src/backend/src/engine/world/worldService.ts
+++ b/src/backend/src/engine/world/worldService.ts
@@ -2,6 +2,12 @@ import { generateId } from '@/state/initialization/common.js';
 import type { RngService, RngStream } from '@/lib/rng.js';
 import { CostAccountingService, type TickAccumulator } from '@/engine/economy/costAccounting.js';
 import {
+  DEFAULT_MAINTENANCE_INTERVAL_TICKS,
+  DEFAULT_ZONE_NUTRIENT_LITERS,
+  DEFAULT_ZONE_RESERVOIR_LEVEL,
+  DEFAULT_ZONE_WATER_LITERS,
+} from '@/constants/world.js';
+import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
@@ -22,11 +28,6 @@ import { validateStructureGeometry } from '@/state/geometry.js';
 import { findStructure, findRoom, findZone, type ZoneLookupResult } from './stateSelectors.js';
 import { type RoomPurposeSource, resolveRoomPurposeId } from '@/engine/roomPurposes/index.js';
 import type { DifficultyConfig } from '@/data/configs/difficulty.js';
-
-const DEFAULT_ZONE_RESERVOIR_LEVEL = 0.75;
-const DEFAULT_ZONE_WATER_LITERS = 800;
-const DEFAULT_ZONE_NUTRIENT_LITERS = 400;
-const DEFAULT_MAINTENANCE_INTERVAL_TICKS = 24 * 30;
 
 const deriveDuplicateName = (original: string, fallbackSuffix: string): string => {
   const trimmed = original.trim();

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -4,6 +4,12 @@ import type {
   // DeviceBlueprint,
   StrainBlueprint,
 } from '@/data/schemas/index.js';
+import {
+  DEFAULT_MAINTENANCE_INTERVAL_TICKS,
+  DEFAULT_ZONE_NUTRIENT_LITERS,
+  DEFAULT_ZONE_RESERVOIR_LEVEL,
+  DEFAULT_ZONE_WATER_LITERS,
+} from '@/constants/world.js';
 import { DEFAULT_SAVEGAME_VERSION } from './persistence/saveGame.js';
 import type {
   CultivationMethodBlueprint,
@@ -64,9 +70,6 @@ export { loadTaskDefinitions } from './state/initialization/tasks.js';
 // Default tick length is 60 minutes (1 hour) per tick for realistic gameplay and KPI parity
 const DEFAULT_TICK_LENGTH_MINUTES = 60;
 const DEFAULT_TARGET_TICK_RATE = 1;
-const DEFAULT_ZONE_RESERVOIR_LEVEL = 0.75;
-const DEFAULT_ZONE_WATER_LITERS = 800;
-const DEFAULT_ZONE_NUTRIENT_LITERS = 400;
 const DEFAULT_EMPLOYEE_COUNTS: Record<EmployeeRole, number> = {
   Gardener: 4,
   Technician: 2,
@@ -166,7 +169,7 @@ const createDeviceInstance = (
     runtimeHours: 0,
     maintenance: {
       lastServiceTick: 0,
-      nextDueTick: 24 * 30,
+      nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
       condition: Math.min(1, Math.max(0, blueprint.quality ?? 1)),
       runtimeHoursAtLastService: 0,
       degradation: 0,


### PR DESCRIPTION
### **User description**
## Summary
- add a shared `@/constants/world` module for default zone reservoir fill levels, water/nutrient volumes, and maintenance cadence
- update the world service and state factory to consume the shared defaults and prevent divergent literals
- document the world constants and changelog entry to explain the rationale behind the default values

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test
- pnpm run check *(fails: @weebbreed/frontend lint currently errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d72ded8200832590cf7d8724984c21


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize world-state defaults into shared constants module

- Extract hardcoded values from world service and state factory

- Add comprehensive documentation for default values

- Prevent divergent literals across initialization flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded constants"] --> B["@/constants/world module"]
  B --> C["worldService.ts"]
  B --> D["stateFactory.ts"]
  B --> E["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>world.ts</strong><dd><code>Add shared world constants module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/constants/world.ts

<ul><li>Create new constants module with world-state defaults<br> <li> Define <code>DEFAULT_ZONE_RESERVOIR_LEVEL</code>, water/nutrient volumes<br> <li> Add <code>DEFAULT_MAINTENANCE_INTERVAL_TICKS</code> constant<br> <li> Include comprehensive JSDoc comments explaining rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/212/files#diff-486960a53bd7b5989d8c4bf020d6dedc0f1c8602d1a77d913d21d395081b2d20">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worldService.ts</strong><dd><code>Replace hardcoded defaults with imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/world/worldService.ts

<ul><li>Import world constants from shared module<br> <li> Remove local hardcoded default values<br> <li> Replace inline constants with imported values</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/212/files#diff-0f448a14ac57d61b6f39b36cc348a413f5c35b3167b2de38d3880fc0819bcc78">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stateFactory.ts</strong><dd><code>Use shared constants in state factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/stateFactory.ts

<ul><li>Import world constants from shared module<br> <li> Remove duplicate hardcoded default values<br> <li> Update device maintenance initialization to use shared constant</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/212/files#diff-b6717c682188d3c383076f167ab885cb22994e0b35db26c3df9c56efad636878">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document world constants changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add changelog entry for world constants consolidation<br> <li> Document rationale for shared defaults approach</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/212/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>world.md</strong><dd><code>Add world constants documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/constants/world.md

<ul><li>Create comprehensive documentation for world defaults<br> <li> Include table with constants, values, and rationale<br> <li> Explain alignment between engine behaviors</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/212/files#diff-e1b882e9aabc5431e148f80d27c88bfbe76e28d0468db855a4a66dcc67b2eb59">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

