### PR TITLE
Add labor profile hours to cultivation method schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extended cultivation method labor modelling by accepting optional
+  `laborProfile.hoursPerPlantPerWeek` in blueprints and teaching the
+  compatibility service to honor the value while retaining safe defaults.
 - Clarified simulation constant authoring guidance in `AGENTS.md` and `/docs/constants/physiology.md`, pointing to ADR 0009 on constant stewardship.
 - Refactored the simulation loop to delegate tick-state orchestration and accounting flows to dedicated modules with updated tests safeguarding the phase order.
 - Centralized shared plant physiology coefficients (Magnus, canopy conductance, photon conversions) in `@/constants/physiology` and documented the module.

--- a/data/blueprints/cultivationMethods/basic_soil_pot.json
+++ b/data/blueprints/cultivationMethods/basic_soil_pot.json
@@ -4,6 +4,9 @@
   "name": "Basic Soil Pot",
   "setupCost": 2.0,
   "laborIntensity": 0.1,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 0.35
+  },
   "areaPerPlant": 0.5,
   "minimumSpacing": 0.5,
   "maxCycles": 1,

--- a/data/blueprints/cultivationMethods/scrog.json
+++ b/data/blueprints/cultivationMethods/scrog.json
@@ -4,6 +4,9 @@
   "name": "Screen of Green",
   "setupCost": 15.0,
   "laborIntensity": 0.7,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 1.2
+  },
   "areaPerPlant": 1.0,
   "minimumSpacing": 0.8,
   "maxCycles": 4,

--- a/data/blueprints/cultivationMethods/sog.json
+++ b/data/blueprints/cultivationMethods/sog.json
@@ -4,6 +4,9 @@
   "name": "Sea of Green",
   "setupCost": 10.0,
   "laborIntensity": 0.4,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 0.65
+  },
   "areaPerPlant": 0.25,
   "minimumSpacing": 0.25,
   "maxCycles": 2,

--- a/src/backend/src/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/src/data/schemas/cultivationMethodSchema.ts
@@ -61,6 +61,12 @@ export const cultivationMethodSchema = z
         canopyHeight_m: z.number().positive(),
       })
       .optional(),
+    laborProfile: z
+      .object({
+        hoursPerPlantPerWeek: z.number().nonnegative(),
+      })
+      .passthrough()
+      .optional(),
     idealConditions: z
       .object({
         idealTemperature: rangeTuple.optional(),

--- a/src/backend/src/engine/cultivation/methodCompatibilityService.ts
+++ b/src/backend/src/engine/cultivation/methodCompatibilityService.ts
@@ -143,7 +143,7 @@ export class MethodCompatibilityService {
     strain: EnhancedStrainBlueprint,
     method: CultivationMethodBlueprint,
   ): { score: number; details: { methodHours: number; strainTolerance: number } } {
-    const methodHours = method.laborProfile?.hoursPerPlantPerWeek || 0.5;
+    const methodHours = this.resolveMethodLaborHours(method);
 
     // Estimate strain labor tolerance based on resilience and method affinity
     const strainResilience = strain.generalResilience || 0.7;
@@ -172,6 +172,20 @@ export class MethodCompatibilityService {
         strainTolerance,
       },
     };
+  }
+
+  private resolveMethodLaborHours(method: CultivationMethodBlueprint): number {
+    const profileHours = method.laborProfile?.hoursPerPlantPerWeek;
+    if (typeof profileHours === 'number' && Number.isFinite(profileHours)) {
+      return Math.max(0, profileHours);
+    }
+
+    const intensity = method.laborIntensity;
+    if (typeof intensity === 'number' && Number.isFinite(intensity)) {
+      return Math.max(0.5, intensity);
+    }
+
+    return 0.5;
   }
 
   /**


### PR DESCRIPTION
## Summary
- extend the cultivation method schema with an optional laborProfile.hoursPerPlantPerWeek field and document the change
- teach labor fit scoring to honour blueprint-provided labor hours while retaining safe defaults when data is missing
- populate cultivation method fixtures with representative laborProfile values

## Testing
- pnpm run check *(fails: @eslint/js is not installed for the frontend lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d750afe22c8325986dc785fadd5407