### PR TITLE
Add finance ledger data and update dashboard aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Exposed a compact 50-entry finance ledger in the simulation snapshot and
+  taught the frontend store plus revenue/expense breakdowns to hydrate from the
+  live data instead of placeholder totals.
 - Shortened the default simulation tick length to 5 minutes (down from 60),
   exposing shared timekeeping constants for the scheduler/state factory and
   updating documentation to reflect the faster cadence.

--- a/src/backend/src/lib/uiSnapshot.test.ts
+++ b/src/backend/src/lib/uiSnapshot.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import { buildSimulationSnapshot, type FinanceLedgerEntrySnapshot } from './uiSnapshot.js';
+import type { RoomPurposeSource } from '@/engine/roomPurposes/index.js';
+import type {
+  GameState,
+  LedgerEntry,
+  ZoneEnvironmentState,
+  ZoneMetricState,
+  ZoneResourceState,
+} from '@/state/models.js';
+
+const createRoomPurposeSource = (): RoomPurposeSource => ({
+  listRoomPurposes: () => [
+    {
+      id: 'purpose-1',
+      kind: 'grow-room',
+      name: 'Grow Room',
+      description: 'Test purpose',
+    },
+  ],
+  getRoomPurpose: (id: string) =>
+    id === 'purpose-1'
+      ? { id: 'purpose-1', kind: 'grow-room', name: 'Grow Room', description: 'Test purpose' }
+      : undefined,
+});
+
+const createEnvironment = (): ZoneEnvironmentState => ({
+  temperature: 24,
+  relativeHumidity: 0.6,
+  co2: 800,
+  ppfd: 420,
+  vpd: 1.2,
+});
+
+const createResources = (): ZoneResourceState => ({
+  waterLiters: 10,
+  nutrientSolutionLiters: 5,
+  nutrientStrength: 0.75,
+  substrateHealth: 0.9,
+  reservoirLevel: 0.5,
+  lastTranspirationLiters: 1,
+});
+
+const createMetrics = (): ZoneMetricState => ({
+  averageTemperature: 24,
+  averageHumidity: 0.6,
+  averageCo2: 800,
+  averagePpfd: 420,
+  stressLevel: 0.1,
+  lastUpdatedTick: 10,
+});
+
+const createState = (ledgerEntries: LedgerEntry[]): GameState => ({
+  metadata: {
+    gameId: 'game-1',
+    createdAt: new Date(0).toISOString(),
+    seed: 'seed',
+    difficulty: 'normal',
+    simulationVersion: '1.0.0',
+    tickLengthMinutes: 10,
+    economics: {
+      initialCapital: 100_000,
+      maintenanceReserve: 5_000,
+      payrollReserve: 5_000,
+      startingEmployees: 0,
+      rentBufferDays: 30,
+    },
+  },
+  clock: {
+    tick: 60,
+    isPaused: false,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    targetTickRate: 1,
+  },
+  structures: [
+    {
+      id: 'structure-1',
+      blueprintId: 'structure-blueprint',
+      name: 'Structure',
+      status: 'active',
+      footprint: { length: 10, width: 5, height: 3, area: 50, volume: 150 },
+      rooms: [
+        {
+          id: 'room-1',
+          structureId: 'structure-1',
+          name: 'Room',
+          purposeId: 'purpose-1',
+          area: 50,
+          height: 3,
+          volume: 150,
+          zones: [
+            {
+              id: 'zone-1',
+              roomId: 'room-1',
+              name: 'Zone',
+              cultivationMethodId: 'method-1',
+              area: 50,
+              ceilingHeight: 3,
+              volume: 150,
+              environment: createEnvironment(),
+              resources: createResources(),
+              plants: [],
+              devices: [],
+              metrics: createMetrics(),
+              control: { setpoints: {} },
+              health: {
+                plantHealth: {},
+                pendingTreatments: [],
+                appliedTreatments: [],
+              },
+              activeTaskIds: [],
+              plantingPlan: null,
+            },
+          ],
+          cleanliness: 1,
+          maintenanceLevel: 1,
+        },
+      ],
+      rentPerTick: 0,
+      upfrontCostPaid: 0,
+    },
+  ],
+  inventory: {
+    resources: {
+      waterLiters: 0,
+      nutrientsGrams: 0,
+      co2Kg: 0,
+      substrateKg: 0,
+      packagingUnits: 0,
+      sparePartsValue: 0,
+    },
+    seeds: [],
+    devices: [],
+    harvest: [],
+    consumables: {},
+  },
+  finances: {
+    cashOnHand: 10_000,
+    reservedCash: 500,
+    outstandingLoans: [],
+    ledger: ledgerEntries,
+    summary: {
+      totalRevenue: ledgerEntries
+        .filter((entry) => entry.type === 'income')
+        .reduce((total, entry) => total + entry.amount, 0),
+      totalExpenses: ledgerEntries
+        .filter((entry) => entry.type === 'expense')
+        .reduce((total, entry) => total + entry.amount, 0),
+      totalPayroll: 0,
+      totalMaintenance: 0,
+      netIncome:
+        ledgerEntries
+          .filter((entry) => entry.type === 'income')
+          .reduce((total, entry) => total + entry.amount, 0) -
+        ledgerEntries
+          .filter((entry) => entry.type === 'expense')
+          .reduce((total, entry) => total + entry.amount, 0),
+      lastTickRevenue: 0,
+      lastTickExpenses: 0,
+    },
+    utilityPrices: {
+      electricityCostPerKWh: 0.12,
+      waterCostPerM3: 2,
+      nutrientsCostPerKg: 10,
+    },
+  },
+  personnel: {
+    employees: [],
+    applicants: [],
+    trainingPrograms: [],
+    overallMorale: 1,
+  },
+  tasks: { backlog: [], active: [], completed: [], cancelled: [] },
+});
+
+const createLedgerEntries = (count: number): LedgerEntry[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `ledger_${index + 1}`,
+    tick: index + 1,
+    timestamp: new Date(index + 1).toISOString(),
+    amount: index + 1,
+    type: index % 2 === 0 ? 'income' : 'expense',
+    category: index % 2 === 0 ? 'sales' : 'rent',
+    description: index === 10 ? '   ' : `Entry ${index + 1}`,
+  }));
+
+describe('buildSimulationSnapshot finance ledger', () => {
+  const roomPurposeSource = createRoomPurposeSource();
+
+  it('includes the last 50 ledger entries with compact fields', () => {
+    const ledgerEntries = createLedgerEntries(55);
+    const snapshot = buildSimulationSnapshot(createState(ledgerEntries), roomPurposeSource);
+
+    const ledger = snapshot.finance.ledger;
+    expect(ledger).toBeDefined();
+    expect(ledger).toHaveLength(50);
+
+    const first = ledger?.[0] as FinanceLedgerEntrySnapshot;
+    expect(first.tick).toBe(6);
+    expect(first.description).toBe('Entry 6');
+
+    const blankDescriptionEntry = ledger?.find((entry) => entry.tick === 11);
+    expect(blankDescriptionEntry?.description).toBe('sales');
+
+    const last = ledger?.[ledger.length - 1] as FinanceLedgerEntrySnapshot;
+    expect(last.tick).toBe(55);
+    expect(last.description).toBe('Entry 55');
+  });
+
+  it('omits the ledger field when no entries are recorded', () => {
+    const snapshot = buildSimulationSnapshot(createState([]), roomPurposeSource);
+
+    expect(snapshot.finance.ledger).toBeUndefined();
+  });
+});

--- a/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ExpenseBreakdown } from './ExpenseBreakdown';
+import { useSimulationStore } from '@/store/simulation';
+import type { SimulationBridge } from '@/facade/systemFacade';
+import type { SimulationSnapshot } from '@/types/simulation';
+
+const bridge = { sendIntent: () => Promise.resolve() } as unknown as SimulationBridge;
+
+const baseSnapshot: SimulationSnapshot = {
+  tick: 12,
+  clock: {
+    tick: 12,
+    isPaused: false,
+    targetTickRate: 1,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+  },
+  structures: [],
+  rooms: [],
+  zones: [],
+  personnel: { employees: [], applicants: [], overallMorale: 1 },
+  finance: {
+    cashOnHand: 4200,
+    reservedCash: 0,
+    totalRevenue: 2000,
+    totalExpenses: 950,
+    netIncome: 1050,
+    lastTickRevenue: 2000,
+    lastTickExpenses: 450,
+    ledger: [
+      { type: 'expense', category: 'utilities', amount: 150, tick: 12, description: 'Electricity' },
+      {
+        type: 'expense',
+        category: 'payroll',
+        amount: 300,
+        tick: 11,
+        description: 'Cultivation team',
+      },
+      {
+        type: 'expense',
+        category: 'device',
+        amount: 500,
+        tick: 8,
+        description: 'LED array upgrade',
+      },
+      { type: 'income', category: 'sales', amount: 2000, tick: 12, description: 'Wholesale order' },
+    ],
+  },
+};
+
+describe('ExpenseBreakdown', () => {
+  beforeEach(() => {
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: structuredClone(baseSnapshot),
+        events: [],
+        timeStatus: null,
+        connectionStatus: 'connected',
+        zoneHistory: {},
+        lastTick: baseSnapshot.clock.tick,
+      });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useSimulationStore.getState().reset();
+    });
+  });
+
+  it('renders expense categories derived from ledger entries', () => {
+    render(<ExpenseBreakdown bridge={bridge} timeRange="1M" />);
+
+    expect(screen.getByText('Utilities')).toBeInTheDocument();
+    expect(screen.getByText('Payroll')).toBeInTheDocument();
+    expect(screen.getByText('Equipment Purchases')).toBeInTheDocument();
+    expect(screen.getAllByText('€500')).not.toHaveLength(0);
+    expect(screen.getAllByText('€150')).not.toHaveLength(0);
+    expect(screen.getAllByText('€300')).not.toHaveLength(0);
+    expect(screen.getAllByText('€450')).not.toHaveLength(0);
+  });
+
+  it('provides a fallback summary when ledger data is missing', () => {
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: {
+          ...structuredClone(baseSnapshot),
+          finance: {
+            ...structuredClone(baseSnapshot.finance),
+            ledger: undefined,
+          },
+        },
+      });
+    });
+
+    render(<ExpenseBreakdown bridge={bridge} timeRange="1M" />);
+
+    expect(screen.getAllByText('Total Expenses')).not.toHaveLength(0);
+    expect(
+      screen.getAllByText(/Aggregated expenses \(ledger data unavailable\)/i),
+    ).not.toHaveLength(0);
+  });
+});

--- a/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, act } from '@testing-library/react';
+import { RevenueBreakdown } from './RevenueBreakdown';
+import { useSimulationStore } from '@/store/simulation';
+import type { SimulationBridge } from '@/facade/systemFacade';
+import type { SimulationSnapshot } from '@/types/simulation';
+
+const bridge = { sendIntent: () => Promise.resolve() } as unknown as SimulationBridge;
+
+const baseSnapshot: SimulationSnapshot = {
+  tick: 10,
+  clock: {
+    tick: 10,
+    isPaused: false,
+    targetTickRate: 1,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+  },
+  structures: [],
+  rooms: [],
+  zones: [],
+  personnel: { employees: [], applicants: [], overallMorale: 1 },
+  finance: {
+    cashOnHand: 5000,
+    reservedCash: 0,
+    totalRevenue: 2000,
+    totalExpenses: 900,
+    netIncome: 1100,
+    lastTickRevenue: 1200,
+    lastTickExpenses: 450,
+    ledger: [
+      { type: 'income', category: 'sales', amount: 1200, tick: 10, description: 'Harvest A' },
+      { type: 'income', category: 'sales', amount: 800, tick: 9, description: 'Harvest B' },
+    ],
+  },
+};
+
+describe('RevenueBreakdown', () => {
+  beforeEach(() => {
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: structuredClone(baseSnapshot),
+        events: [],
+        timeStatus: null,
+        connectionStatus: 'connected',
+        zoneHistory: {},
+        lastTick: baseSnapshot.clock.tick,
+      });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useSimulationStore.getState().reset();
+    });
+  });
+
+  it('renders revenue sources based on ledger data', () => {
+    render(<RevenueBreakdown bridge={bridge} timeRange="1M" />);
+
+    expect(screen.getAllByText('Harvest A')).not.toHaveLength(0);
+    expect(screen.getAllByText('Harvest B')).not.toHaveLength(0);
+    expect(screen.getAllByText('€1,200')).not.toHaveLength(0);
+    expect(screen.getAllByText('€800')).not.toHaveLength(0);
+    expect(
+      screen.queryByText(/Detailed ledger data is not yet available/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to summary messaging when the ledger is missing', () => {
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: {
+          ...structuredClone(baseSnapshot),
+          finance: {
+            ...structuredClone(baseSnapshot.finance),
+            ledger: undefined,
+          },
+        },
+      });
+    });
+
+    render(<RevenueBreakdown bridge={bridge} timeRange="1M" />);
+
+    expect(screen.getAllByText(/Detailed ledger data is not yet available/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/Last tick revenue/i)).not.toHaveLength(0);
+  });
+});

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -190,6 +190,29 @@ export interface PersonnelSnapshot {
   overallMorale: number;
 }
 
+export type FinanceLedgerEntryType = 'income' | 'expense';
+
+export type FinanceLedgerCategory =
+  | 'capital'
+  | 'structure'
+  | 'device'
+  | 'inventory'
+  | 'rent'
+  | 'utilities'
+  | 'payroll'
+  | 'maintenance'
+  | 'sales'
+  | 'loan'
+  | 'other';
+
+export interface FinanceLedgerEntrySnapshot {
+  type: FinanceLedgerEntryType;
+  category: FinanceLedgerCategory;
+  amount: number;
+  tick: number;
+  description: string;
+}
+
 export interface FinanceSummarySnapshot {
   cashOnHand: number;
   reservedCash: number;
@@ -203,6 +226,7 @@ export interface FinanceSummarySnapshot {
     pricePerLiterWater?: number;
     pricePerGramNutrients?: number;
   };
+  ledger?: FinanceLedgerEntrySnapshot[];
 }
 
 export interface SimulationSnapshot {


### PR DESCRIPTION
### **User description**
## Summary
- expose a compact finance ledger in the backend simulation snapshot and cover it with a new unit test
- extend the shared simulation types and store to preserve ledger entries while hydrating updates
- drive the revenue and expense breakdown components from real ledger data with fresh frontend tests

## Testing
- pnpm --filter @weebbreed/backend test -- src/lib/uiSnapshot.test.ts
- pnpm vitest run src/components/finance/RevenueBreakdown.test.tsx src/components/finance/ExpenseBreakdown.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7c38259908325a94d47fcb92d366b


___

### **PR Type**
Enhancement


___

### **Description**
- Add finance ledger data to simulation snapshot

- Update dashboard components to use real ledger data

- Preserve ledger entries during frontend state hydration

- Add comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Snapshot"] --> B["Finance Ledger"]
  B --> C["Frontend Store"]
  C --> D["Revenue Component"]
  C --> E["Expense Component"]
  F["Unit Tests"] --> B
  F --> D
  F --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>uiSnapshot.test.ts</strong><dd><code>Add comprehensive finance ledger unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-454e7ade8216149bde0ffc49dd152c0493562307b3868fccf4fac88dfecce90b">+216/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ExpenseBreakdown.test.tsx</strong><dd><code>Add expense breakdown component tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-2a2162e3a1dbe1062005da7bde91ef8c23083ec4ffdba6ba81c92ff9d62abfa2">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RevenueBreakdown.test.tsx</strong><dd><code>Add revenue breakdown component tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-9e5753b7bb83fb67598400cb374f56a010568553daa4a2ef275500358257212c">+89/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>uiSnapshot.ts</strong><dd><code>Expose compact finance ledger in snapshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-d9ac9b699a49c8ab7e44b627df34f87f0ee3fc377d6b7ec6870bc783a675ead6">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>simulation.ts</strong><dd><code>Preserve ledger entries during state hydration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-a39f3164f5647a1ce0530a9f0dc5ac62a822368842e9765d40bba0a74e580d00">+34/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>simulation.ts</strong><dd><code>Add finance ledger entry type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-496e7c3b3984c81d10f204f8a799e414986f37a4f8cfda2fb5ab5ae03b9b999d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExpenseBreakdown.tsx</strong><dd><code>Update expense breakdown with real ledger data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-aa61780d2dcf636fd6b7a6ee9afad130a03249f8d2a9edce1e0457b59cd7a715">+161/-28</a></td>

</tr>

<tr>
  <td><strong>RevenueBreakdown.tsx</strong><dd><code>Update revenue breakdown with real ledger data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-c3beac2d25b73e0a0b968f8f837243a81fbbee7c0f0fca8e61836e1cda7bd4bc">+107/-64</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document finance ledger feature addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/243/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

