### PR TITLE
Harden seed generator config typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the frontend seed generator by typing `seed-config.json`, dropping
+  unused config overrides, routing weighted picks through the Mulberry32 RNG,
+  and enforcing blacklist lookups with `Set<string>` to keep deterministic name
+  generation aligned with the shipped configuration.
 - Aligned the personnel refresh button with the shared button primitive by
   removing the unsupported `lg` size option and matching the default variant
   to the primitive configuration.


### PR DESCRIPTION
### **User description**
## Summary
- define a SeedConfig interface that matches the shipped seed-config.json lexicon and templates
- update the seed generator to type the imported config, drop the unused generatedSeed toggle, and run weighted picks through the Mulberry32 RNG while using a Set-based blacklist
- document the determinism and typing adjustments in the changelog

## Testing
- pnpm run check *(fails: frontend lint requires @eslint/js which is not available in the workspace)*
- pnpm --filter @weebbreed/frontend typecheck *(fails: workspace is missing several optional frontend dev dependencies such as @testing-library/react and clsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d73e35bbe88325bafddab53edb1251


___

### **PR Type**
Enhancement


___

### **Description**
- Define typed `SeedConfig` interface for seed-config.json

- Route weighted picks through Mulberry32 RNG for determinism

- Remove unused `generatedSeed` config toggle

- Use `Set<string>` for blacklist lookups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON Config"] --> B["Typed SeedConfig Interface"]
  B --> C["Mulberry32 RNG"]
  C --> D["Weighted Selection"]
  D --> E["Deterministic Seeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seedGenerator.ts</strong><dd><code>Type seed config and enforce deterministic RNG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/utils/seedGenerator.ts

<ul><li>Define <code>SeedConfig</code>, <code>SeedLexicon</code>, and <code>Template</code> interfaces<br> <li> Remove unused <code>generatedSeed</code> config handling<br> <li> Route <code>pickWeighted</code> and <code>chooseTemplate</code> through Mulberry32 RNG<br> <li> Add error handling for empty lexicons and templates<br> <li> Use <code>Set<string></code> for blacklist instead of array</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/222/files#diff-d106db9b5daccd5bd2b6410c99f1f313134dcc9488e9763890dd5a8538bf5864">+68/-39</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document seed generator improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document seed generator hardening improvements<br> <li> Note typing, RNG routing, and blacklist changes</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/222/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

