### PR TITLE
Refine modal selectors for blueprint options

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,12 @@ importers:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@18.3.24)(react@18.3.1)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.4.2
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.2.1
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.2.66
         version: 18.3.24
@@ -175,6 +181,9 @@ importers:
         version: 24.1.3
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -712,8 +721,26 @@ packages:
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@14.3.1':
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1023,6 +1050,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1036,6 +1067,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1238,6 +1276,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -1341,6 +1382,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1367,6 +1412,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -1420,6 +1471,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1793,6 +1847,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -1807,6 +1865,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2077,6 +2139,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
@@ -2117,6 +2183,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
@@ -2182,6 +2252,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -2351,6 +2425,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -2397,6 +2475,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -2441,6 +2522,10 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2686,6 +2771,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3094,6 +3183,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -3538,10 +3629,42 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3871,6 +3994,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -3881,6 +4006,12 @@ snapshots:
       picomatch: 2.3.1
 
   argparse@2.0.1: {}
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
+
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -4097,6 +4228,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -4183,6 +4316,27 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.4
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -4210,6 +4364,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -4326,6 +4484,18 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-module-lexer@1.7.0: {}
 
@@ -4794,6 +4964,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -4808,6 +4980,11 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5098,6 +5275,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5132,6 +5311,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.0.3:
     dependencies:
@@ -5185,6 +5366,11 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -5346,6 +5532,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-warning@5.0.0: {}
 
   prop-types@15.8.1:
@@ -5383,6 +5575,8 @@ snapshots:
       typescript: 5.9.2
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -5433,6 +5627,11 @@ snapshots:
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5750,6 +5949,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/src/backend/src/server/socketGateway.test.ts
+++ b/src/backend/src/server/socketGateway.test.ts
@@ -120,6 +120,7 @@ describe('SocketGateway uiStream integration', () => {
   it('subscribes to uiStream$ and forwards batched packets', async () => {
     expect(handshake).toBeDefined();
     expect(catalogHandshake).toBeDefined();
+    expect(catalogHandshake!.cultivationMethods.length).toBeGreaterThan(0);
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
 
     const baseSnapshot: SimulationSnapshot = {
@@ -204,6 +205,7 @@ describe('SocketGateway uiStream integration', () => {
     const payload = await catalogUpdate;
     expect(payload.devices.length).toBeGreaterThan(0);
     expect(payload.strains.length).toBeGreaterThan(0);
+    expect(payload.cultivationMethods.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,8 @@
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
     "@vitejs/plugin-react": "^4.2.1",
     "jsdom": "^24.0.0"
   }

--- a/src/frontend/src/components/ModalRoot.module.css
+++ b/src/frontend/src/components/ModalRoot.module.css
@@ -101,6 +101,37 @@
   box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.35);
 }
 
+.select {
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, rgba(148, 163, 184, 0.65) 50%),
+    linear-gradient(135deg, rgba(148, 163, 184, 0.65) 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) calc(1.05rem),
+    calc(100% - 13px) calc(1.05rem);
+  background-size:
+    6px 6px,
+    6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 2.2rem;
+  cursor: pointer;
+}
+
+.helperText {
+  margin: -0.25rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #94a3b8);
+}
+
+.emptyState {
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--color-text-muted, #cbd5f5);
+  font-size: 0.85rem;
+  background: rgba(15, 23, 42, 0.45);
+}
+
 .checkbox {
   display: flex;
   align-items: center;
@@ -159,6 +190,13 @@
   transform: translateY(-1px);
   box-shadow: 0 20px 44px -20px rgba(124, 58, 237, 0.85);
   outline: none;
+}
+
+.confirm:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .danger {

--- a/src/frontend/src/components/ModalRoot.test.tsx
+++ b/src/frontend/src/components/ModalRoot.test.tsx
@@ -1,0 +1,183 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModalRoot } from './ModalRoot';
+import { useAppStore } from '../store';
+import type { ZoneSnapshot } from '../types/simulation';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; count?: number }) => {
+      if (key === 'modals.selectStrain') {
+        return 'Select strain';
+      }
+      if (key === 'modals.plantCount') {
+        return 'Plant count';
+      }
+      if (key === 'modals.cancel') {
+        return 'Cancel';
+      }
+      if (key === 'modals.apply') {
+        return 'Apply';
+      }
+      if (key === 'modals.recommendedPlantCount' && typeof options?.count === 'number') {
+        return `Recommended: ${options.count} plants`;
+      }
+      if (typeof options?.defaultValue === 'string') {
+        return options.defaultValue;
+      }
+      return key;
+    },
+  }),
+}));
+
+const initialState = useAppStore.getState();
+
+describe('ModalRoot planting modal', () => {
+  beforeEach(() => {
+    useAppStore.setState(() => initialState, true);
+  });
+
+  it('renders strain options and submits recommended payload', () => {
+    const closeModal = vi.fn();
+    const issueFacadeIntent = vi.fn();
+    const issueControlCommand = vi.fn();
+    const setWasRunningBeforeModal = vi.fn();
+
+    const zone: ZoneSnapshot = {
+      id: 'zone-1',
+      name: 'Alpha',
+      structureId: 'structure-1',
+      structureName: 'Structure One',
+      roomId: 'room-1',
+      roomName: 'Room One',
+      area: 10,
+      ceilingHeight: 3,
+      volume: 30,
+      cultivationMethodId: 'method-1',
+      environment: {
+        temperature: 24,
+        relativeHumidity: 0.55,
+        co2: 900,
+        ppfd: 500,
+        vpd: 1.1,
+      },
+      resources: {
+        waterLiters: 100,
+        nutrientSolutionLiters: 50,
+        nutrientStrength: 1,
+        substrateHealth: 1,
+        reservoirLevel: 0.5,
+      },
+      metrics: {
+        averageTemperature: 24,
+        averageHumidity: 0.55,
+        averageCo2: 900,
+        averagePpfd: 500,
+        stressLevel: 0.1,
+        lastUpdatedTick: 0,
+      },
+      devices: [],
+      plants: [],
+      health: {
+        diseases: 0,
+        pests: 0,
+        pendingTreatments: 0,
+        appliedTreatments: 0,
+      },
+      lighting: undefined,
+      supplyStatus: undefined,
+      plantingGroups: [],
+      plantingPlan: null,
+      deviceGroups: [],
+    };
+
+    useAppStore.setState((state) => ({
+      ...state,
+      closeModal,
+      issueFacadeIntent,
+      issueControlCommand,
+      setWasRunningBeforeModal,
+      wasRunningBeforeModal: false,
+      activeModal: {
+        kind: 'planting',
+        payload: { zoneId: 'zone-1' },
+        title: 'Schedule planting',
+      },
+      blueprintCatalog: {
+        strains: {
+          'strain-1': {
+            id: 'strain-1',
+            slug: 'strain-1',
+            name: 'Sunset Haze',
+            genotype: { indica: 0.6, sativa: 0.4 },
+            chemotype: {},
+            morphology: { growthRate: 1, yieldFactor: 1, leafAreaIndex: 1 },
+            photoperiod: {
+              vegetationTime: 1_209_600,
+              floweringTime: 1_209_600,
+              transitionTrigger: 0,
+            },
+            harvestWindow: [60, 90],
+            generalResilience: 0.8,
+            germinationRate: 0.9,
+          },
+        },
+        devices: {},
+        cultivationMethods: {
+          'method-1': {
+            id: 'method-1',
+            name: 'Sea of Green',
+            areaPerPlant: 0.5,
+            minimumSpacing: 0.5,
+          },
+        },
+      },
+      rooms: {
+        'room-1': {
+          id: 'room-1',
+          name: 'Room One',
+          structureId: 'structure-1',
+          structureName: 'Structure One',
+          purposeId: 'grow-room',
+          purposeKind: 'grow',
+          purposeName: 'Grow',
+          purposeFlags: {},
+          area: 10,
+          height: 3,
+          volume: 30,
+          cleanliness: 1,
+          maintenanceLevel: 1,
+          zoneIds: ['zone-1'],
+        },
+      },
+      zones: {
+        'zone-1': zone,
+      },
+    }));
+
+    render(<ModalRoot />);
+
+    const strainSelect = screen.getByLabelText('Select strain');
+    expect(strainSelect).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Sunset Haze/ })).toBeInTheDocument();
+
+    const countInput = screen.getByLabelText('Plant count') as HTMLInputElement;
+    expect(countInput.value).toBe('20');
+
+    fireEvent.submit(strainSelect.closest('form') as HTMLFormElement);
+
+    expect(issueFacadeIntent).toHaveBeenCalledTimes(1);
+    expect(issueFacadeIntent).toHaveBeenCalledWith({
+      domain: 'plants',
+      action: 'addPlanting',
+      payload: {
+        zoneId: 'zone-1',
+        strainId: 'strain-1',
+        count: 20,
+      },
+    });
+    expect(closeModal).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/hooks/useSimulationBridge.ts
+++ b/src/frontend/src/hooks/useSimulationBridge.ts
@@ -13,6 +13,7 @@ import { useAppStore } from '../store';
 import type { ConnectionStatus } from '../store';
 import type {
   BlueprintCatalogPayload,
+  CultivationMethodOption,
   DeviceOption,
   FinanceTickEntry,
   StrainOption,
@@ -322,6 +323,10 @@ export const useSimulationBridge = (
 
       if (Array.isArray(catalog.devices)) {
         nextCatalog.devices = catalog.devices as DeviceOption[];
+      }
+
+      if (Array.isArray(catalog.cultivationMethods)) {
+        nextCatalog.cultivationMethods = catalog.cultivationMethods as CultivationMethodOption[];
       }
 
       ingestBlueprintCatalog(nextCatalog);

--- a/src/frontend/src/i18n/locales/en/simulation.json
+++ b/src/frontend/src/i18n/locales/en/simulation.json
@@ -307,10 +307,12 @@
     "apply": "Apply",
     "close": "Close",
     "defaultTitle": "Simulation action",
-    "deviceBlueprint": "Device blueprint ID",
+    "deviceBlueprint": "Select device",
     "deviceName": "Device name",
     "deviceSettings": "Device settings (JSON)",
+    "deviceSettingsOptional": "Optional. Leave blank to use blueprint defaults.",
     "strainId": "Strain ID",
+    "selectStrain": "Select strain",
     "plantCount": "Plant count",
     "defaultStrain": "Default strain ID",
     "planCount": "Default plant count",
@@ -347,6 +349,9 @@
     "assignStructureTitle": "Assign {{name}} to a structure",
     "terminateEmployeeTitle": "Terminate {{name}}",
     "recordSaleTitle": "Record sale",
-    "utilityPriceTitle": "Adjust utility pricing"
+    "utilityPriceTitle": "Adjust utility pricing",
+    "noCompatibleDevices": "No compatible devices for this zone.",
+    "noStrainsAvailable": "No compatible strains for this zone.",
+    "recommendedPlantCount": "Recommended: {{count}} plants"
   }
 }

--- a/src/frontend/src/store/slices/simulationSlice.ts
+++ b/src/frontend/src/store/slices/simulationSlice.ts
@@ -241,7 +241,7 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
   zones: {},
   devices: {},
   plants: {},
-  blueprintCatalog: { strains: {}, devices: {} },
+  blueprintCatalog: { strains: {}, devices: {}, cultivationMethods: {} },
   events: [],
   timeline: [],
   lastSetpoints: {},
@@ -293,6 +293,9 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
       const nextCatalog: BlueprintCatalogState = {
         strains: catalog.strains ? indexById(catalog.strains) : state.blueprintCatalog.strains,
         devices: catalog.devices ? indexById(catalog.devices) : state.blueprintCatalog.devices,
+        cultivationMethods: catalog.cultivationMethods
+          ? indexById(catalog.cultivationMethods)
+          : state.blueprintCatalog.cultivationMethods,
       };
 
       return { blueprintCatalog: nextCatalog };
@@ -321,7 +324,7 @@ export const createSimulationSlice: StateCreator<AppStoreState, [], [], Simulati
       zones: {},
       devices: {},
       plants: {},
-      blueprintCatalog: { strains: {}, devices: {} },
+      blueprintCatalog: { strains: {}, devices: {}, cultivationMethods: {} },
       events: [],
       timeline: [],
       lastTickCompleted: undefined,

--- a/src/frontend/src/store/types.ts
+++ b/src/frontend/src/store/types.ts
@@ -31,6 +31,17 @@ export interface DeviceOption {
   settings: Record<string, number | readonly number[]>;
 }
 
+export interface CultivationMethodOption {
+  id: string;
+  name: string;
+  areaPerPlant: number;
+  minimumSpacing: number;
+  strainTraitCompatibility?: {
+    preferred?: Record<string, { min?: number; max?: number }>;
+    conflicting?: Record<string, { min?: number; max?: number }>;
+  };
+}
+
 export interface StrainOption {
   id: string;
   slug: string;
@@ -56,11 +67,13 @@ export interface StrainOption {
 export interface BlueprintCatalogPayload {
   strains?: StrainOption[];
   devices?: DeviceOption[];
+  cultivationMethods?: CultivationMethodOption[];
 }
 
 export interface BlueprintCatalogState {
   strains: Record<string, StrainOption>;
   devices: Record<string, DeviceOption>;
+  cultivationMethods: Record<string, CultivationMethodOption>;
 }
 
 export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';


### PR DESCRIPTION
### **User description**
## Summary
- extend the backend blueprint catalog DTO to include cultivation methods and surface them through the websocket gateway
- update the frontend store to track cultivation methods, expose zone-aware selectors, and refactor the install/planting/automation modals to use select inputs with empty states and validated payloads
- refresh modal styling/translations and add a planting modal test that confirms catalog options and recommended counts are respected

## Testing
- pnpm --filter @weebbreed/frontend test
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d7f06969b0832584b98ee4eab79218


___

### **PR Type**
Enhancement


___

### **Description**
- Extend blueprint catalog with cultivation methods

- Add zone-aware selectors for devices and strains

- Refactor modals to use select inputs with validation

- Add planting modal test with catalog integration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Blueprint Catalog"] -- "Add cultivation methods" --> B["WebSocket Gateway"]
  B -- "Broadcast catalog updates" --> C["Frontend Store"]
  C -- "Zone-aware selectors" --> D["Modal Components"]
  D -- "Select inputs with validation" --> E["User Interface"]
  F["Test Suite"] -- "Validates catalog options" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>blueprintCatalog.ts</strong><dd><code>Add cultivation methods to blueprint catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-6eae4c663e7807deec4da299a4335876d8d184cec72d73d84cddcbec2c87afdf">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSimulationBridge.ts</strong><dd><code>Handle cultivation methods in websocket bridge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-119d26423cad028b43466664dec6ceaff1dfcff03de9e21047e530a7513b7be0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>selectors.ts</strong><dd><code>Add zone-aware selectors for strains and recommendations</code>&nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-a10cb40755867d7281ae6d9d1485992271a113618fd57f501e60f8486bf431bf">+115/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>simulationSlice.ts</strong><dd><code>Update store to track cultivation methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-f9356233c41c7862137ee210b8781f14ba04e0bd7a6530f15f2b0b5c831d1e07">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add cultivation method option types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-90760fb052c8ab2aeb11bd10ee73c158fa0efc01d42ac4a980181e68c1d9c77c">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalRoot.module.css</strong><dd><code>Add styling for select inputs and states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-7b203cf8fb5fa1885a2b673580da04af3947266794476174bb4cdf4ad1c16462">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalRoot.tsx</strong><dd><code>Refactor modals with select inputs and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-ed4650fcaade32d5f9da2413116516269845343e29757c7206f7194d3a86c772">+185/-28</a></td>

</tr>

<tr>
  <td><strong>simulation.json</strong><dd><code>Update modal translations and labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-6e6b49677a97fc4ae1a82b65bbea131e895d55ffe6d4911667faee403dd3b532">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>socketGateway.test.ts</strong><dd><code>Update tests for cultivation methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-055670629119482efd84b5ef3d052f5abcde87c9ffe3cbc07017ed9104e2a669">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalRoot.test.tsx</strong><dd><code>Add planting modal test with catalog validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-c50800a315f83747441a2329e3370cb20e199fd77ead01e2c4d7e9cdff554747">+183/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Add testing library dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+203/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Add testing library packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/250/files#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

