### PR TITLE
Handle pause/resume failures in ModalHost

### DIFF
--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Button } from '@/components/primitives/Button';
 import { Icon } from '@/components/common/Icon';
 import { ModalFrame } from '@/components/modals/ModalFrame';
@@ -1356,17 +1356,60 @@ const modalRenderers: Record<
   ),
 };
 
+type PauseContext = {
+  resumable: boolean;
+  speed: number;
+  pauseConfirmed: boolean;
+};
+
 export const ModalHost = ({ bridge }: ModalHostProps) => {
   const activeModal = useUIStore((state) => state.activeModal);
   const closeModal = useUIStore((state) => state.closeModal);
-  const pauseContext = useRef<{ resumable: boolean; speed: number } | null>(null);
+  const pauseContext = useRef<PauseContext | null>(null);
   const [pausing, setPausing] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [pauseFeedback, setPauseFeedback] = useState<string | null>(null);
+
+  const handleCloseModal = useCallback(() => {
+    const context = pauseContext.current;
+    if (context?.resumable && context.pauseConfirmed) {
+      setPauseFeedback(null);
+      setResuming(true);
+      void bridge
+        .sendControl({ action: 'play', gameSpeed: context.speed })
+        .then((response) => {
+          if (!response.ok) {
+            const warning = response.errors?.[0]?.message ?? response.warnings?.[0];
+            setPauseFeedback(
+              warning ??
+                'Failed to resume simulation after modal actions. Please resume from the toolbar.',
+            );
+            return;
+          }
+          pauseContext.current = null;
+          closeModal();
+        })
+        .catch((error) => {
+          console.error('Failed to resume simulation after modal close', error);
+          setPauseFeedback('Connection error while resuming simulation. Please try again.');
+        })
+        .finally(() => {
+          setResuming(false);
+        });
+      return;
+    }
+    pauseContext.current = null;
+    closeModal();
+  }, [bridge, closeModal]);
 
   useEffect(() => {
     if (!activeModal) {
       const context = pauseContext.current;
       pauseContext.current = null;
-      if (context?.resumable) {
+      setPausing(false);
+      setResuming(false);
+      setPauseFeedback(null);
+      if (context?.resumable && context.pauseConfirmed) {
         void bridge.sendControl({ action: 'play', gameSpeed: context.speed }).catch((error) => {
           console.error('Failed to resume simulation after modal close', error);
         });
@@ -1376,6 +1419,8 @@ export const ModalHost = ({ bridge }: ModalHostProps) => {
     if (pauseContext.current) {
       return;
     }
+    setPauseFeedback(null);
+    setResuming(false);
     const snapshot = useSimulationStore.getState().snapshot;
     const timeStatus = useSimulationStore.getState().timeStatus;
     const timeStatusPaused = typeof timeStatus?.paused === 'boolean' ? timeStatus.paused : null;
@@ -1392,16 +1437,43 @@ export const ModalHost = ({ bridge }: ModalHostProps) => {
 
     const resumable = !isPaused;
     const speed = timeStatus?.speed ?? snapshot?.clock.targetTickRate ?? 1;
-    pauseContext.current = { resumable, speed };
+    const context: PauseContext = { resumable, speed, pauseConfirmed: !resumable };
+    pauseContext.current = context;
     if (resumable) {
       setPausing(true);
       void bridge
         .sendControl({ action: 'pause' })
+        .then((response) => {
+          if (pauseContext.current !== context) {
+            return;
+          }
+          if (!response.ok) {
+            const warning = response.errors?.[0]?.message ?? response.warnings?.[0];
+            setPauseFeedback(
+              warning ??
+                'Failed to pause simulation before opening the modal. Simulation will keep running.',
+            );
+            pauseContext.current = null;
+            return;
+          }
+          pauseContext.current = { ...context, pauseConfirmed: true };
+        })
         .catch((error) => {
+          if (pauseContext.current !== context) {
+            return;
+          }
           console.error('Failed to pause simulation for modal', error);
+          setPauseFeedback(
+            'Connection error while pausing simulation. Simulation will keep running.',
+          );
+          pauseContext.current = null;
         })
         .finally(() => {
-          setPausing(false);
+          if (pauseContext.current === context) {
+            setPausing(false);
+          } else if (!pauseContext.current) {
+            setPausing(false);
+          }
         });
     }
   }, [activeModal, bridge]);
@@ -1414,19 +1486,22 @@ export const ModalHost = ({ bridge }: ModalHostProps) => {
     if (!renderer) {
       return null;
     }
-    return renderer({ bridge, closeModal, context: activeModal.context });
-  }, [activeModal, bridge, closeModal]);
+    return renderer({ bridge, closeModal: handleCloseModal, context: activeModal.context });
+  }, [activeModal, bridge, handleCloseModal]);
 
   if (!activeModal || !content) {
     return null;
   }
 
+  const subtitle = pausing
+    ? 'Pausing simulation…'
+    : resuming
+      ? 'Resuming simulation…'
+      : activeModal.subtitle;
+
   return (
-    <ModalFrame
-      title={activeModal.title}
-      subtitle={pausing ? 'Pausing simulation…' : activeModal.subtitle}
-      onClose={closeModal}
-    >
+    <ModalFrame title={activeModal.title} subtitle={subtitle} onClose={handleCloseModal}>
+      {pauseFeedback ? <Feedback message={pauseFeedback} /> : null}
       {content}
     </ModalFrame>
   );

--- a/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+// eslint-disable-next-line import/no-unresolved
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ModalHost } from '@/components/modals/ModalHost';
+import { useUIStore } from '@/store/ui';
+import { useSimulationStore } from '@/store/simulation';
+import type { SimulationSnapshot, SimulationTimeStatus } from '@/types/simulation';
+import type { SimulationBridge } from '@/facade/systemFacade';
+
+const ensureModalRoot = () => {
+  const existing = document.getElementById('modal-root');
+  if (existing) {
+    return existing;
+  }
+  const root = document.createElement('div');
+  root.id = 'modal-root';
+  document.body.append(root);
+  return root;
+};
+
+const buildRunningSnapshot = (): SimulationSnapshot => ({
+  tick: 10,
+  clock: {
+    tick: 10,
+    isPaused: false,
+    targetTickRate: 1,
+    startedAt: '2024-01-01T00:00:00.000Z',
+    lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+  },
+  structures: [],
+  rooms: [],
+  zones: [],
+  personnel: {
+    employees: [],
+    applicants: [],
+    overallMorale: 0,
+  },
+  finance: {
+    cashOnHand: 0,
+    reservedCash: 0,
+    totalRevenue: 0,
+    totalExpenses: 0,
+    netIncome: 0,
+    lastTickRevenue: 0,
+    lastTickExpenses: 0,
+  },
+});
+
+const runningTimeStatus: SimulationTimeStatus = {
+  running: true,
+  paused: false,
+  speed: 1,
+  tick: 10,
+  targetTickRate: 1,
+};
+
+describe('ModalHost pause safety', () => {
+  beforeEach(() => {
+    ensureModalRoot();
+    useUIStore.setState({
+      activeModal: null,
+      modalQueue: [],
+      notificationsUnread: 0,
+      theme: 'dark',
+    });
+    useSimulationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    useUIStore.setState({
+      activeModal: null,
+      modalQueue: [],
+      notificationsUnread: 0,
+      theme: 'dark',
+    });
+    useSimulationStore.getState().reset();
+  });
+
+  it('does not send resume when pause command rejects', async () => {
+    const sendControl = vi.fn((command: Parameters<SimulationBridge['sendControl']>[0]) => {
+      if (command.action === 'pause') {
+        return Promise.reject(new Error('pause failed'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    const bridge = {
+      sendControl,
+    } as unknown as SimulationBridge;
+
+    useSimulationStore.setState({
+      snapshot: buildRunningSnapshot(),
+      timeStatus: runningTimeStatus,
+    });
+
+    render(<ModalHost bridge={bridge} />);
+
+    act(() => {
+      useUIStore.getState().openModal({
+        id: 'test',
+        type: 'notifications',
+        title: 'Test Modal',
+      });
+    });
+
+    const closeButton = await screen.findByLabelText('Close modal');
+
+    await waitFor(() => {
+      expect(sendControl).toHaveBeenCalledWith({ action: 'pause' });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Connection error while pausing simulation. Simulation will keep running.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(useUIStore.getState().activeModal).toBeNull();
+    });
+
+    const resumeCalls = sendControl.mock.calls.filter(([command]) => command.action === 'play');
+    expect(resumeCalls).toHaveLength(0);
+    expect(sendControl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- await simulation pause/resume commands in `ModalHost` so failures clear the pause context and show feedback
- gate close-path resume on a confirmed pause to avoid resuming after a rejected control command
- add a regression test that injects a rejected pause promise and asserts no resume command is issued when the modal closes

## Testing
- pnpm --filter @weebbreed/frontend test -- ModalHost *(fails: repository test suite expects @testing-library/jest-dom/vitest which is currently missing in this environment)*
- pnpm --filter @weebreed/frontend exec vitest run src/components/modals/__tests__/ModalHost.test.tsx *(fails: vitest cannot resolve @testing-library/react in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d01e042c83258e0b3d171a2c2d03


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Handle pause/resume failures in ModalHost with proper error feedback

- Gate resume commands on confirmed pause to prevent invalid state

- Add regression test for pause failure scenarios

- Improve user experience with loading states and error messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Opens"] --> B["Check Simulation State"]
  B --> C["Send Pause Command"]
  C --> D{"Pause Success?"}
  D -->|Yes| E["Set pauseConfirmed: true"]
  D -->|No| F["Show Error Feedback"]
  F --> G["Clear Pause Context"]
  E --> H["Modal Closes"]
  H --> I{"pauseConfirmed?"}
  I -->|Yes| J["Send Resume Command"]
  I -->|No| K["Skip Resume"]
  J --> L{"Resume Success?"}
  L -->|Yes| M["Close Modal"]
  L -->|No| N["Show Resume Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Enhanced pause/resume handling with error feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Add <code>PauseContext</code> type with <code>pauseConfirmed</code> flag to track pause state<br> <li> Implement <code>handleCloseModal</code> callback with proper pause/resume error <br>handling<br> <li> Add loading states (<code>pausing</code>, <code>resuming</code>) and error feedback display<br> <li> Gate resume commands on confirmed pause to prevent invalid operations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/247/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+87/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.test.tsx</strong><dd><code>Add regression tests for pause failure handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/__tests__/ModalHost.test.tsx

<ul><li>Add comprehensive test suite for ModalHost pause safety scenarios<br> <li> Test pause command rejection and verify no resume is sent<br> <li> Include helper functions for simulation state setup<br> <li> Verify error feedback display for failed pause operations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/247/files#diff-e92b53fd6668114772e447043d05f8493203456b0ceec22b803e993a0e821a3b">+133/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

