### PR TITLE
Add blueprint catalog handling to simulation store

### DIFF
--- a/src/frontend/src/store/selectors.ts
+++ b/src/frontend/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import type { AppStoreState } from './types';
+import type { AppStoreState, DeviceOption } from './types';
 
 export const selectFinanceSummary = (state: AppStoreState) => state.financeSummary;
 
@@ -81,4 +81,31 @@ export const selectSelectedRoom = (state: AppStoreState) => {
 export const selectSelectedZone = (state: AppStoreState) => {
   const zoneId = state.selectedZoneId;
   return zoneId ? state.zones[zoneId] : undefined;
+};
+
+const matchesRoomPurpose = (
+  purposeKind: string | undefined,
+  compatibility: DeviceOption['compatibility'],
+): boolean => {
+  if (!purposeKind || compatibility.mode === 'all') {
+    return true;
+  }
+
+  return compatibility.roomPurposes?.includes(purposeKind) ?? false;
+};
+
+export const selectDeviceOptionsForZone = (zoneId: string) => (state: AppStoreState) => {
+  const zone = state.zones[zoneId];
+  if (!zone) {
+    return [];
+  }
+
+  const purposeKind = state.rooms[zone.roomId]?.purposeKind;
+  const devices = Object.values(state.blueprintCatalog.devices);
+
+  return devices.filter((device) => matchesRoomPurpose(purposeKind, device.compatibility));
+};
+
+export const selectStrainOptions = (state: AppStoreState) => {
+  return Object.values(state.blueprintCatalog.strains);
 };

--- a/src/frontend/src/store/slices/simulationSlice.ts
+++ b/src/frontend/src/store/slices/simulationSlice.ts
@@ -12,6 +12,8 @@ import type {
 } from '../../types/simulation';
 import type {
   AppStoreState,
+  BlueprintCatalogPayload,
+  BlueprintCatalogState,
   FinanceTickEntry,
   MaintenanceExpenseEntry,
   SimulationSlice,
@@ -239,6 +241,7 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
   zones: {},
   devices: {},
   plants: {},
+  blueprintCatalog: { strains: {}, devices: {} },
   events: [],
   timeline: [],
   lastSetpoints: {},
@@ -285,6 +288,15 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
         hrEvents: nextHrEvents,
       };
     }),
+  ingestBlueprintCatalog: (catalog: BlueprintCatalogPayload) =>
+    set((state) => {
+      const nextCatalog: BlueprintCatalogState = {
+        strains: catalog.strains ? indexById(catalog.strains) : state.blueprintCatalog.strains,
+        devices: catalog.devices ? indexById(catalog.devices) : state.blueprintCatalog.devices,
+      };
+
+      return { blueprintCatalog: nextCatalog };
+    }),
   appendEvents: (events) =>
     set((state) => {
       return events.length ? { events: mergeEvents(state.events, events) } : {};
@@ -309,6 +321,7 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
       zones: {},
       devices: {},
       plants: {},
+      blueprintCatalog: { strains: {}, devices: {} },
       events: [],
       timeline: [],
       lastTickCompleted: undefined,

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -16,6 +16,53 @@ import type {
   ZoneSnapshot,
 } from '../types/simulation';
 
+export type RoomPurposeCompatibilityOption =
+  | { mode: 'all' }
+  | { mode: 'restricted'; roomPurposes: string[] };
+
+export interface DeviceOption {
+  id: string;
+  name: string;
+  kind: string;
+  quality: number;
+  complexity: number;
+  lifespan: number;
+  compatibility: RoomPurposeCompatibilityOption;
+  settings: Record<string, number | readonly number[]>;
+}
+
+export interface StrainOption {
+  id: string;
+  slug: string;
+  name: string;
+  genotype: Record<string, number>;
+  chemotype: Record<string, number>;
+  morphology: {
+    growthRate: number;
+    yieldFactor: number;
+    leafAreaIndex: number;
+  };
+  photoperiod: {
+    vegetationTime: number;
+    floweringTime: number;
+    transitionTrigger: number;
+    [key: string]: unknown;
+  };
+  harvestWindow: readonly [number, number];
+  generalResilience: number;
+  germinationRate: number;
+}
+
+export interface BlueprintCatalogPayload {
+  strains?: StrainOption[];
+  devices?: DeviceOption[];
+}
+
+export interface BlueprintCatalogState {
+  strains: Record<string, StrainOption>;
+  devices: Record<string, DeviceOption>;
+}
+
 export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
 export type NavigationView = 'overview' | 'world' | 'personnel' | 'finance' | 'settings';
@@ -66,6 +113,7 @@ export interface SimulationSlice {
   zones: Record<string, ZoneSnapshot>;
   devices: Record<string, DeviceSnapshot>;
   plants: Record<string, PlantSnapshot>;
+  blueprintCatalog: BlueprintCatalogState;
   events: SimulationEvent[];
   timeline: SimulationTimelineEntry[];
   lastTickCompleted?: SimulationTickEvent;
@@ -78,6 +126,7 @@ export interface SimulationSlice {
   hrEvents: SimulationEvent[];
   setConnectionStatus: (status: ConnectionStatus, errorMessage?: string) => void;
   ingestUpdate: (update: SimulationUpdateEntry) => void;
+  ingestBlueprintCatalog: (catalog: BlueprintCatalogPayload) => void;
   appendEvents: (events: SimulationEvent[]) => void;
   recordFinanceTick: (entry: FinanceTickEntry) => void;
   recordHREvent: (event: SimulationEvent) => void;


### PR DESCRIPTION
### **User description**
## Summary
- add blueprint catalog types and state to the simulation store with reset-safe updates
- subscribe the simulation bridge to catalog.blueprints events and dispose the listener correctly
- expose blueprint-aware selectors for zone device options and available strains

## Testing
- pnpm --filter @weebbreed/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ed7cae208325ba28fc0bfe255789


___

### **PR Type**
Enhancement


___

### **Description**
- Add blueprint catalog state management to simulation store

- Subscribe to `catalog.blueprints` socket events for real-time updates

- Expose device and strain selectors with room compatibility filtering

- Implement reset-safe catalog updates with proper cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Socket Events"] -- "catalog.blueprints" --> B["useSimulationBridge"]
  B -- "ingestBlueprintCatalog" --> C["SimulationSlice"]
  C --> D["BlueprintCatalogState"]
  D --> E["Device/Strain Selectors"]
  E --> F["Room Compatibility Filtering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSimulationBridge.ts</strong><dd><code>Subscribe to blueprint catalog socket events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/hooks/useSimulationBridge.ts

<ul><li>Add <code>handleBlueprintCatalog</code> function to process catalog events<br> <li> Subscribe to <code>catalog.blueprints</code> socket event<br> <li> Import blueprint catalog types and store action<br> <li> Add proper cleanup in useEffect dependency array</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/249/files#diff-119d26423cad028b43466664dec6ceaff1dfcff03de9e21047e530a7513b7be0">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>selectors.ts</strong><dd><code>Add blueprint-aware device and strain selectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/store/selectors.ts

<ul><li>Add <code>selectDeviceOptionsForZone</code> selector with room purpose filtering<br> <li> Add <code>selectStrainOptions</code> selector for available strains<br> <li> Implement <code>matchesRoomPurpose</code> helper for device compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/249/files#diff-a10cb40755867d7281ae6d9d1485992271a113618fd57f501e60f8486bf431bf">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simulationSlice.ts</strong><dd><code>Extend simulation slice with blueprint catalog state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/store/slices/simulationSlice.ts

<ul><li>Add <code>blueprintCatalog</code> state with strains and devices<br> <li> Implement <code>ingestBlueprintCatalog</code> action for catalog updates<br> <li> Reset catalog state in <code>resetSimulation</code> function<br> <li> Import blueprint catalog types</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/249/files#diff-f9356233c41c7862137ee210b8781f14ba04e0bd7a6530f15f2b0b5c831d1e07">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add blueprint catalog type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/store/types.ts

<ul><li>Define <code>DeviceOption</code> interface with compatibility settings<br> <li> Define <code>StrainOption</code> interface with genetics and morphology<br> <li> Add <code>BlueprintCatalogPayload</code> and <code>BlueprintCatalogState</code> types<br> <li> Define <code>RoomPurposeCompatibilityOption</code> for device filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/249/files#diff-90760fb052c8ab2aeb11bd10ee73c158fa0efc01d42ac4a980181e68c1d9c77c">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

