### PR TITLE
Fix applicant skill level normalisation

### DIFF
--- a/src/frontend/src/components/personnel/CandidateCard.tsx
+++ b/src/frontend/src/components/personnel/CandidateCard.tsx
@@ -10,6 +10,7 @@ import {
   formatSkillLevel,
   getRoleDisplayName,
   getGenderIcon,
+  normaliseSkillEntries,
 } from './utils';
 
 interface CandidateCardProps {
@@ -20,7 +21,11 @@ interface CandidateCardProps {
 export const CandidateCard = ({ applicant, className }: CandidateCardProps) => {
   const openModal = useUIStore((state) => state.openModal);
 
-  const skillEntries = Object.entries(applicant.skills).filter(([, level]) => level && level > 0);
+  const skillEntries = normaliseSkillEntries(applicant.skills);
+  const averageSkillLevel =
+    skillEntries.length > 0
+      ? skillEntries.reduce((sum, [, level]) => sum + level, 0) / skillEntries.length
+      : 0;
 
   return (
     <Card
@@ -136,14 +141,8 @@ export const CandidateCard = ({ applicant, className }: CandidateCardProps) => {
           {skillEntries.length > 0 && (
             <div className="flex items-center justify-between text-sm mt-1">
               <span className="text-text-muted">Avg. Level</span>
-              <Badge
-                tone={getSkillColor(
-                  skillEntries.reduce((sum, [, level]) => sum + level, 0) / skillEntries.length,
-                )}
-              >
-                {formatSkillLevel(
-                  skillEntries.reduce((sum, [, level]) => sum + level, 0) / skillEntries.length,
-                )}
+              <Badge tone={getSkillColor(averageSkillLevel)}>
+                {formatSkillLevel(averageSkillLevel)}
               </Badge>
             </div>
           )}

--- a/src/frontend/src/components/personnel/HireModal.tsx
+++ b/src/frontend/src/components/personnel/HireModal.tsx
@@ -10,6 +10,7 @@ import {
   formatSkillLevel,
   getRoleDisplayName,
   getGenderIcon,
+  normaliseSkillEntries,
 } from './utils';
 
 interface HireModalProps {
@@ -91,7 +92,7 @@ export const HireModal = ({ bridge, closeModal, context }: HireModalProps) => {
     }
   };
 
-  const skillEntries = Object.entries(applicant.skills).filter(([, level]) => level && level > 0);
+  const skillEntries = normaliseSkillEntries(applicant.skills);
   const averageSkillLevel =
     skillEntries.length > 0
       ? skillEntries.reduce((sum, [, level]) => sum + level, 0) / skillEntries.length

--- a/src/frontend/src/components/personnel/utils.ts
+++ b/src/frontend/src/components/personnel/utils.ts
@@ -1,3 +1,5 @@
+import type { ApplicantSnapshot } from '@/types/simulation';
+
 export const getSkillColor = (level: number): 'success' | 'warning' | 'danger' | 'default' => {
   if (level >= 8) return 'success';
   if (level >= 6) return 'warning';
@@ -64,4 +66,30 @@ export const getStatusColor = (status: string): 'success' | 'warning' | 'danger'
 
 export const formatStatusDisplay = (status: string): string => {
   return status.charAt(0).toUpperCase() + status.slice(1);
+};
+
+export type NormalisedSkillEntry = [skill: string, level: number];
+
+export const normaliseSkillEntries = (
+  skills: ApplicantSnapshot['skills'] | undefined,
+): NormalisedSkillEntry[] => {
+  const entries: NormalisedSkillEntry[] = [];
+
+  if (!skills) {
+    return entries;
+  }
+
+  for (const [skill, level] of Object.entries(skills)) {
+    if (typeof level !== 'number') {
+      continue;
+    }
+
+    if (!Number.isFinite(level) || level <= 0) {
+      continue;
+    }
+
+    entries.push([skill, level]);
+  }
+
+  return entries;
 };


### PR DESCRIPTION
## Summary
- add a shared helper to normalise applicant skill entries to finite numeric values
- use the helper in CandidateCard and HireModal so skill badges and averages always receive numbers

## Testing
- pnpm run check *(fails: @eslint/js missing in lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d73c89310c8325b5d8b51cbe5cafc9