### PR TITLE
feat: broadcast blueprint catalog updates to clients

### DIFF
--- a/src/backend/src/lib/blueprintCatalog.ts
+++ b/src/backend/src/lib/blueprintCatalog.ts
@@ -1,0 +1,115 @@
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import type {
+  DeviceBlueprint,
+  DeviceRoomPurposeCompatibility,
+} from '@/data/schemas/deviceSchema.js';
+import type { StrainBlueprint } from '@/data/schemas/strainsSchema.js';
+
+export interface BlueprintCatalogStrainDto {
+  id: string;
+  slug: string;
+  name: string;
+  genotype: StrainBlueprint['genotype'];
+  chemotype: StrainBlueprint['chemotype'];
+  morphology: Pick<StrainBlueprint['morphology'], 'growthRate' | 'yieldFactor' | 'leafAreaIndex'>;
+  photoperiod: StrainBlueprint['photoperiod'];
+  harvestWindow: StrainBlueprint['harvestWindow'];
+  generalResilience: number;
+  germinationRate: number;
+}
+
+export type RoomPurposeCompatibilitySummary =
+  | { mode: 'all' }
+  | { mode: 'restricted'; roomPurposes: string[] };
+
+export type DeviceSettingsSummaryValue = number | readonly number[];
+
+export type DeviceSettingsSummary = Record<string, DeviceSettingsSummaryValue>;
+
+export interface BlueprintCatalogDeviceDto {
+  id: string;
+  name: string;
+  kind: DeviceBlueprint['kind'];
+  quality: number;
+  complexity: number;
+  lifespan: number;
+  compatibility: RoomPurposeCompatibilitySummary;
+  settings: DeviceSettingsSummary;
+}
+
+export interface BlueprintCatalogDto {
+  strains: BlueprintCatalogStrainDto[];
+  devices: BlueprintCatalogDeviceDto[];
+}
+
+export type BlueprintCatalogSource = Pick<BlueprintRepository, 'listStrains' | 'listDevices'>;
+
+const normaliseCompatibility = (
+  value: DeviceRoomPurposeCompatibility,
+): RoomPurposeCompatibilitySummary => {
+  if (value === '*') {
+    return { mode: 'all' };
+  }
+  return { mode: 'restricted', roomPurposes: [...value] };
+};
+
+const createDeviceSettingsSummary = (blueprint: DeviceBlueprint): DeviceSettingsSummary => {
+  const settings = blueprint.settings;
+  const summary: DeviceSettingsSummary = {};
+  if (!settings) {
+    return summary;
+  }
+  for (const [key, rawValue] of Object.entries(settings)) {
+    if (typeof rawValue === 'number') {
+      summary[key] = rawValue;
+      continue;
+    }
+    if (Array.isArray(rawValue) && rawValue.every((item) => typeof item === 'number')) {
+      summary[key] = [...rawValue];
+    }
+  }
+  return summary;
+};
+
+const mapDevice = (blueprint: DeviceBlueprint): BlueprintCatalogDeviceDto => ({
+  id: blueprint.id,
+  name: blueprint.name,
+  kind: blueprint.kind,
+  quality: blueprint.quality,
+  complexity: blueprint.complexity,
+  lifespan: blueprint.lifespan,
+  compatibility: normaliseCompatibility(blueprint.roomPurposes),
+  settings: createDeviceSettingsSummary(blueprint),
+});
+
+const mapStrain = (blueprint: StrainBlueprint): BlueprintCatalogStrainDto => ({
+  id: blueprint.id,
+  slug: blueprint.slug,
+  name: blueprint.name,
+  genotype: { ...blueprint.genotype },
+  chemotype: { ...blueprint.chemotype },
+  morphology: {
+    growthRate: blueprint.morphology.growthRate,
+    yieldFactor: blueprint.morphology.yieldFactor,
+    leafAreaIndex: blueprint.morphology.leafAreaIndex,
+  },
+  photoperiod: {
+    vegetationTime: blueprint.photoperiod.vegetationTime,
+    floweringTime: blueprint.photoperiod.floweringTime,
+    transitionTrigger: blueprint.photoperiod.transitionTrigger,
+  },
+  harvestWindow: [...blueprint.harvestWindow],
+  generalResilience: blueprint.generalResilience,
+  germinationRate: blueprint.germinationRate,
+});
+
+export const createBlueprintCatalog = (source: BlueprintCatalogSource): BlueprintCatalogDto => {
+  const strains = source.listStrains().map(mapStrain);
+  const devices = source.listDevices().map(mapDevice);
+  return {
+    strains,
+    devices,
+  };
+};
+
+export default createBlueprintCatalog;


### PR DESCRIPTION
### **User description**
## Summary
- add a blueprint catalog helper that maps repository devices and strains into UI-friendly DTOs
- emit the catalog on SocketGateway handshake and expose a broadcast method for hot reload updates
- trigger catalog broadcasts during server startup and blueprint hot reloads, with socket tests covering the new event

## Testing
- pnpm --filter @weebbreed/backend test -- socketGateway

------
https://chatgpt.com/codex/tasks/task_e_68d7d346e18083259b6079c4fd8f64ec


___

### **PR Type**
Enhancement


___

### **Description**
- Add blueprint catalog helper for UI-friendly DTOs

- Broadcast catalog updates via SocketGateway on handshake

- Trigger catalog broadcasts during startup and hot reloads

- Add comprehensive socket tests for catalog events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blueprint Repository"] --> B["Blueprint Catalog Helper"]
  B --> C["SocketGateway"]
  C --> D["Client Handshake"]
  C --> E["Hot Reload Broadcast"]
  F["Server Startup"] --> C
  G["Hot Reload Manager"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blueprintCatalog.ts</strong><dd><code>Blueprint catalog helper implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/lib/blueprintCatalog.ts

<ul><li>Create blueprint catalog helper with DTO interfaces<br> <li> Map repository devices and strains to UI-friendly format<br> <li> Normalize device compatibility and settings data<br> <li> Export catalog creation function</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/248/files#diff-6eae4c663e7807deec4da299a4335876d8d184cec72d73d84cddcbec2c87afdf">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>socketGateway.ts</strong><dd><code>Socket gateway catalog broadcasting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/socketGateway.ts

<ul><li>Add blueprint catalog source dependency<br> <li> Emit catalog on socket handshake event<br> <li> Implement broadcast method for catalog updates<br> <li> Build catalog from repository source</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/248/files#diff-e7c4459685aa6255cb512b1d7cd6d296dc4322282f75230933afde37e786e639">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>startServer.ts</strong><dd><code>Server startup catalog integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/startServer.ts

<ul><li>Add blueprint catalog source to gateway options<br> <li> Broadcast catalog on server startup<br> <li> Trigger catalog broadcast on hot reload commits<br> <li> Reorganize hot reload event handling</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/248/files#diff-c4431a2d11d516ace2935639c61ffc280edf7064d5506e879ba1e253b25b2929">+21/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>socketGateway.test.ts</strong><dd><code>Socket gateway catalog broadcast tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/socketGateway.test.ts

<ul><li>Add blueprint catalog source to gateway constructor<br> <li> Test catalog broadcast on client handshake<br> <li> Test on-demand catalog broadcasting functionality<br> <li> Verify catalog payload structure and content</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/248/files#diff-055670629119482efd84b5ef3d052f5abcde87c9ffe3cbc07017ed9104e2a669">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

