### PR TITLE
Ensure active task is defined before currentTaskId assertion

### DIFF
--- a/src/backend/src/engine/workforce/workforceIntegration.test.ts
+++ b/src/backend/src/engine/workforce/workforceIntegration.test.ts
@@ -257,10 +257,19 @@ describe('workforce integration', () => {
 
     expect(state.tasks.active).toHaveLength(1);
     const activeTask = state.tasks.active[0];
-    expect(activeTask?.assignment?.employeeId).toBe('emp-night');
+    expect(activeTask).toBeDefined();
+    if (!activeTask) {
+      throw new Error('Expected active task to be defined');
+    }
+    expect(activeTask.assignment?.employeeId).toBe('emp-night');
     expect(state.personnel.employees.find((emp) => emp.id === 'emp-day')?.status).toBe('offShift');
+    const activeTaskForCurrentTaskCheck = state.tasks.active[0];
+    expect(activeTaskForCurrentTaskCheck).toBeDefined();
+    if (!activeTaskForCurrentTaskCheck) {
+      throw new Error('Expected active task for current task check to be defined');
+    }
     expect(state.personnel.employees.find((emp) => emp.id === 'emp-night')?.currentTaskId).toBe(
-      activeTask?.id,
+      activeTaskForCurrentTaskCheck.id,
     );
     expect(state.tasks.backlog).toHaveLength(0);
   });


### PR DESCRIPTION
### **User description**
## Summary
- safeguard the workforce integration test by ensuring the active task is defined before dereferencing its fields
- cache the active task lookup immediately prior to the currentTaskId assertion to prevent undefined dereferences

## Testing
- pnpm --filter backend test -- src/engine/workforce/workforceIntegration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d75cf5293c8325a244809cfc8d6008


___

### **PR Type**
Tests


___

### **Description**
- Add null checks for active task before property access

- Prevent undefined reference errors in workforce integration test

- Cache active task lookup with proper validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test execution"] --> B["Check active task exists"]
  B --> C["Validate task is defined"]
  C --> D["Access task properties safely"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workforceIntegration.test.ts</strong><dd><code>Add null safety for active task access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/workforce/workforceIntegration.test.ts

<ul><li>Add <code>toBeDefined()</code> assertions for active task<br> <li> Include null checks with error throwing for undefined tasks<br> <li> Cache active task lookup before <code>currentTaskId</code> assertion<br> <li> Replace optional chaining with safe property access</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/233/files#diff-22cf8aab0179e5a9aa37d3babb081fe475597ac8fe5e1f2dca9c396ad8b2b629">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

