### PR TITLE
Guard modal resume when time status is paused

### DIFF
--- a/src/frontend/src/components/modals/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/ModalHost.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, act } from '@testing-library/react';
+import { ModalHost } from './ModalHost';
+import { useSimulationStore } from '@/store/simulation';
+import { useUIStore } from '@/store/ui';
+import type { SimulationBridge } from '@/facade/systemFacade';
+import type { SimulationSnapshot, SimulationTimeStatus } from '@/types/simulation';
+
+const baseSnapshot: SimulationSnapshot = {
+  tick: 42,
+  clock: {
+    tick: 42,
+    isPaused: false,
+    targetTickRate: 2,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+  },
+  structures: [],
+  rooms: [],
+  zones: [],
+  personnel: { employees: [], applicants: [], overallMorale: 1 },
+  finance: {
+    cashOnHand: 1000,
+    reservedCash: 0,
+    totalRevenue: 0,
+    totalExpenses: 0,
+    netIncome: 0,
+    lastTickRevenue: 0,
+    lastTickExpenses: 0,
+  },
+};
+
+const pausedStatus: SimulationTimeStatus = {
+  running: false,
+  paused: true,
+  speed: 4,
+  tick: baseSnapshot.clock.tick,
+  targetTickRate: baseSnapshot.clock.targetTickRate,
+};
+
+describe('ModalHost', () => {
+  let sendControlMock: ReturnType<typeof vi.fn>;
+  let bridge: SimulationBridge;
+
+  beforeEach(() => {
+    sendControlMock = vi.fn(async () => ({ ok: true }));
+    bridge = {
+      connect: vi.fn(),
+      loadQuickStart: vi.fn(async () => ({ ok: true })),
+      getStructureBlueprints: vi.fn(async () => ({ ok: true, data: [] })),
+      getDifficultyConfig: vi.fn(async () => ({ ok: true })),
+      sendControl: sendControlMock as unknown as SimulationBridge['sendControl'],
+      sendConfigUpdate: vi.fn(async () => ({ ok: true })),
+      sendIntent: vi.fn(async () => ({ ok: true })),
+      subscribeToUpdates: vi.fn(() => vi.fn()),
+    };
+
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: structuredClone(baseSnapshot),
+        timeStatus: { ...pausedStatus },
+        events: [],
+        connectionStatus: 'connected',
+        zoneHistory: {},
+        lastTick: baseSnapshot.clock.tick,
+      });
+      useUIStore.setState({ activeModal: null, modalQueue: [] });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    act(() => {
+      useSimulationStore.getState().reset();
+      useUIStore.setState({ activeModal: null, modalQueue: [] });
+    });
+  });
+
+  it('does not send a play command when time status is paused', async () => {
+    render(<ModalHost bridge={bridge} />);
+
+    act(() => {
+      useUIStore
+        .getState()
+        .openModal({ id: 'test', type: 'notifications', title: 'Notifications' });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      useUIStore.getState().closeModal();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sendControlMock).not.toHaveBeenCalledWith(expect.objectContaining({ action: 'play' }));
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- gate modal resume logic on the paused flag while retaining the stored speed when reopening
- add a regression test that ensures a paused simulation does not trigger a play command when the modal closes

## Testing
- CI=1 pnpm run check *(fails: frontend typecheck currently errors in ExpenseBreakdown.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ca76c8708325a827ff57c2169380


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix modal resume logic to respect paused simulation state

- Add regression test for paused simulation modal behavior

- Replace `wasRunning` with `resumable` flag for clearer logic

- Prevent play command when simulation is explicitly paused


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Opens"] --> B["Check Time Status"]
  B --> C{Is Paused?}
  C -->|No| D["Set resumable=true"]
  C -->|Yes| E["Set resumable=false"]
  D --> F["Pause Simulation"]
  E --> G["Store Speed Only"]
  F --> H["Modal Closes"]
  G --> H
  H --> I{resumable?}
  I -->|Yes| J["Resume with Speed"]
  I -->|No| K["No Action"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.test.tsx</strong><dd><code>Add ModalHost regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.test.tsx

<ul><li>Add comprehensive test suite for ModalHost component<br> <li> Create test for paused simulation modal behavior<br> <li> Mock SimulationBridge and store states for testing<br> <li> Verify no play command sent when simulation is paused</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/244/files#diff-8ee6381cf7a28b5cd6e5c13ca6bcebdcde493bf906dc8bf301bcb558c4527383">+104/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Fix modal pause/resume logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Replace <code>wasRunning</code> with <code>resumable</code> flag for clarity<br> <li> Check <code>timeStatus.paused</code> instead of <code>timeStatus.running</code><br> <li> Gate resume logic on explicit pause state<br> <li> Preserve speed value regardless of pause state</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/244/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

