### PR TITLE
Add accounting stubs to simulation test contexts

### DIFF
--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -24,7 +24,7 @@ import type {
   ZoneResourceState,
   ZoneState,
 } from '@/state/models.js';
-import type { SimulationPhaseContext } from '@/sim/loop.js';
+import type { AccountingPhaseTools, SimulationPhaseContext } from '@/sim/loop.js';
 
 const diseaseBalancing: DiseaseBalancingConfig = {
   global: {
@@ -300,6 +300,11 @@ const createGameState = (): GameState => {
   } satisfies GameState;
 };
 
+const accountingTools: AccountingPhaseTools = {
+  recordUtility: () => undefined,
+  recordDevicePurchase: () => undefined,
+};
+
 const createContext = (
   state: GameState,
   tick: number,
@@ -310,6 +315,7 @@ const createContext = (
   tickLengthMinutes: state.metadata.tickLengthMinutes,
   phase: 'updatePlants',
   events: createEventCollector(events, tick),
+  accounting: accountingTools,
 });
 
 describe('PlantHealthEngine', () => {

--- a/src/backend/src/persistence/hotReload.test.ts
+++ b/src/backend/src/persistence/hotReload.test.ts
@@ -99,12 +99,17 @@ describe('BlueprintHotReloadManager', () => {
     const commitHook = manager.createCommitHook();
     const buffered: SimulationEvent[] = [];
     const collector = createEventCollector(buffered, 12);
+    const accountingStub: SimulationPhaseContext['accounting'] = {
+      recordUtility: () => undefined,
+      recordDevicePurchase: () => undefined,
+    };
     const context: SimulationPhaseContext = {
       state: {} as GameState,
       tick: 12,
       tickLengthMinutes: 60,
       phase: 'commit',
       events: collector,
+      accounting: accountingStub,
     };
 
     await commitHook(context);


### PR DESCRIPTION
### **User description**
## Summary
- ensure the health engine test context includes an accounting tools stub so it satisfies SimulationPhaseContext
- provide the same accounting stub for the hot reload unit test to cover commit-phase helpers

## Testing
- pnpm -r typecheck *(fails: frontend package missing dev dependencies such as clsx and @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a187780c83259afc3b71f8e08b35


___

### **PR Type**
Tests


___

### **Description**
- Add accounting tools stub to simulation test contexts

- Ensure test contexts satisfy SimulationPhaseContext interface

- Fix type compatibility in health engine and hot reload tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Context Creation"] --> B["Add Accounting Stub"]
  B --> C["Health Engine Tests"]
  B --> D["Hot Reload Tests"]
  C --> E["SimulationPhaseContext Compliance"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>healthEngine.test.ts</strong><dd><code>Add accounting stub to health engine tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/health/healthEngine.test.ts

<ul><li>Import <code>AccountingPhaseTools</code> type from simulation loop<br> <li> Create <code>accountingTools</code> stub with empty function implementations<br> <li> Add <code>accounting</code> field to <code>createContext</code> function return object</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/239/files#diff-42dc15709c6127b08c1d39b4f8ddb23b6733189925ed5e75b04a56a4388c010b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotReload.test.ts</strong><dd><code>Add accounting stub to hot reload tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/persistence/hotReload.test.ts

<ul><li>Create <code>accountingStub</code> with empty <code>recordUtility</code> and <br><code>recordDevicePurchase</code> functions<br> <li> Add <code>accounting</code> field to <code>SimulationPhaseContext</code> object in test</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/239/files#diff-ddf0cc751a3ece6a1d9ee25577f31359c5ed134e001b8f064528fb4c30a4350e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

