### PR TITLE
Refine finance profit chart inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the finance ProfitChart to read the finance summary snapshot safely
+  and derive chart metrics from available totals instead of missing ledger
+  entries.
 - Ensured blueprint hot reload waits for the underlying staging promise so the
   first commit after a file change applies the updated data even when reloads
   take longer than a tick interval.


### PR DESCRIPTION
## Summary
- refactor the finance ProfitChart to read `snapshot.finance` and guard until finance summary data arrives
- drive the chart metrics from the aggregated finance totals/last-tick fields instead of ledger entries or metadata
- document the frontend fix in the changelog

## Testing
- pnpm run check *(fails: frontend eslint binary from workspace root cannot resolve @eslint/js flat config)*
- pnpm --filter @weebbreed/frontend typecheck *(fails: workspace lacks optional frontend dev dependencies such as @testing-library/react and tailwindcss types)*

------
https://chatgpt.com/codex/tasks/task_e_68d7361e41748325a5fe2005631c1133