### PR TITLE
Refine command failure helpers with generics

### DIFF
--- a/src/backend/src/engine/devices/deviceGroupService.ts
+++ b/src/backend/src/engine/devices/deviceGroupService.ts
@@ -111,7 +111,7 @@ export class DeviceGroupService {
     return generateId(this.taskStream, 'task');
   }
 
-  private failure(code: ErrorCode, message: string, path: string[]): CommandResult {
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
       errors: [
@@ -121,7 +121,7 @@ export class DeviceGroupService {
           path,
         },
       ],
-    } satisfies CommandResult;
+    };
   }
 }
 

--- a/src/backend/src/engine/plants/plantingPlanService.ts
+++ b/src/backend/src/engine/plants/plantingPlanService.ts
@@ -95,7 +95,7 @@ export class PlantingPlanService {
     return generateId(this.taskStream, 'task');
   }
 
-  private failure(code: ErrorCode, message: string, path: string[]): CommandResult {
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
       errors: [
@@ -105,7 +105,7 @@ export class PlantingPlanService {
           path,
         },
       ],
-    } satisfies CommandResult;
+    };
   }
 }
 

--- a/src/backend/src/engine/world/worldService.ts
+++ b/src/backend/src/engine/world/worldService.ts
@@ -1010,7 +1010,7 @@ export class WorldService {
     return generateId(this.idStream, prefix);
   }
 
-  private failure(code: ErrorCode, message: string, path: string[]): CommandResult {
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
       errors: [
@@ -1020,7 +1020,7 @@ export class WorldService {
           path,
         },
       ],
-    } satisfies CommandResult;
+    };
   }
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- make `createFailure`, `handleValidationError`, and `handleCommandError` generic so command results preserve their data types
- update device, planting plan, and world service helpers to return typed `CommandResult` failures

## Testing
- pnpm --filter @weebbreed/backend typecheck *(fails: existing type errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d74c6b2f4083259c6eb04b510ab5b0


___

### **PR Type**
Enhancement


___

### **Description**
- Add generic type parameters to command failure helpers

- Update service classes to return typed `CommandResult` failures

- Improve type safety for command error handling functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command Helpers"] -- "Add generics" --> B["createFailure<T>"]
  A -- "Add generics" --> C["handleValidationError<T>"]
  A -- "Add generics" --> D["handleCommandError<T>"]
  E["Service Classes"] -- "Update failure methods" --> F["Typed CommandResult<T>"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deviceGroupService.ts</strong><dd><code>Add generic type to failure method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/devices/deviceGroupService.ts

<ul><li>Add generic type parameter <code><T = never></code> to <code>failure</code> method<br> <li> Update return type to <code>CommandResult<T></code><br> <li> Remove <code>satisfies CommandResult</code> assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/225/files#diff-98542c71b855a16be4a9810838666442f0be18c15dccb9488c807db3b7fc2662">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plantingPlanService.ts</strong><dd><code>Add generic type to failure method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/plants/plantingPlanService.ts

<ul><li>Add generic type parameter <code><T = never></code> to <code>failure</code> method<br> <li> Update return type to <code>CommandResult<T></code><br> <li> Remove <code>satisfies CommandResult</code> assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/225/files#diff-b71a21ebfbf111530c2f84961cf8ed1a070a2a0e31dc2793ed3f6b2baad76f07">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worldService.ts</strong><dd><code>Add generic type to failure method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/world/worldService.ts

<ul><li>Add generic type parameter <code><T = never></code> to <code>failure</code> method<br> <li> Update return type to <code>CommandResult<T></code><br> <li> Remove <code>satisfies CommandResult</code> assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/225/files#diff-0f448a14ac57d61b6f39b36cc348a413f5c35b3167b2de38d3880fc0819bcc78">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commandRegistry.ts</strong><dd><code>Add generics to command error helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/facade/commands/commandRegistry.ts

<ul><li>Add generic type parameters to <code>createFailure</code>, <code>handleValidationError</code>, <br>and <code>handleCommandError</code><br> <li> Update function signatures to return <code>CommandResult<T></code><br> <li> Refactor function implementations to use generic types<br> <li> Update internal function calls to pass generic type parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/225/files#diff-b63f9890ed8fea8af29d87dee656644a26642da708b715f3a830d69204933256">+18/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

