### PR TITLE
Re-export schema blueprint and runtime types from state models

### DIFF
--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 
 import { readJsonFile } from './initialization/common.js';
 
+export type { CultivationMethodBlueprint } from '@/data/schemas/cultivationMethodSchema.js';
+export type { DeviceBlueprint } from '@/data/schemas/deviceSchema.js';
+export type { SimulationEvent } from '@runtime/eventBusCore.js';
+export type { TimeStatus } from '@/facade/commands/time.js';
+
 /**
  * Core TypeScript interfaces for the simulation game state.
  * These structures intentionally mirror the blueprint driven domain model


### PR DESCRIPTION
### **User description**
## Summary
- re-export the schema-derived blueprint types along with SimulationEvent and TimeStatus through `state/models.ts` to centralize consumption points

## Testing
- pnpm --filter @weebbreed/backend typecheck *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d753fefc3c832582678ac0b3614cc8


___

### **PR Type**
Other


___

### **Description**
- Re-export blueprint types from schema modules

- Re-export runtime types for centralized access

- Consolidate type imports through state models


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schemas["Schema Modules"] --> models["state/models.ts"]
  runtime["Runtime Modules"] --> models
  models --> consumers["Type Consumers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.ts</strong><dd><code>Add type re-exports for blueprint and runtime types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/state/models.ts

<ul><li>Added re-exports for <code>CultivationMethodBlueprint</code> and <code>DeviceBlueprint</code> <br>types<br> <li> Added re-exports for <code>SimulationEvent</code> and <code>TimeStatus</code> runtime types<br> <li> Centralized type access point for external consumers</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/228/files#diff-4add87c1e2455a661c8c58aace322947b293e58cd6654203a03ba1a2c3f46686">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

