### PR TITLE
Refine difficulty modifier range typing

### DIFF
--- a/src/frontend/src/components/modifiers/EnhancedModifierInputs.tsx
+++ b/src/frontend/src/components/modifiers/EnhancedModifierInputs.tsx
@@ -1,4 +1,4 @@
-import { DifficultyModifiers, MODIFIER_RANGES } from '../../types/difficulty';
+import { DifficultyModifiers, getModifierRange } from '../../types/difficulty';
 
 interface EnhancedModifierInputsProps {
   modifiers: DifficultyModifiers;
@@ -33,13 +33,13 @@ export const EnhancedModifierInputs = ({ modifiers, onChange }: EnhancedModifier
     label: string,
   ) => {
     const value = modifiers[category][key] as number;
-    const [min, max] = MODIFIER_RANGES[category][key] as [number, number];
+    const [min, max] = getModifierRange(category, key);
 
     const handleChange = (input: string) => {
       const parsed = parseFloat(input);
       if (!isNaN(parsed)) {
         const clamped = Math.max(min, Math.min(max, parsed));
-        updateModifier(category, key, clamped);
+        updateModifier(category, key, clamped as DifficultyModifiers[T][K]);
       }
     };
 
@@ -86,7 +86,7 @@ export const EnhancedModifierInputs = ({ modifiers, onChange }: EnhancedModifier
     label: string,
   ) => {
     const value = modifiers[category][key] as number;
-    const [min, max] = MODIFIER_RANGES[category][key] as [number, number];
+    const [min, max] = getModifierRange(category, key);
 
     const handleChange = (input: string) => {
       // Remove commas and parse
@@ -94,7 +94,7 @@ export const EnhancedModifierInputs = ({ modifiers, onChange }: EnhancedModifier
       const parsed = parseFloat(cleanInput);
       if (!isNaN(parsed)) {
         const clamped = Math.max(min, Math.min(max, parsed));
-        updateModifier(category, key, clamped);
+        updateModifier(category, key, clamped as DifficultyModifiers[T][K]);
       }
     };
 

--- a/src/frontend/src/components/modifiers/ModifierInputs.tsx
+++ b/src/frontend/src/components/modifiers/ModifierInputs.tsx
@@ -1,5 +1,5 @@
 //import { useState } from 'react';
-import { DifficultyModifiers, MODIFIER_RANGES } from '../../types/difficulty';
+import { DifficultyModifiers, getModifierRange } from '../../types/difficulty';
 
 interface ModifierInputsProps {
   modifiers: DifficultyModifiers;
@@ -54,7 +54,7 @@ export const ModifierInputs = ({ modifiers, onChange }: ModifierInputsProps) => 
     step: number = 0.01,
   ) => {
     const value = modifiers[category][key] as number;
-    const [min, max] = MODIFIER_RANGES[category][key] as [number, number];
+    const [min, max] = getModifierRange(category, key);
 
     return (
       <div className="grid gap-1">
@@ -68,7 +68,9 @@ export const ModifierInputs = ({ modifiers, onChange }: ModifierInputsProps) => 
             max={max}
             step={step}
             value={value}
-            onChange={(e) => updateModifier(category, key, Number(e.target.value))}
+            onChange={(e) =>
+              updateModifier(category, key, Number(e.target.value) as DifficultyModifiers[T][K])
+            }
             className="flex-1 accent-primary"
           />
           <span className="text-xs font-mono text-text-muted min-w-16 text-right">

--- a/src/frontend/src/types/difficulty.ts
+++ b/src/frontend/src/types/difficulty.ts
@@ -25,24 +25,13 @@ export interface DifficultyConfig {
   [key: string]: DifficultyPreset;
 }
 
-export interface ModifierRanges {
-  plantStress: {
-    optimalRangeMultiplier: [number, number];
-    stressAccumulationMultiplier: [number, number];
+export type ModifierRanges = {
+  [T in keyof DifficultyModifiers]: {
+    [K in keyof DifficultyModifiers[T]]: readonly [number, number];
   };
-  deviceFailure: {
-    mtbfMultiplier: [number, number];
-  };
-  economics: {
-    initialCapital: [number, number];
-    itemPriceMultiplier: [number, number];
-    harvestPriceMultiplier: [number, number];
-    rentPerSqmStructurePerTick: [number, number];
-    rentPerSqmRoomPerTick: [number, number];
-  };
-}
+};
 
-export const MODIFIER_RANGES: ModifierRanges = {
+export const MODIFIER_RANGES = {
   plantStress: {
     optimalRangeMultiplier: [0.5, 1.5],
     stressAccumulationMultiplier: [0.5, 1.5],
@@ -57,4 +46,9 @@ export const MODIFIER_RANGES: ModifierRanges = {
     rentPerSqmStructurePerTick: [0.1, 1.5],
     rentPerSqmRoomPerTick: [0.1, 1.5],
   },
-};
+} as const satisfies ModifierRanges;
+
+export const getModifierRange = <T extends keyof ModifierRanges, K extends keyof ModifierRanges[T]>(
+  category: T,
+  key: K,
+): ModifierRanges[T][K] => MODIFIER_RANGES[category][key];


### PR DESCRIPTION
## Summary
- derive modifier range typing directly from `DifficultyModifiers` and expose a helper to read ranges
- update difficulty modifier input components to use the shared range lookup instead of casting

## Testing
- pnpm --filter @weebbreed/frontend typecheck *(fails: existing missing dependency/type issues outside the modified files)*

------
https://chatgpt.com/codex/tasks/task_e_68d73b5259c083258293df3e30c18130