### PR TITLE
Align enhanced strain helpers with schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Promoted environment device coefficients, climate controller gains, and transpiration feedback defaults into `@/constants/environment` with updated references and documentation.
 - Extracted disease/pest detection and spread thresholds plus treatment defaults into `@/constants/health` with supporting documentation.
 - Shared world-state resource and maintenance defaults through `@/constants/world` and extended the constants documentation with rationale for each value.
+- Derived strain environmental band, stress tolerance, method affinity, and phase
+  duration helpers directly from the strain blueprint schema, updating
+  environment evaluators to accept passthrough properties while preserving
+  numeric safety when widening bands or reading optional durations.
 - Extended the frontend `FacadeIntentCommand` domain union with the `config` channel so facade hooks mirror the backend contract for configuration updates.
 
 ### Fixed


### PR DESCRIPTION
## Summary
- derive enhanced strain helper types directly from the StrainBlueprint schema so passthrough fields remain compatible
- harden environmental band lookups and tolerance helpers with runtime guards and numeric checks
- document the schema-driven helper updates in the changelog

## Testing
- pnpm -r typecheck *(fails: frontend package is missing type declarations for testing libraries and tailwind)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a22940c08325b0149e2635e9a167