### PR TITLE
Document simulation constant stewardship guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - **Socket transport parity.** Keep `socket.io` and `socket.io-client` on the **same minor version** across backend and frontend packages. Update both sides together to avoid wire-protocol drift.
 - **No breaking directory churn.** Prefer additive refactors with clear commits, green CI at every step.
 - **Documentation** is crucial. Please document changes before committing (`CHANGELOG.md`). Always check against `/docs/weedbreed-final-truth.md` and `/docs/ui-building_guide.md` - change missalginments. Also take a look at the rest of `/docs/**/*.md`.
+- **Centralize simulation constants.** Author new or updated constants in the shared backend modules under `src/backend/src/constants/`, include a short JSDoc description, and mirror every change in `/docs/constants/**`. This policy will be anchored in the forthcoming ADR on simulation constant stewardship so plan updates accordingly.
 - **Before commiting** use `pnpm run check` to satisfy `husky` rules.
 - **If unsure: ask!**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Clarified simulation constant authoring guidance in `AGENTS.md` and `/docs/constants/physiology.md`, pointing to the forthcoming ADR on constant stewardship.
 - Refactored the simulation loop to delegate tick-state orchestration and accounting flows to dedicated modules with updated tests safeguarding the phase order.
 - Centralized shared plant physiology coefficients (Magnus, canopy conductance, photon conversions) in `@/constants/physiology` and documented the module.
 - Consolidated plant growth defaults (light/CO₂ saturation, VPD tolerances, health alerts, yield multipliers) into `@/constants/plants` and documented the tuning guide for designers.

--- a/docs/constants/physiology.md
+++ b/docs/constants/physiology.md
@@ -1,5 +1,7 @@
 # Plant Physiology Constants
 
+> Authoring guidance: Define these constants in the shared backend modules under `src/backend/src/constants/` with concise JSDoc and reference this catalogue when editing. All contributions follow the forthcoming ADR on simulation constant stewardship (pending publication) to keep engine and documentation aligned.
+
 ## Vapor Pressure & VPD
 
 `MAGNUS_COEFFICIENT_A = 17.27`


### PR DESCRIPTION
## Summary
- add AGENT instructions that centralize simulation constants with JSDoc coverage and cross-reference the forthcoming stewardship ADR
- annotate the physiology constants documentation with the same guidance so the catalogue and code stay in lockstep
- record the documentation policy update in the changelog for visibility

## Testing
- pnpm run check *(fails: @weebbreed/frontend lint exits 2)*

------
https://chatgpt.com/codex/tasks/task_e_68d72f631e6c832584bd2a7ad015f71e