### PR TITLE
Fix utility pricing badge and button props

### DIFF
--- a/src/frontend/src/components/finance/UtilityPricing.tsx
+++ b/src/frontend/src/components/finance/UtilityPricing.tsx
@@ -192,7 +192,7 @@ export const UtilityPricing = ({ bridge }: UtilityPricingProps) => {
                       <h4 className="font-medium text-text flex items-center gap-2">
                         {utility.name}
                         {hasChange && (
-                          <Badge variant="warning" size="sm">
+                          <Badge tone="warning" className="px-2 py-0.5 text-[10px]">
                             Modified
                           </Badge>
                         )}
@@ -214,7 +214,10 @@ export const UtilityPricing = ({ bridge }: UtilityPricingProps) => {
                         </span>
                         <span className="text-sm text-text-muted">{utility.unit}</span>
                         {hasChange && (
-                          <Badge variant={changePercent >= 0 ? 'warning' : 'success'} size="sm">
+                          <Badge
+                            tone={changePercent >= 0 ? 'warning' : 'success'}
+                            className="px-2 py-0.5 text-[10px]"
+                          >
                             {formatPercentage(changePercent)}
                           </Badge>
                         )}
@@ -304,8 +307,14 @@ export const UtilityPricing = ({ bridge }: UtilityPricingProps) => {
                 size="sm"
                 variant="primary"
                 onClick={handleSaveChanges}
-                loading={isUpdating}
-                icon={<Icon name="save" />}
+                disabled={isUpdating}
+                icon={
+                  isUpdating ? (
+                    <Icon name="autorenew" className="animate-spin text-primary-strong" size={18} />
+                  ) : (
+                    <Icon name="save" />
+                  )
+                }
               >
                 Save Changes
               </Button>


### PR DESCRIPTION
### **User description**
## Summary
- update UtilityPricing badges to use the supported tone styling API
- swap the Button loading prop for a disabled state with an inline spinner icon

## Testing
- pnpm --filter @weebbreed/frontend typecheck *(fails: pnpm is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d73a77ecd48325884fbba713118046


___

### **PR Type**
Bug fix


___

### **Description**
- Update Badge components to use `tone` prop instead of deprecated `variant`

- Replace Button `loading` prop with `disabled` state and custom spinner icon

- Add custom styling classes for consistent badge appearance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Badge variant prop"] -- "replace with" --> B["Badge tone prop"]
  C["Button loading prop"] -- "replace with" --> D["Button disabled + spinner icon"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UtilityPricing.tsx</strong><dd><code>Update Badge and Button prop usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/finance/UtilityPricing.tsx

<ul><li>Replace <code>variant</code> with <code>tone</code> prop in Badge components<br> <li> Add custom CSS classes for badge styling consistency<br> <li> Replace Button <code>loading</code> prop with <code>disabled</code> state<br> <li> Implement custom spinner icon with conditional rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/218/files#diff-8f3eb27d29796c44be7a90238dbae8e0f7443c929ea8a21c3f9902528961efe8">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

