### PR TITLE
Align refresh button size options with primitive button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the personnel refresh button with the shared button primitive by
+  removing the unsupported `lg` size option and matching the default variant
+  to the primitive configuration.
 - Updated the finance ProfitChart to read the finance summary snapshot safely
   and derive chart metrics from available totals instead of missing ledger
   entries.

--- a/src/frontend/src/components/personnel/RefreshButton.tsx
+++ b/src/frontend/src/components/personnel/RefreshButton.tsx
@@ -8,14 +8,14 @@ interface RefreshButtonProps {
   onRefreshComplete?: () => void;
   className?: string;
   variant?: 'primary' | 'secondary' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md';
 }
 
 export const RefreshButton = ({
   bridge,
   onRefreshComplete,
   className,
-  variant = 'secondary',
+  variant = 'primary',
   size = 'md',
 }: RefreshButtonProps) => {
   const [isRefreshing, setIsRefreshing] = useState(false);


### PR DESCRIPTION
## Summary
- remove the unsupported `lg` size option from the personnel refresh button props
- default the refresh button variant to match the shared button primitive defaults
- document the alignment in the changelog

## Testing
- pnpm run check *(fails: frontend lint misses @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d73d766e9083258e63193b8409506e