### PR TITLE
Fix expense breakdown totals and badge tone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   take longer than a tick interval.
 - Unified difficulty preset usage across the engine: initial state creation and world.newGame now derive economics from `data/configs/difficulty.json` via injected config. Removed duplicated hard-coded tables and added tests to prevent regressions.
 - Accepted prefixed zone identifiers when toggling planting plans and added façade/socket gateway integration coverage to prevent regressions.
+- Prevented undefined CapEx/OpEx totals in the finance expense breakdown and aligned badge tones with the supported palette.
 
 ### Added
 

--- a/src/frontend/src/components/finance/ExpenseBreakdown.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.tsx
@@ -51,6 +51,8 @@ export const ExpenseBreakdown = ({
     // Since we don't have detailed ledger data in the frontend snapshot,
     // we'll create a simplified expense breakdown based on available data
     const categories: ExpenseCategory[] = [];
+    const capexTotal = 0;
+    let opexTotal = 0;
 
     if (totalExpenses > 0) {
       // Create a simplified breakdown showing total expenses
@@ -74,6 +76,8 @@ export const ExpenseBreakdown = ({
           },
         ],
       });
+
+      opexTotal = totalExpenses;
     }
 
     // Calculate averages
@@ -172,7 +176,7 @@ export const ExpenseBreakdown = ({
                   <div className="flex items-center gap-3">
                     <span className="font-semibold text-text">{category.name}</span>
                     <Badge
-                      tone={category.type === 'CapEx' ? 'primary' : 'warning'}
+                      tone={category.type === 'CapEx' ? 'danger' : 'warning'}
                       className="text-xs"
                     >
                       {category.type}


### PR DESCRIPTION
### **User description**
## Summary
- ensure the finance expense breakdown memo always defines CapEx/OpEx totals before returning data
- align the expense category badge tone with an existing Badge component tone and document the fix in the changelog

## Testing
- pnpm --filter @weebbreed/frontend typecheck *(fails: existing missing dependency/type issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d734c7dfc0832594c69ad31a6813b0


___

### **PR Type**
Bug fix


___

### **Description**
- Initialize CapEx/OpEx totals to prevent undefined values

- Fix badge tone alignment with supported palette

- Update changelog with fix documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ExpenseBreakdown Component"] --> B["Initialize capexTotal = 0"]
  A --> C["Initialize opexTotal = 0"]
  A --> D["Set opexTotal when expenses > 0"]
  A --> E["Change badge tone from 'primary' to 'danger'"]
  F["CHANGELOG.md"] --> G["Document fix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document expense breakdown fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the fix for undefined CapEx/OpEx totals<br> <li> Documented badge tone alignment with supported palette</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/215/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExpenseBreakdown.tsx</strong><dd><code>Fix undefined totals and badge tone</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/finance/ExpenseBreakdown.tsx

<ul><li>Initialize <code>capexTotal</code> to 0 to prevent undefined values<br> <li> Initialize <code>opexTotal</code> to 0 and set it when totalExpenses > 0<br> <li> Change CapEx badge tone from 'primary' to 'danger'</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/215/files#diff-aa61780d2dcf636fd6b7a6ee9afad130a03249f8d2a9edce1e0457b59cd7a715">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

