### PR TITLE
Adjust default tick cadence to five minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Shortened the default simulation tick length to 5 minutes (down from 60),
+  exposing shared timekeeping constants for the scheduler/state factory and
+  updating documentation to reflect the faster cadence.
 - Typed strain growth model harvest index and temperature metadata, wiring the
   schema defaults into the plant model and refreshing strain blueprints with
   curated coefficients for Q10, reference temperature, and flowering harvest

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -92,7 +92,7 @@
 
 ### Personnel & Labor Market
 
-- **Weekly refresh** of the candidate pool (e.g., every 168 ticks).
+- **Weekly refresh** of the candidate pool (e.g., every 2202f016 ticks).
 - **Seeded external name [provider][username.me]** (results & `inc=name` only) to generate **deterministic** candidate names from `apiSeed = "{gameSeed}-week-{weekIndex}"`.
 - **Fallback** to `/data/personnel/` when offline/unavailable.
 - **Profile synthesis**: for each candidate, generate `skills`, `traits`, and `hourlyWage` from balancing rules (deterministic when seeded).

--- a/docs/_extraction/formulas.md
+++ b/docs/_extraction/formulas.md
@@ -170,10 +170,10 @@ revenue = harvestBasePricePerGram × modifiers
 - Source: docs/system/job_market_population.md#weekly-refresh-lifecycle (L16)
 - Heading: Weekly Refresh Lifecycle
 
-> `Math.floor(tick / 168)` (168 ticks ≈ 1 simulated week when 1 tick = 1 hour).
+> `Math.floor(tick / 2016)` (2 016 ticks ≈ 1 simulated week at the 5-minute default cadence).
 
 ```math
-Math.floor(tick / 168)
+Math.floor(tick / 2016)
 ```
 
 ## F-0017 — Seeding

--- a/docs/_extraction/formulas_index.json
+++ b/docs/_extraction/formulas_index.json
@@ -182,13 +182,13 @@
   {
     "id": "F-0016",
     "topic": "Scheduler",
-    "formula": "Math.floor(tick / 168)",
+    "formula": "Math.floor(tick / 2016)",
     "sourcePath": "docs/system/job_market_population.md",
     "heading": "Weekly Refresh Lifecycle",
     "anchor": "weekly-refresh-lifecycle",
     "startLine": 16,
     "endLine": 16,
-    "context": "`Math.floor(tick / 168)` (168 ticks ≈ 1 simulated week when 1 tick = 1 hour).",
+    "context": "`Math.floor(tick / 2016)` (2\u202f016 ticks \u2248 1 simulated week at the 5-minute default cadence).",
     "glossary": []
   },
   {

--- a/docs/_final/05-math-formulas-overview.md
+++ b/docs/_final/05-math-formulas-overview.md
@@ -42,7 +42,7 @@
 
 ## Scheduler & Seeding
 
-- `Math.floor(tick / 168)`【F:docs/\_extraction/formulas.md†L168-L177】
+- `Math.floor(tick / 2016)`【F:docs/\_extraction/formulas.md†L168-L177】
 - `apiSeed = override ?? "<gameSeed>-<weekIndex>"`【F:docs/\_extraction/formulas.md†L179-L188】
 - `accumulatedMs += now - lastNow`【F:docs/\_extraction/formulas.md†L212-L221】
 - `accumulatedMs ≥ tickIntervalMs / gameSpeed`【F:docs/\_extraction/formulas.md†L223-L232】

--- a/docs/_final/11-open-questions.md
+++ b/docs/_final/11-open-questions.md
@@ -3,6 +3,6 @@
 - **First Harvest Time:** First harvest in **< 30 minutes** of play (MVP default setup). _(OPEN: validate)_【F:docs/vision_scope.md†L55-L56】
 - **Retention Proxy:** 70% of players reach day 7 of a sandbox save. _(OPEN: measure)_【F:docs/vision_scope.md†L55-L57】
 - **Memory Target:** Reference scenario uses < **1.0 GB RAM**. _(OPEN: finalize)_【F:docs/vision_scope.md†L61-L64】
-- **Time Scale.** Tick-based with fixed tick duration: **1 tick = 1 in-game hour**; **24 ticks = 1 in-game day**, **7×24 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
+- **Time Scale.** Tick-based with fixed tick duration: **default tick length = 5 in-game minutes**; **12 ticks = 1 in-game hour**, **288 ticks = 1 in-game day**, **7×288 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
 - **v1 Scope (Targets):** \~8–12 strains, \~10–15 devices, 2–3 cultivation methods, basic pests/diseases, treatments. _(OPEN: finalize list)_【F:docs/vision_scope.md†L214-L218】
 - **Open-Source Strategy:** License model (e.g., AGPL/Polyform?); contributions via PR policy, CLA. _(OPEN: decide)_【F:docs/vision_scope.md†L254-L257】

--- a/docs/constants/time.md
+++ b/docs/constants/time.md
@@ -1,0 +1,19 @@
+# Timekeeping Defaults
+
+> These values anchor the simulation's default cadence and provide shared
+> conversions for systems that scale behaviour with tick length.
+
+| Constant                      | Default       | Rationale                                                                                                                      |
+| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `MINUTES_PER_HOUR`            | `60` minutes  | Canonical minutes-per-hour conversion used across scheduling maths.                                                            |
+| `HOURS_PER_DAY`               | `24` hours    | Standard day length for aggregating tick metrics.                                                                              |
+| `DAYS_PER_MONTH`              | `30` days     | Baseline month length for maintenance and finance rollups.                                                                     |
+| `DEFAULT_TICK_LENGTH_MINUTES` | `5` minutes   | Default simulated minutes advanced per tick, keeping within the documented 1–10 minute guidance for responsive gameplay loops. |
+| `DEFAULT_TICK_INTERVAL_MS`    | `300 000` ms  | Millisecond interval corresponding to the default tick cadence at 1×.                                                          |
+| `DEFAULT_TICKS_PER_HOUR`      | `12` ticks    | Number of ticks executed during one simulated hour at the default cadence.                                                     |
+| `DEFAULT_TICKS_PER_DAY`       | `288` ticks   | One simulated day (24 hours) represented at the default tick length.                                                           |
+| `DEFAULT_TICKS_PER_MONTH`     | `8 640` ticks | Thirty simulated days worth of ticks at the default cadence; reused by maintenance scheduling.                                 |
+
+All time-sensitive subsystems (scheduler, accounting, maintenance) should source
+these constants to avoid desynchronised assumptions when the default cadence
+changes.

--- a/docs/constants/world.md
+++ b/docs/constants/world.md
@@ -8,12 +8,12 @@ zone and the recurring maintenance cadence. These values align engine behaviours
 (`stateFactory`, `WorldService`) and prevent drift between initialization and
 runtime management flows.
 
-| Constant                             | Default         | Rationale                                                                                                                                                                    |
-| ------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DEFAULT_ZONE_RESERVOIR_LEVEL`       | `0.75`          | New reservoirs launch three-quarters full so irrigation controllers have working volume while still leaving headroom for rapid top-offs or rain events triggered by devices. |
-| `DEFAULT_ZONE_WATER_LITERS`          | `800` litres    | Provides roughly a week of transpiration supply for a mid-vegetative canopy before automated refills need to trigger.                                                        |
-| `DEFAULT_ZONE_NUTRIENT_LITERS`       | `400` litres    | Mirrors the water allocation while assuming a 50 % nutrient dilution plan, allowing alternating water/feed cycles without immediate mixing.                                  |
-| `DEFAULT_MAINTENANCE_INTERVAL_TICKS` | `24 * 30` ticks | Schedules routine device servicing every in-game month (24 hourly ticks per day × 30 days), matching the finance model's maintenance accrual cadence.                        |
+| Constant                             | Default                                 | Rationale                                                                                                                                                                    |
+| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_ZONE_RESERVOIR_LEVEL`       | `0.75`                                  | New reservoirs launch three-quarters full so irrigation controllers have working volume while still leaving headroom for rapid top-offs or rain events triggered by devices. |
+| `DEFAULT_ZONE_WATER_LITERS`          | `800` litres                            | Provides roughly a week of transpiration supply for a mid-vegetative canopy before automated refills need to trigger.                                                        |
+| `DEFAULT_ZONE_NUTRIENT_LITERS`       | `400` litres                            | Mirrors the water allocation while assuming a 50 % nutrient dilution plan, allowing alternating water/feed cycles without immediate mixing.                                  |
+| `DEFAULT_MAINTENANCE_INTERVAL_TICKS` | `DEFAULT_TICKS_PER_MONTH` (8 640 ticks) | Schedules routine device servicing every in-game month (30 days). Uses the default 5-minute tick length (288 ticks/day) to keep maintenance aligned with finance accruals.   |
 
 Referencing these constants ensures all world management flows respect the same
 default resource budgets and maintenance timeline.

--- a/docs/system/employees.md
+++ b/docs/system/employees.md
@@ -15,8 +15,8 @@ directory populated.
 
 To keep the labor market dynamic and credible, the game continuously injects new, unique candidates. Rather than relying only on a fixed local name list, the game **optionally** queries a **seedable external name provider** (e.g., an API that returns first/last names) and falls back to local data if unavailable. An free and open provider is https://randomuser.me/. For detailed information about the API, check the providers documentation.
 
-- **Periodic refresh**  
-   Once per in-game week (e.g., every **168 ticks** if 1 tick = 1 hour), refresh the candidate pool.
+- **Periodic refresh**
+  Once per in-game week (e.g., every **2 016 ticks** with the 5-minute default cadence), refresh the candidate pool.
 - **Deterministic, efficient fetch**  
    Use an endpoint that accepts `results` (e.g., 12), `inc=name` (only first/last names), and a deterministic `seed`.
   - **Seed construction**: derive `apiSeed` from the game’s original seed + current in-game week index, e.g.  
@@ -68,9 +68,9 @@ Work is modeled as **discrete Tasks** rather than continuous processes.
 
 Overtime is directly tied to **employee energy**.
 
-- **Trigger**  
-   Employees have **energy** in the range `0..100`. Each hour (tick) of work consumes energy.  
-   An employee **always finishes the current task**, even if their energy dips **below 0** during execution. Any negative energy at completion counts as **overtime**.
+- **Trigger**
+  Employees have **energy** in the range `0..100`. Each tick (≈5 minutes at default cadence) of work consumes energy.
+  An employee **always finishes the current task**, even if their energy dips **below 0** during execution. Any negative energy at completion counts as **overtime**.
 - **Computation**  
    At task completion, convert the **magnitude of negative energy** into **overtime hours** (ticks). Energy is then clamped/reset according to rest policy.
 - **Compensation policy (player-defined)**  
@@ -99,7 +99,7 @@ Overtime is directly tied to **employee energy**.
 
 ## Hiring / Candidate Source
 
-- `hiring.candidateRefreshIntervalTicks: number` — e.g., `168`.
+- `hiring.candidateRefreshIntervalTicks: number` — e.g., `2016` at the 5-minute default cadence.
 - `hiring.externalNameProvider.enabled: boolean` — on/off.
 - `hiring.externalNameProvider.results: number` — e.g., `12`.
 - `hiring.externalNameProvider.includeFields: string[]` — e.g., `["name"]`.

--- a/docs/system/job_market_population.md
+++ b/docs/system/job_market_population.md
@@ -13,7 +13,7 @@ strategy, and operator-facing configuration levers.
   on the simulation loop’s `commit` phase so the job market refresh runs right
   after a tick is committed.
 - **Tick-based cadence.** The service derives the in-game week with
-  `Math.floor(tick / 168)` (168 ticks ≈ 1 simulated week when 1 tick = 1 hour).
+  `Math.floor(tick / 2016)` (2 016 ticks ≈ 1 simulated week at the 5-minute default cadence).
   A refresh is attempted whenever the derived week changes or the applicant pool
   is empty.
 - **Idempotence guard.** Within the same week the service short-circuits if the
@@ -159,7 +159,7 @@ HTTP support is disabled or `fetch` is unavailable.
 | `batchSize`      | 12               | Number of candidates requested per refresh (`results` query param).                                                                   |
 | `maxRetries`     | 2                | Maximum remote fetch attempts before falling back to offline generation.                                                              |
 | `httpEnabled`    | `true`           | Feature toggle; disabled automatically when `fetch` is unavailable or the environment flag below is set.                              |
-| `TICKS_PER_WEEK` | 168              | Interval between automatic refreshes (commit hook compares `tick / 168`).                                                             |
+| `TICKS_PER_WEEK` | 2 016            | Interval between automatic refreshes (commit hook compares `tick / 2016`).                                                            |
 | `fetchImpl`      | global `fetch`   | Injectable fetch implementation for tests or alternative transports.                                                                  |
 | `dataDirectory`  | resolved at boot | Source for personnel names/traits used during offline fallback.                                                                       |
 | `pDiverse`       | 0.1              | Probability that a candidate is assigned the `other` gender; the remaining probability is split evenly between male and female draws. |

--- a/docs/system/simulation_philosophy.md
+++ b/docs/system/simulation_philosophy.md
@@ -5,7 +5,7 @@ This section details the core design philosophies that underpin each major subsy
 ## 1. Time & Simulation Loop: Stability and Fairness
 
 - **Philosophy**: The game world must be predictable and fair, progressing at a constant rate regardless of the user's hardware. A simulation's integrity depends on its timekeeping.
-- **Implementation Rationale**: It is important to decouple the simulation's "tick rate" from the UI's "frame rate". A tick represents a fixed unit of game time (1 hour), ensuring that a player on a 144Hz monitor experiences the same game progression as a player on a 60Hz monitor. The "catch-up" mechanism, which limits ticks per frame, embodies a user-centric philosophy: **responsiveness is more important than perfect simulation.** The game will never freeze the UI to catch up; it will instead fast-forward gracefully, maintaining a fluid player experience.
+- **Implementation Rationale**: It is important to decouple the simulation's "tick rate" from the UI's "frame rate". A tick represents a fixed unit of game time (default 5 minutes), ensuring that a player on a 144Hz monitor experiences the same game progression as a player on a 60Hz monitor. The "catch-up" mechanism, which limits ticks per frame, embodies a user-centric philosophy: **responsiveness is more important than perfect simulation.** The game will never freeze the UI to catch up; it will instead fast-forward gracefully, maintaining a fluid player experience.
 - **Example**: In a browser-based tech-stack we probably would use a `requestAnimationFrame` loop with a time accumulator instead of `setInterval`.
 
 ## 2. Environmental Model: Emergent Complexity from Simple Rules

--- a/docs/vision_scope.md
+++ b/docs/vision_scope.md
@@ -58,7 +58,7 @@
 
 **Quality Goals/SLOs.**
 
-- **Performance:** Reference scenario (see below) runs at **1× speed** with **≥ 1 tick/s** (1 in-game day in ≤ 24 s). Per-tick CPU budget ≤ **50 ms**.
+- **Performance:** Reference scenario (see below) runs at **1× speed** with **≥ 1 tick/s** (1 in-game day in ≤ 4.8 min at the 5 min tick default). Per-tick CPU budget ≤ **50 ms**.
 - **Stability:** No sim deadlocks; crash recovery without data loss (< 1 tick).
 - **Memory Target:** Reference scenario uses < **1.0 GB RAM**. _(OPEN: finalize)_
 
@@ -92,7 +92,7 @@
 - **Plant:** Seed → Vegetative → Flowering → Harvest → Post-harvest (drying/curing).
 - **Device:** Efficiency degradation, maintenance, replacement triggers (OpEx vs CapEx tipping points).
 
-**Time Scale.** Tick-based with fixed tick duration: **1 tick = 1 in-game hour**; **24 ticks = 1 in-game day**, **7×24 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_
+**Time Scale.** Tick-based with fixed tick duration: **default tick length = 5 in-game minutes**; **12 ticks = 1 in-game hour**, **288 ticks = 1 in-game day**, **7×288 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_
 
 **Glossary (Excerpt).**
 

--- a/docs/weedbreed-final-truth.backup.md
+++ b/docs/weedbreed-final-truth.backup.md
@@ -100,7 +100,7 @@
 
 ### Scheduler & Seeding
 
-- `Math.floor(tick / 168)`【F:docs/\_extraction/formulas.md†L168-L177】
+- `Math.floor(tick / 2016)`【F:docs/\_extraction/formulas.md†L168-L177】
 - `apiSeed = override ?? "<gameSeed>-<weekIndex>"`【F:docs/\_extraction/formulas.md†L179-L188】
 - `accumulatedMs += now - lastNow`【F:docs/\_extraction/formulas.md†L212-L221】
 - `accumulatedMs ≥ tickIntervalMs / gameSpeed`【F:docs/\_extraction/formulas.md†L223-L232】
@@ -187,7 +187,7 @@
 - **First Harvest Time:** First harvest in **< 30 minutes** of play (MVP default setup). _(OPEN: validate)_【F:docs/vision_scope.md†L55-L56】
 - **Retention Proxy:** 70% of players reach day 7 of a sandbox save. _(OPEN: measure)_【F:docs/vision_scope.md†L55-L57】
 - **Memory Target:** Reference scenario uses < **1.0 GB RAM**. _(OPEN: finalize)_【F:docs/vision_scope.md†L61-L64】
-- **Time Scale.** Tick-based with fixed tick duration: **1 tick = 1 in-game hour**; **24 ticks = 1 in-game day**, **7×24 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
+- **Time Scale.** Tick-based with fixed tick duration: **default tick length = 5 in-game minutes**; **12 ticks = 1 in-game hour**, **288 ticks = 1 in-game day**, **7×288 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
 - **v1 Scope (Targets):** \~8–12 strains, \~10–15 devices, 2–3 cultivation methods, basic pests/diseases, treatments. _(OPEN: finalize list)_【F:docs/vision_scope.md†L214-L218】
 - **Open-Source Strategy:** License model (e.g., AGPL/Polyform?); contributions via PR policy, CLA. _(OPEN: decide)_【F:docs/vision_scope.md†L254-L257】
 

--- a/docs/weedbreed-final-truth.md
+++ b/docs/weedbreed-final-truth.md
@@ -100,7 +100,7 @@
 
 ### Scheduler & Seeding
 
-- `Math.floor(tick / 168)`【F:docs/\_extraction/formulas.md†L168-L177】
+- `Math.floor(tick / 2016)`【F:docs/\_extraction/formulas.md†L168-L177】
 - `apiSeed = override ?? "<gameSeed>-<weekIndex>"`【F:docs/\_extraction/formulas.md†L179-L188】
 - `accumulatedMs += now - lastNow`【F:docs/\_extraction/formulas.md†L212-L221】
 - `accumulatedMs ≥ tickIntervalMs / gameSpeed`【F:docs/\_extraction/formulas.md†L223-L232】
@@ -499,7 +499,7 @@ Core formula references used for v1 arcade model (transpiration, photosynthesis,
 - **First Harvest Time:** First harvest in **< 30 minutes** of play (MVP default setup). _(OPEN: validate)_【F:docs/vision_scope.md†L55-L56】
 - **Retention Proxy:** 70% of players reach day 7 of a sandbox save. _(OPEN: measure)_【F:docs/vision_scope.md†L55-L57】
 - **Memory Target:** Reference scenario uses < **1.0 GB RAM**. _(OPEN: finalize)_【F:docs/vision_scope.md†L61-L64】
-- **Time Scale.** Tick-based with fixed tick duration: **1 tick = 1 in-game hour**; **24 ticks = 1 in-game day**, **7×24 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
+- **Time Scale.** Tick-based with fixed tick duration: **default tick length = 5 in-game minutes**; **12 ticks = 1 in-game hour**, **288 ticks = 1 in-game day**, **7×288 ticks = 1 in-game week**. Ticks are aggregated into day/week summaries; replays/logs reference tick IDs. _(OPEN: standard wall-clock tick duration, e.g., 1 min)_【F:docs/vision_scope.md†L95-L96】
 - **v1 Scope (Targets):** \~8–12 strains, \~10–15 devices, 2–3 cultivation methods, basic pests/diseases, treatments. _(OPEN: finalize list)_【F:docs/vision_scope.md†L214-L218】
 - **Open-Source Strategy:** License model (e.g., AGPL/Polyform?); contributions via PR policy, CLA. _(OPEN: decide)_【F:docs/vision_scope.md†L254-L257】
 

--- a/src/backend/src/constants/time.ts
+++ b/src/backend/src/constants/time.ts
@@ -1,0 +1,40 @@
+/**
+ * Simulation timekeeping constants shared across the backend. These values
+ * define the default cadence for ticks and help downstream systems derive
+ * hourly/daily/monthly aggregates from minutes-per-tick inputs.
+ */
+export const MINUTES_PER_HOUR = 60;
+
+export const HOURS_PER_DAY = 24;
+
+export const DAYS_PER_MONTH = 30;
+
+/**
+ * Default simulated minutes advanced per tick when booting a fresh game.
+ * Aligned with the 1–10 minute window documented in the PRD to keep early
+ * game feedback loops responsive while preserving hourly aggregation maths.
+ */
+export const DEFAULT_TICK_LENGTH_MINUTES = 5;
+
+/**
+ * Millisecond interval corresponding to the default tick cadence at 1× speed.
+ */
+export const DEFAULT_TICK_INTERVAL_MS = DEFAULT_TICK_LENGTH_MINUTES * MINUTES_PER_HOUR * 1000;
+
+/**
+ * Number of ticks that elapse during one simulated hour at the default tick
+ * length.
+ */
+export const DEFAULT_TICKS_PER_HOUR = MINUTES_PER_HOUR / DEFAULT_TICK_LENGTH_MINUTES;
+
+/**
+ * Number of ticks that elapse during one simulated day at the default tick
+ * length.
+ */
+export const DEFAULT_TICKS_PER_DAY = DEFAULT_TICKS_PER_HOUR * HOURS_PER_DAY;
+
+/**
+ * Number of ticks that elapse during one simulated 30-day month at the
+ * default tick length.
+ */
+export const DEFAULT_TICKS_PER_MONTH = DEFAULT_TICKS_PER_DAY * DAYS_PER_MONTH;

--- a/src/backend/src/constants/world.ts
+++ b/src/backend/src/constants/world.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_TICKS_PER_MONTH } from './time.js';
+
 /**
  * Fractional fill level (0–1) applied to freshly provisioned zone reservoirs.
  * Keeps irrigation controllers within their nominal operating range while
@@ -19,6 +21,7 @@ export const DEFAULT_ZONE_NUTRIENT_LITERS = 400;
 
 /**
  * Number of simulation ticks between routine device maintenance windows.
- * Based on one tick per hour, giving a monthly service cadence.
+ * Derives a monthly cadence (30 days) using the default tick length (5 minutes
+ * per tick ⇒ 288 ticks per day, 8,640 per 30-day month).
  */
-export const DEFAULT_MAINTENANCE_INTERVAL_TICKS = 24 * 30;
+export const DEFAULT_MAINTENANCE_INTERVAL_TICKS = DEFAULT_TICKS_PER_MONTH;

--- a/src/backend/src/facade/config.test.ts
+++ b/src/backend/src/facade/config.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SimulationFacade } from './index.js';
+import { DEFAULT_MAINTENANCE_INTERVAL_TICKS } from '@/constants/world.js';
 import type { GameState } from '@/state/models.js';
 import type { SimulationEvent } from '@/lib/eventBus.js';
 import { EventBus } from '@/lib/eventBus.js';
@@ -85,7 +86,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -103,7 +104,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -127,7 +128,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -149,7 +150,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -1,4 +1,5 @@
 import { eventBus as telemetryEventBus } from '@runtime/eventBus.js';
+import { DEFAULT_TICK_INTERVAL_MS, MINUTES_PER_HOUR } from '@/constants/time.js';
 import { EventBus, type EventFilter } from '@/lib/eventBus.js';
 import {
   computeHumidityForVpd,
@@ -519,7 +520,7 @@ export class SimulationFacade {
         'time.setTickLength',
       );
     }
-    const tickIntervalMs = minutes * 60 * 1000;
+    const tickIntervalMs = minutes * MINUTES_PER_HOUR * 1000;
     if (Math.abs(tickIntervalMs - this.tickIntervalMs) < Number.EPSILON) {
       return {
         ok: true,
@@ -909,9 +910,9 @@ export class SimulationFacade {
     }
     const minutes = this.state.metadata.tickLengthMinutes;
     if (Number.isFinite(minutes) && minutes > 0) {
-      return minutes * 60 * 1000;
+      return minutes * MINUTES_PER_HOUR * 1000;
     }
-    return 60 * 60 * 1000;
+    return DEFAULT_TICK_INTERVAL_MS;
   }
 
   private createScheduler(

--- a/src/backend/src/facade/intent.integration.test.ts
+++ b/src/backend/src/facade/intent.integration.test.ts
@@ -5,6 +5,7 @@ import type { GameState } from '@/state/models.js';
 import type { SimulationEvent } from '@/lib/eventBus.js';
 import type { SimulationLoop } from '@/sim/loop.js';
 import { WorldService } from '@/engine/world/worldService.js';
+import { DEFAULT_MAINTENANCE_INTERVAL_TICKS } from '@/constants/world.js';
 import { DeviceGroupService } from '@/engine/devices/deviceGroupService.js';
 import { PlantingPlanService } from '@/engine/plants/plantingPlanService.js';
 import { CostAccountingService } from '@/engine/economy/costAccounting.js';
@@ -116,7 +117,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,

--- a/src/backend/src/server/socketGateway.integration.test.ts
+++ b/src/backend/src/server/socketGateway.integration.test.ts
@@ -17,6 +17,7 @@ import type { PriceCatalog } from '@/engine/economy/pricing.js';
 import { RngService } from '@/lib/rng.js';
 import type { RoomPurpose, RoomPurposeSource } from '@/engine/roomPurposes/index.js';
 import { SocketGateway } from '@/server/socketGateway.js';
+import { DEFAULT_MAINTENANCE_INTERVAL_TICKS } from '@/constants/world.js';
 
 const STRUCTURE_ID = '11111111-1111-1111-1111-111111111111';
 const ROOM_ID = '22222222-2222-2222-2222-222222222222';
@@ -213,7 +214,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -231,7 +232,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -255,7 +256,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,
@@ -277,7 +278,7 @@ const createTestState = (): GameState => ({
                   runtimeHours: 0,
                   maintenance: {
                     lastServiceTick: 0,
-                    nextDueTick: 720,
+                    nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
                     condition: 1,
                     runtimeHoursAtLastService: 0,
                     degradation: 0,

--- a/src/backend/src/sim/loop.golden.test.ts
+++ b/src/backend/src/sim/loop.golden.test.ts
@@ -363,7 +363,8 @@ const runReferenceSimulation = async (): Promise<SimulationKpiSummary> => {
   const rng = new RngService(seed);
   const sampleStream = rng.getStream(RNG_STREAM_IDS.simulationTest);
   const context = createStateFactoryContext(seed, { repository, rng });
-  const state = await createInitialState(context);
+  const tickLengthMinutes = 60;
+  const state = await createInitialState(context, { tickLengthMinutes });
 
   const ticksPerDayRaw = (24 * 60) / state.metadata.tickLengthMinutes;
   if (!Number.isInteger(ticksPerDayRaw)) {

--- a/src/backend/src/stateFactory.test.ts
+++ b/src/backend/src/stateFactory.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_TICK_LENGTH_MINUTES } from '@/constants/time.js';
 import type { TaskDefinitionMap } from './state/models.js';
 import { createInitialState } from './stateFactory.js';
 import {
@@ -145,6 +146,27 @@ describe('createInitialState', () => {
     const firstDeviceIds = firstZone?.devices.map((device) => device.id);
     const secondDeviceIds = secondZone?.devices.map((device) => device.id);
     expect(firstDeviceIds).toEqual(secondDeviceIds);
+  });
+
+  it('applies the default tick length and honours overrides', async () => {
+    const baseContext = createStateFactoryContext('tick-default', {
+      repository: createBlueprintRepositoryStub(),
+      structureBlueprints: [createStructureBlueprint()],
+    });
+
+    const defaultState = await createInitialState(baseContext);
+    expect(defaultState.metadata.tickLengthMinutes).toBe(DEFAULT_TICK_LENGTH_MINUTES);
+
+    const overrideMinutes = 7;
+    const overriddenState = await createInitialState(
+      createStateFactoryContext('tick-override', {
+        repository: createBlueprintRepositoryStub(),
+        structureBlueprints: [createStructureBlueprint()],
+      }),
+      { tickLengthMinutes: overrideMinutes },
+    );
+
+    expect(overriddenState.metadata.tickLengthMinutes).toBe(overrideMinutes);
   });
 
   it('rejects device installations that are incompatible with the grow room purpose', async () => {

--- a/src/backend/src/stateFactory.ts
+++ b/src/backend/src/stateFactory.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_ZONE_RESERVOIR_LEVEL,
   DEFAULT_ZONE_WATER_LITERS,
 } from '@/constants/world.js';
+import { DEFAULT_TICK_LENGTH_MINUTES } from '@/constants/time.js';
 import { DEFAULT_SAVEGAME_VERSION } from './persistence/saveGame.js';
 import type {
   CultivationMethodBlueprint,
@@ -69,8 +70,6 @@ export {
 } from './state/initialization/personnel.js';
 export { loadTaskDefinitions } from './state/initialization/tasks.js';
 
-// Default tick length is 60 minutes (1 hour) per tick for realistic gameplay and KPI parity
-const DEFAULT_TICK_LENGTH_MINUTES = 60;
 const DEFAULT_TARGET_TICK_RATE = 1;
 const DEFAULT_EMPLOYEE_COUNTS: Record<EmployeeRole, number> = {
   Gardener: 4,

--- a/src/frontend/src/data/mockTelemetry.ts
+++ b/src/frontend/src/data/mockTelemetry.ts
@@ -18,7 +18,7 @@ const createDevice = (overrides: Partial<DeviceSnapshot>): DeviceSnapshot => ({
   runtimeHours: 0,
   maintenance: {
     lastServiceTick: 0,
-    nextDueTick: 720,
+    nextDueTick: 8640,
     condition: 0.98,
     degradation: 0.02,
   },


### PR DESCRIPTION
### **User description**
## Summary
- introduce shared timekeeping constants and switch the default tick length to five minutes while keeping scheduler fallbacks consistent
- update state factory, tests, and fixtures to honour overrides and retain the golden loop baseline
- refresh documentation and changelog entries to describe the faster cadence and derived tick counts

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm --filter @weebbreed/backend bench


------
https://chatgpt.com/codex/tasks/task_e_68d76961d7608325ab02dcd4f35860a0


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce default tick length from 60 to 5 minutes

- Introduce shared timekeeping constants for consistency

- Update maintenance intervals and test fixtures

- Refresh documentation with new cadence calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Time Constants"] --> B["State Factory"]
  A --> C["Simulation Facade"]
  A --> D["Test Fixtures"]
  B --> E["Default Tick Length"]
  C --> F["Scheduler Intervals"]
  D --> G["Maintenance Timing"]
  E --> H["5 Minutes"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>time.ts</strong><dd><code>Add shared timekeeping constants module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-595201d8751512188d831fff45a3cf5032df0c9138ac44af405bd7cd99f53431">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>world.ts</strong><dd><code>Update maintenance interval to use time constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-486960a53bd7b5989d8c4bf020d6dedc0f1c8602d1a77d913d21d395081b2d20">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Use time constants for tick calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-af16b94f90c68e774020b86f3f1f6bb2d924eb966d3b8912b95a3892a225bdce">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stateFactory.ts</strong><dd><code>Import and use default tick length constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-b6717c682188d3c383076f167ab885cb22994e0b35db26c3df9c56efad636878">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>config.test.ts</strong><dd><code>Replace hardcoded maintenance ticks with constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-f900f0f1dea021bb93758cb4a957ec98f8a7d36cb19c77f4efbedd584803d10c">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>intent.integration.test.ts</strong><dd><code>Update test fixture maintenance intervals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-0fc31b031d6e27ede376bc51ec4c67dffe923881c50f62ab33be2986bda824c6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>socketGateway.integration.test.ts</strong><dd><code>Replace hardcoded maintenance values in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-61720f7c0e2f6a10ea2d4a9b4e1202718b9d1f36d3cc88be588cd5d09b0854cc">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loop.golden.test.ts</strong><dd><code>Override tick length for golden test baseline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-618ecec07b78c331513eca5b31f6393f072826aa1ea8c9852a71fbc31c5916d1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stateFactory.test.ts</strong><dd><code>Add tests for tick length defaults and overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-379e7b6361a12c31f752b9fdce6da95a27822987863b7ec30a6184c2bd41824d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mockTelemetry.ts</strong><dd><code>Update mock maintenance tick values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-52860a4102baec4470f0f74292b73106cf5df0052b57950799b43618c6e6e2aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document tick length reduction change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TDD.md</strong><dd><code>Update weekly refresh tick calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-c63c42f48fafc730ffe37944d96bcb50e147434901be8b1d3dbc50fc36573fc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>formulas.md</strong><dd><code>Update formula tick counts for new cadence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-81eed9e5f51aa31e1ebeebf0be68509c17857ee5c6cfa5f2414fc756c341f067">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>formulas_index.json</strong><dd><code>Update formula index with new tick values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-dc7d3834da86c7761e68e2c52cbbfe09d06cd87cf9482e1a9e098ba7e54ad05c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>05-math-formulas-overview.md</strong><dd><code>Update formula overview with new tick counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-5fa4fcdd0559cc2ac3c464a2202b422ce8493f29f03ec1d32604be5d5a612d0a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>11-open-questions.md</strong><dd><code>Update time scale documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-c23c0e4266024a1e73af4ad27e3a6f0c37756bc7a7c7ae9431f6a51ce91d948e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>time.md</strong><dd><code>Add new timekeeping constants documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-6feb6910bb8f64de96064c17fbe28cd3c80e98abea0a6a6efb428687a62e74ed">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>world.md</strong><dd><code>Update maintenance interval documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-e1b882e9aabc5431e148f80d27c88bfbe76e28d0468db855a4a66dcc67b2eb59">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>employees.md</strong><dd><code>Update employee system tick references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-459b6aa9cfa0f709dc7cacc91d4b3f12333e94f70aba49e8d7e6adfb339c212a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>job_market_population.md</strong><dd><code>Update job market refresh calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-383b1084e754736d0b66e00e202dedba4de9d69482cc1811f8e300b4f11fb3d1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>simulation_philosophy.md</strong></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-0bfd7da98b1fefeb2c944bc3f55b7c8ed6ebc0fa2a64808e2cc790cd625d13eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vision_scope.md</strong></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-99756b090df40b7be3c70ffc28c74c9ffeac705a05b03d0087329f74bad9f163">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weedbreed-final-truth.backup.md</strong></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-83232c989a030555cf07e6bdfc721b70e0096c2544ea1fe570b606b13b09faa7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weedbreed-final-truth.md</strong></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/236/files#diff-6d10972ddae45ac54f763340836674371bca4efb5f0f136de0a390f0fcef820a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

