### PR TITLE
Add blueprint availability gating to zone detail actions

### DIFF
--- a/src/frontend/src/components/WorldExplorer.tsx
+++ b/src/frontend/src/components/WorldExplorer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../store';
+import { useAppStore, selectDeviceOptionsForZone, selectStrainOptionsForZone } from '../store';
 import type { DeviceSnapshot, PlantSnapshot, ZoneSnapshot } from '../types/simulation';
 import { BreedingStationPlaceholder } from './world-explorer/BreedingStationPlaceholder';
 import { RoomGrid, type RoomSummary } from './world-explorer/RoomGrid';
@@ -156,6 +156,20 @@ export const WorldExplorer = () => {
       plants: groupPlantsByZone(activeZone, plants),
     };
   }, [activeZone, devices, plants]);
+
+  const hasAvailableStrains = useAppStore((state) => {
+    if (!resolvedZone) {
+      return false;
+    }
+    return selectStrainOptionsForZone(resolvedZone.zone.id)(state).length > 0;
+  });
+
+  const hasCompatibleDevices = useAppStore((state) => {
+    if (!resolvedZone) {
+      return false;
+    }
+    return selectDeviceOptionsForZone(resolvedZone.zone.id)(state).length > 0;
+  });
 
   const siblingZoneIds = useMemo(() => {
     if (!activeRoom || isLabRoom) {
@@ -313,6 +327,8 @@ export const WorldExplorer = () => {
               zone={resolvedZone.zone}
               devices={resolvedZone.devices}
               plants={resolvedZone.plants}
+              hasAvailableStrains={hasAvailableStrains}
+              hasCompatibleDevices={hasCompatibleDevices}
               previousZoneId={previousZoneId}
               nextZoneId={nextZoneId}
               onSelectZone={(zoneId) => selectZone(zoneId)}

--- a/src/frontend/src/components/world-explorer/ZoneDetailView.module.css
+++ b/src/frontend/src/components/world-explorer/ZoneDetailView.module.css
@@ -93,7 +93,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .navButton:hover,
@@ -173,7 +175,9 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .supplyButton:hover,
@@ -273,7 +277,9 @@
   align-items: center;
   gap: 0.4rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .harvestButton:hover,
@@ -284,6 +290,20 @@
 .deviceActionButton:focus-visible {
   background: rgba(96, 165, 250, 0.3);
   color: #bfdbfe;
+}
+
+.actionDisabled {
+  cursor: not-allowed;
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--wb-text-muted, #94a3b8);
+  opacity: 0.75;
+}
+
+.actionDisabled:hover,
+.actionDisabled:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--wb-text-muted, #94a3b8);
 }
 
 .toggleSwitch {
@@ -390,4 +410,12 @@
 
 .infoIcon {
   color: var(--wb-primary, #60a5fa);
+}
+
+.helperText {
+  margin: 0;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--wb-text-muted, #94a3b8);
+  line-height: 1.4;
 }

--- a/src/frontend/src/components/world-explorer/ZoneDetailView.test.tsx
+++ b/src/frontend/src/components/world-explorer/ZoneDetailView.test.tsx
@@ -1,0 +1,117 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ZoneSnapshot } from '../../types/simulation';
+import { ZoneDetailView } from './ZoneDetailView';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => {
+      if (key === 'actions.addPlanting') {
+        return 'Add planting';
+      }
+      if (key === 'actions.installDevice') {
+        return 'Install device';
+      }
+      if (typeof options?.defaultValue === 'string') {
+        return options.defaultValue;
+      }
+      return key;
+    },
+  }),
+}));
+
+const deviceOptionsByZone: Record<string, number> = {};
+const strainOptionsByZone: Record<string, number> = {};
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) => selector({}),
+  selectDeviceOptionsForZone: (zoneId: string) => () =>
+    Array.from({ length: deviceOptionsByZone[zoneId] ?? 0 }),
+  selectStrainOptionsForZone: (zoneId: string) => () =>
+    Array.from({ length: strainOptionsByZone[zoneId] ?? 0 }),
+}));
+
+describe('ZoneDetailView availability indicators', () => {
+  it('disables planting and device install actions when no options are returned', () => {
+    deviceOptionsByZone['zone-1'] = 0;
+    strainOptionsByZone['zone-1'] = 0;
+
+    const zone: ZoneSnapshot = {
+      id: 'zone-1',
+      name: 'Alpha Zone',
+      structureId: 'structure-1',
+      structureName: 'Structure One',
+      roomId: 'room-1',
+      roomName: 'Room One',
+      area: 20,
+      ceilingHeight: 3,
+      volume: 60,
+      environment: {
+        temperature: 24,
+        relativeHumidity: 0.55,
+        co2: 950,
+        ppfd: 500,
+        vpd: 1.1,
+      },
+      resources: {
+        waterLiters: 120,
+        nutrientSolutionLiters: 60,
+        nutrientStrength: 1.2,
+        substrateHealth: 0.9,
+        reservoirLevel: 0.8,
+      },
+      metrics: {
+        averageTemperature: 24,
+        averageHumidity: 0.55,
+        averageCo2: 950,
+        averagePpfd: 500,
+        stressLevel: 0.1,
+        lastUpdatedTick: 0,
+      },
+      devices: [],
+      plants: [],
+      health: {
+        diseases: 0,
+        pests: 0,
+        pendingTreatments: 0,
+        appliedTreatments: 0,
+      },
+      lighting: undefined,
+      supplyStatus: undefined,
+      plantingGroups: [],
+      plantingPlan: null,
+      deviceGroups: [],
+    };
+
+    const markup = renderToStaticMarkup(
+      <ZoneDetailView
+        zone={zone}
+        devices={[]}
+        plants={[]}
+        onSelectZone={() => {}}
+        onRename={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        onAdjustWater={() => {}}
+        onAdjustNutrients={() => {}}
+        onOpenPlantingModal={() => {}}
+        onOpenAutomationPlanModal={() => {}}
+        onOpenDeviceModal={() => {}}
+        onHarvestPlant={() => {}}
+        onHarvestAll={() => {}}
+        onToggleDeviceGroup={() => {}}
+        onTogglePlan={() => {}}
+      />,
+    );
+
+    expect(markup).toContain(
+      'disabled="" aria-disabled="true" title="No compatible strains available. Ask your designers to add strain blueprints."',
+    );
+    expect(markup).toContain('Designers: add strain blueprints to enable planting.');
+    expect(markup).toContain(
+      'disabled="" aria-disabled="true" title="No compatible devices available. Ask your designers to add device blueprints."',
+    );
+    expect(markup).toContain('Designers: add device blueprints to enable installations.');
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- compute available strain and device options for the active zone using the existing selectors
- disable the add planting/install device buttons with helper messaging when no compatible blueprints exist
- add a ZoneDetailView unit test to cover the disabled state behaviour

## Testing
- pnpm --filter @weebbreed/frontend exec vitest run src/components/world-explorer/ZoneDetailView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7fc8b2cfc83259994eeb38efdd4c0


___

### **PR Type**
Enhancement


___

### **Description**
- Add availability gating to zone planting and device actions

- Disable buttons with helper text when no blueprints exist

- Implement unit tests for disabled state behavior

- Style disabled buttons with muted appearance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zone Detail View"] --> B["Check Available Strains"]
  A --> C["Check Compatible Devices"]
  B --> D["Disable Add Planting Button"]
  C --> E["Disable Install Device Button"]
  D --> F["Show Helper Text"]
  E --> G["Show Helper Text"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ZoneDetailView.module.css</strong><dd><code>Add disabled button and helper text styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/world-explorer/ZoneDetailView.module.css

<ul><li>Add <code>.actionDisabled</code> styles for disabled buttons<br> <li> Add <code>.helperText</code> styles for guidance messages<br> <li> Format CSS transition properties for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/251/files#diff-64ae675ea70e05248d0a7a03e26835df589eb7f76ced916d867b430bc374bb4f">+31/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WorldExplorer.tsx</strong><dd><code>Add blueprint availability checks to WorldExplorer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/WorldExplorer.tsx

<ul><li>Import strain and device option selectors<br> <li> Calculate <code>hasAvailableStrains</code> and <code>hasCompatibleDevices</code> flags<br> <li> Pass availability flags to <code>ZoneDetailView</code> component</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/251/files#diff-df7445aec1f2cd33ef8f94e28f23e9fed438daa5e993a7b8133ca63fdd8f1293">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZoneDetailView.tsx</strong><dd><code>Implement blueprint availability gating logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/world-explorer/ZoneDetailView.tsx

<ul><li>Add <code>hasAvailableStrains</code> and <code>hasCompatibleDevices</code> props<br> <li> Implement button disabling logic with tooltips<br> <li> Add helper text when no blueprints available<br> <li> Use store selectors as fallback for availability checks</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/251/files#diff-0a66a6540b194ec8c9a47aa63953b2a04e73dd0ef1e2e4cd726ca573321c3f19">+130/-28</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ZoneDetailView.test.tsx</strong><dd><code>Add unit tests for availability gating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/world-explorer/ZoneDetailView.test.tsx

<ul><li>Create comprehensive unit test for disabled state behavior<br> <li> Mock store selectors and translation functions<br> <li> Test button disabling and helper text rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/251/files#diff-1ff04e001722a27485619e99495966702abfa65916ccf98abe55e6cff91bf598">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

