### PR TITLE
Fix workforce handover test assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused config overrides, routing weighted picks through the Mulberry32 RNG,
   and enforcing blacklist lookups with `Set<string>` to keep deterministic name
   generation aligned with the shipped configuration.
+- Corrected the workforce shift handover integration test to assert the night
+  shift technician remains assigned to the active maintenance task after the
+  handover.
 - Aligned the personnel refresh button with the shared button primitive by
   removing the unsupported `lg` size option and matching the default variant
   to the primitive configuration.

--- a/src/backend/src/engine/workforce/workforceIntegration.test.ts
+++ b/src/backend/src/engine/workforce/workforceIntegration.test.ts
@@ -265,7 +265,7 @@ describe('workforce integration', () => {
     expect(currentTask.assignment?.employeeId).toBe('emp-night');
     expect(state.personnel.employees.find((emp) => emp.id === 'emp-day')?.status).toBe('offShift');
     expect(state.personnel.employees.find((emp) => emp.id === 'emp-night')?.currentTaskId).toBe(
-      activeTask?.id,
+      currentTask.id,
     );
     expect(state.tasks.backlog).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- fix the workforce shift handover integration test to assert the night shift technician stays on the active task using a defined identifier
- document the regression fix in the changelog

## Testing
- pnpm --filter @weebbreed/backend test -- workforceIntegration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7640c42188325a52ae5b65342cbd0