### PR TITLE
Remove redundant DashboardShell sidebar margin

### DIFF
--- a/src/frontend/src/views/DashboardShell.tsx
+++ b/src/frontend/src/views/DashboardShell.tsx
@@ -13,7 +13,7 @@ interface DashboardShellProps {
 export const DashboardShell = ({ children, bridge }: DashboardShellProps) => (
   <div className="flex min-h-screen w-full bg-surface text-text">
     <Sidebar />
-    <div className="content-area flex min-h-screen w-full flex-col gap-6 px-6 pb-10 pt-6 lg:ml-[var(--sidebar-width)] lg:pl-8">
+    <div className="content-area flex min-h-screen w-full flex-col gap-6 px-6 pb-10 pt-6 lg:pl-8">
       <DashboardHeader bridge={bridge} />
       <Breadcrumbs />
       <main className="grid flex-1 gap-6 pb-20">{children}</main>


### PR DESCRIPTION
### **User description**
## Summary
- remove the extra `lg:ml-[var(--sidebar-width)]` offset from the dashboard shell so the sidebar/content flex layout aligns naturally
- manually verified the dashboard on desktop and mobile breakpoints to confirm full-width content and working sidebar toggle

## Testing
- CI=1 pnpm run check *(fails: frontend typecheck reports TS2345 in ExpenseBreakdown.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ccc895848325984a15bc82e2daa2


___

### **PR Type**
Bug fix


___

### **Description**
- Remove redundant sidebar margin from dashboard layout

- Fix double margin issue in desktop view


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DashboardShell"] --> B["Sidebar"]
  A --> C["Content Area"]
  C --> D["Remove lg:ml-[var(--sidebar-width)]"]
  D --> E["Natural flex layout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardShell.tsx</strong><dd><code>Remove redundant sidebar margin class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/views/DashboardShell.tsx

<ul><li>Remove <code>lg:ml-[var(--sidebar-width)]</code> margin from content area<br> <li> Keep existing padding and flex layout structure</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/245/files#diff-7eab6048cf6bc946a8ed0d76fda972a1bbdd6bcd35358be412d9c806486fccc2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

