### PR TITLE
Handle conflicting modal pause state

### DIFF
--- a/src/frontend/src/components/modals/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/ModalHost.test.tsx
@@ -101,4 +101,45 @@ describe('ModalHost', () => {
 
     expect(sendControlMock).not.toHaveBeenCalledWith(expect.objectContaining({ action: 'play' }));
   });
+
+  it('treats conflicting pause states as paused and avoids pause/resume commands', async () => {
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: {
+          ...structuredClone(baseSnapshot),
+          clock: {
+            ...structuredClone(baseSnapshot.clock),
+            isPaused: true,
+          },
+        },
+        timeStatus: {
+          ...pausedStatus,
+          paused: false,
+          running: true,
+        },
+      });
+    });
+
+    render(<ModalHost bridge={bridge} />);
+
+    act(() => {
+      useUIStore
+        .getState()
+        .openModal({ id: 'test', type: 'notifications', title: 'Notifications' });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      useUIStore.getState().closeModal();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sendControlMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -1378,11 +1378,19 @@ export const ModalHost = ({ bridge }: ModalHostProps) => {
     }
     const snapshot = useSimulationStore.getState().snapshot;
     const timeStatus = useSimulationStore.getState().timeStatus;
-    const resumable = timeStatus
-      ? timeStatus.paused === false
-      : snapshot
-        ? !snapshot.clock.isPaused
-        : false;
+    const timeStatusPaused = typeof timeStatus?.paused === 'boolean' ? timeStatus.paused : null;
+    const snapshotPaused = snapshot ? snapshot.clock.isPaused : null;
+    let isPaused = true;
+
+    if (timeStatusPaused !== null && snapshotPaused !== null) {
+      isPaused = timeStatusPaused === snapshotPaused ? timeStatusPaused : true;
+    } else if (timeStatusPaused !== null) {
+      isPaused = timeStatusPaused;
+    } else if (snapshotPaused !== null) {
+      isPaused = snapshotPaused;
+    }
+
+    const resumable = !isPaused;
     const speed = timeStatus?.speed ?? snapshot?.clock.targetTickRate ?? 1;
     pauseContext.current = { resumable, speed };
     if (resumable) {


### PR DESCRIPTION
### **User description**
## Summary
- reconcile the modal pause guard with both `timeStatus` and `snapshot.clock`, defaulting to paused on disagreement or missing data
- add a regression test that covers a stale running `timeStatus` with a paused snapshot to ensure no pause/resume commands are issued

## Testing
- pnpm --filter @weebbreed/frontend test -- src/components/modals/ModalHost.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7ce6705b08325b788440603527bd7


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix conflicting modal pause state handling logic

- Add regression test for stale timeStatus scenarios

- Default to paused state when data conflicts

- Prevent unnecessary pause/resume commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["timeStatus.paused"] --> C["Conflict Resolution Logic"]
  B["snapshot.clock.isPaused"] --> C
  C --> D["Default to Paused"]
  D --> E["Prevent Commands"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Implement robust pause state conflict resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Replace simple resumable logic with conflict resolution<br> <li> Check both <code>timeStatus.paused</code> and <code>snapshot.clock.isPaused</code><br> <li> Default to paused when states conflict or data missing<br> <li> Prevent unnecessary pause/resume commands</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/246/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.test.tsx</strong><dd><code>Add regression test for conflicting pause states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.test.tsx

<ul><li>Add test for conflicting pause states scenario<br> <li> Mock stale running <code>timeStatus</code> with paused snapshot<br> <li> Verify no pause/resume commands are issued<br> <li> Test modal open/close cycle with conflicting data</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/246/files#diff-8ee6381cf7a28b5cd6e5c13ca6bcebdcde493bf906dc8bf301bcb558c4527383">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

