### PR TITLE
feat(frontend): centralize number formatting

### DIFF
--- a/src/frontend/src/__tests__/formatNumber.test.ts
+++ b/src/frontend/src/__tests__/formatNumber.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatNumber } from '@/utils/formatNumber';
+
+describe('formatNumber', () => {
+  it('rounds to two decimals by default', () => {
+    expect(formatNumber(123.456, undefined, 'en-US')).toBe('123.46');
+    expect(formatNumber(10.1, undefined, 'en-US')).toBe('10.1');
+  });
+
+  it('respects custom fraction digit overrides', () => {
+    expect(formatNumber(1234.567, { maximumFractionDigits: 0 }, 'en-US')).toBe('1,235');
+    expect(formatNumber(1.2, { minimumFractionDigits: 2, maximumFractionDigits: 2 }, 'en-US')).toBe(
+      '1.20',
+    );
+  });
+});

--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -12,6 +12,7 @@ import { useNavigationStore } from '@/store/navigation';
 import { ModifierInputs } from '../modifiers/ModifierInputs';
 import { DifficultyModifiers } from '../../types/difficulty';
 import { useDifficultyConfig } from '@/hooks/useDifficultyConfig';
+import { formatNumber } from '@/utils/formatNumber';
 
 interface ModalHostProps {
   bridge: SimulationBridge;
@@ -153,12 +154,14 @@ const RentStructureModal = ({
               <div className="flex flex-col gap-1 text-left">
                 <span className="text-sm font-semibold text-text">{blueprint.name}</span>
                 <span className="text-xs text-text-muted">
-                  {area.toLocaleString()} m² · Upfront €{blueprint.upfrontFee.toLocaleString()} ·
-                  Rent €{blueprint.rentalCostPerSqmPerMonth}/m²·month
+                  {formatNumber(area)} m² · Upfront €
+                  {formatNumber(blueprint.upfrontFee, { maximumFractionDigits: 0 })} · Rent €
+                  {formatNumber(blueprint.rentalCostPerSqmPerMonth)}/m²·month
                 </span>
                 <span className="text-xs text-text-muted/80">
-                  {blueprint.footprint.length}m × {blueprint.footprint.width}m ×{' '}
-                  {blueprint.footprint.height}m
+                  {formatNumber(blueprint.footprint.length)}m ×{' '}
+                  {formatNumber(blueprint.footprint.width)}m ×{' '}
+                  {formatNumber(blueprint.footprint.height)}m
                 </span>
               </div>
             </label>
@@ -252,7 +255,7 @@ const DuplicateStructureModal = ({
         <span className="font-medium text-text">{structure.name}</span>
         <span>
           {rooms.length} rooms · {zones.length} zones · Rent €
-          {structure.rentPerTick.toLocaleString()} per tick
+          {formatNumber(structure.rentPerTick, { maximumFractionDigits: 0 })} per tick
         </span>
       </div>
       <label className="grid gap-1 text-sm">
@@ -475,7 +478,9 @@ const CreateRoomModal = ({
       return;
     }
     if (area > availableArea) {
-      setFeedback(`Room area (${area} m²) exceeds available space (${availableArea} m²).`);
+      setFeedback(
+        `Room area (${formatNumber(area)} m²) exceeds available space (${formatNumber(availableArea)} m²).`,
+      );
       return;
     }
     setBusy(true);
@@ -566,8 +571,8 @@ const CreateRoomModal = ({
             }`}
           />
           <span className={`text-xs ${area > availableArea ? 'text-red-600' : 'text-text-muted'}`}>
-            Available: {availableArea.toFixed(0)} m² (structure footprint:{' '}
-            {structure.footprint.area} m²)
+            Available: {formatNumber(availableArea, { maximumFractionDigits: 0 })} m² (structure
+            footprint: {formatNumber(structure.footprint.area)} m²)
           </span>
         </label>
       </div>
@@ -646,7 +651,7 @@ const DuplicateRoomModal = ({
       <div className="grid gap-1 text-sm text-text-muted">
         <span className="font-medium text-text">{room.name}</span>
         <span>
-          {zones.length} zones · {room.area} m² · Purpose {room.purposeName}
+          {zones.length} zones · {formatNumber(room.area)} m² · Purpose {room.purposeName}
         </span>
       </div>
       <label className="grid gap-1 text-sm">
@@ -834,19 +839,27 @@ const EmployeeDetailsModal = ({
         </div>
         <div className="flex justify-between">
           <span className="text-text-muted">Salary</span>
-          <span className="font-medium text-text">€{employee.salaryPerTick}/tick</span>
+          <span className="font-medium text-text">
+            €{formatNumber(employee.salaryPerTick, { maximumFractionDigits: 0 })}/tick
+          </span>
         </div>
         <div className="flex justify-between">
           <span className="text-text-muted">Morale</span>
-          <span className="font-medium text-text">{Math.round(employee.morale * 100)}%</span>
+          <span className="font-medium text-text">
+            {formatNumber(employee.morale * 100, { maximumFractionDigits: 0 })}%
+          </span>
         </div>
         <div className="flex justify-between">
           <span className="text-text-muted">Energy</span>
-          <span className="font-medium text-text">{Math.round(employee.energy * 100)}%</span>
+          <span className="font-medium text-text">
+            {formatNumber(employee.energy * 100, { maximumFractionDigits: 0 })}%
+          </span>
         </div>
         <div className="flex justify-between">
           <span className="text-text-muted">Max Work Time</span>
-          <span className="font-medium text-text">{employee.maxMinutesPerTick} min/tick</span>
+          <span className="font-medium text-text">
+            {formatNumber(employee.maxMinutesPerTick, { maximumFractionDigits: 0 })} min/tick
+          </span>
         </div>
         {employee.assignedStructureId && (
           <div className="flex justify-between">
@@ -992,7 +1005,8 @@ const CreateZoneModal = ({
             className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none"
           />
           <span className="text-xs text-text-muted">
-            Available: {availableArea.toFixed(1)} m² (room area: {room.area} m²)
+            Available: {formatNumber(availableArea, { maximumFractionDigits: 1 })} m² (room area:{' '}
+            {formatNumber(room.area)} m²)
           </span>
         </label>
       </div>
@@ -1044,7 +1058,10 @@ const NewGameModal = ({
       id: key as 'easy' | 'normal' | 'hard',
       name: config.name,
       description: config.description,
-      initialCapital: `€${(config.modifiers.economics.initialCapital / 1_000_000).toFixed(1)}M`,
+      initialCapital: `€${formatNumber(config.modifiers.economics.initialCapital / 1_000_000, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      })}M`,
       color:
         key === 'easy' ? 'text-green-600' : key === 'normal' ? 'text-yellow-600' : 'text-red-600',
     }));

--- a/src/frontend/src/utils/formatNumber.ts
+++ b/src/frontend/src/utils/formatNumber.ts
@@ -1,0 +1,12 @@
+export const formatNumber = (
+  value: number,
+  options: Intl.NumberFormatOptions = {},
+  locale?: string | string[],
+): string => {
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 2,
+    ...options,
+  });
+
+  return formatter.format(value);
+};

--- a/src/frontend/src/views/RoomView.tsx
+++ b/src/frontend/src/views/RoomView.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/primitives/Badge';
 import { useSimulationStore } from '@/store/simulation';
 import { useNavigationStore } from '@/store/navigation';
 import { useUIStore } from '@/store/ui';
+import { formatNumber } from '@/utils/formatNumber';
 
 export const RoomView = () => {
   const snapshot = useSimulationStore((state) => state.snapshot);
@@ -83,7 +84,7 @@ export const RoomView = () => {
         <span className="text-xs uppercase tracking-wide text-text-muted">Room</span>
         <h2 className="text-2xl font-semibold text-text">{room.name}</h2>
         <p className="text-sm text-text-muted">
-          {room.area} m² · {zones.length} zones · method {room.purposeName}
+          {formatNumber(room.area)} m² · {zones.length} zones · method {room.purposeName}
         </p>
       </header>
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -91,7 +92,7 @@ export const RoomView = () => {
           <Card
             key={zone.id}
             title={zone.name}
-            subtitle={`${zone.area} m² · PPFD ${zone.environment.ppfd} µmol`}
+            subtitle={`${formatNumber(zone.area)} m² · PPFD ${formatNumber(zone.environment.ppfd)} µmol`}
             action={
               <Button
                 variant="ghost"
@@ -114,23 +115,36 @@ export const RoomView = () => {
               <div className="flex items-center gap-2 text-text">
                 <Icon name="device_thermostat" size={20} />
                 <span>
-                  {zone.environment.temperature.toFixed(1)}°C · RH{' '}
-                  {(zone.environment.relativeHumidity * 100).toFixed(0)}%
+                  {formatNumber(zone.environment.temperature, {
+                    minimumFractionDigits: 1,
+                    maximumFractionDigits: 1,
+                  })}
+                  °C · RH{' '}
+                  {formatNumber(zone.environment.relativeHumidity * 100, {
+                    maximumFractionDigits: 0,
+                  })}
+                  %
                 </span>
               </div>
               <div className="flex items-center gap-2">
                 <Icon name="water_drop" size={20} />
-                <span>Reservoir {(zone.resources.reservoirLevel * 100).toFixed(0)}%</span>
+                <span>
+                  Reservoir{' '}
+                  {formatNumber(zone.resources.reservoirLevel * 100, { maximumFractionDigits: 0 })}%
+                </span>
               </div>
               <div className="flex items-center gap-2">
                 <Icon name="park" size={20} />
                 <span>
-                  {zone.plants.length} plants · Stress {Math.round(zone.metrics.stressLevel * 100)}%
+                  {zone.plants.length} plants · Stress{' '}
+                  {formatNumber(zone.metrics.stressLevel * 100, { maximumFractionDigits: 0 })}%
                 </span>
               </div>
             </div>
             <div className="mt-4 flex items-center justify-between">
-              <Badge tone="default">DLI {zone.lighting?.dli ?? 0} mol</Badge>
+              <Badge tone="default">
+                DLI {formatNumber(zone.lighting?.dli ?? 0, { maximumFractionDigits: 2 })} mol
+              </Badge>
               <Button
                 variant="primary"
                 size="sm"

--- a/src/frontend/src/views/StructureView.tsx
+++ b/src/frontend/src/views/StructureView.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/primitives/Badge';
 import { useSimulationStore } from '@/store/simulation';
 import { useNavigationStore } from '@/store/navigation';
 import { useUIStore } from '@/store/ui';
+import { formatNumber } from '@/utils/formatNumber';
 
 export const StructureView = () => {
   const snapshot = useSimulationStore((state) => state.snapshot);
@@ -33,8 +34,8 @@ export const StructureView = () => {
             <span className="text-xs uppercase tracking-wide text-text-muted">Structure</span>
             <h2 className="text-2xl font-semibold text-text">{structure.name}</h2>
             <p className="text-sm text-text-muted">
-              {structure.footprint.area} m² · {rooms.length} rooms · {structure.footprint.volume} m³
-              volume
+              {formatNumber(structure.footprint.area)} m² · {rooms.length} rooms ·{' '}
+              {formatNumber(structure.footprint.volume)} m³ volume
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -74,7 +75,9 @@ export const StructureView = () => {
         </div>
         <div className="flex items-center gap-3">
           <Badge tone="success">Operational</Badge>
-          <Badge tone="default">Rent €{structure.rentPerTick.toLocaleString()} / tick</Badge>
+          <Badge tone="default">
+            Rent €{formatNumber(structure.rentPerTick, { maximumFractionDigits: 0 })} / tick
+          </Badge>
         </div>
       </header>
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -84,7 +87,7 @@ export const StructureView = () => {
             <Card
               key={room.id}
               title={room.name}
-              subtitle={`${zones.length} zones · ${room.area} m²`}
+              subtitle={`${zones.length} zones · ${formatNumber(room.area)} m²`}
               action={
                 <div className="flex gap-2">
                   <Button
@@ -117,11 +120,16 @@ export const StructureView = () => {
                 </div>
                 <div className="flex items-center gap-2">
                   <Icon name="science" size={20} />
-                  <span>Maintenance {Math.round(room.maintenanceLevel * 100)}%</span>
+                  <span>
+                    Maintenance{' '}
+                    {formatNumber(room.maintenanceLevel * 100, { maximumFractionDigits: 0 })}%
+                  </span>
                 </div>
               </div>
               <div className="mt-4 flex items-center justify-between">
-                <Badge tone="default">Cleanliness {Math.round(room.cleanliness * 100)}%</Badge>
+                <Badge tone="default">
+                  Cleanliness {formatNumber(room.cleanliness * 100, { maximumFractionDigits: 0 })}%
+                </Badge>
                 <Button
                   variant="primary"
                   size="sm"

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -25,6 +25,7 @@ import { useNavigationStore } from '@/store/navigation';
 import { useUIStore } from '@/store/ui';
 import type { PlantSnapshot } from '@/types/simulation';
 import type { ZoneHistoryPoint } from '@/store/simulation';
+import { formatNumber } from '@/utils/formatNumber';
 
 const columnHelper = createColumnHelper<PlantSnapshot>();
 
@@ -42,15 +43,16 @@ const plantColumns = [
   }),
   columnHelper.accessor('health', {
     header: 'Health',
-    cell: (info) => `${Math.round(info.getValue() * 100)}%`,
+    cell: (info) => `${formatNumber(info.getValue() * 100, { maximumFractionDigits: 0 })}%`,
   }),
   columnHelper.accessor('stress', {
     header: 'Stress',
-    cell: (info) => `${Math.round(info.getValue() * 100)}%`,
+    cell: (info) => `${formatNumber(info.getValue() * 100, { maximumFractionDigits: 0 })}%`,
   }),
   columnHelper.accessor('biomassDryGrams', {
     header: 'Biomass (g)',
-    cell: (info) => info.getValue().toFixed(1),
+    cell: (info) =>
+      formatNumber(info.getValue(), { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
   }),
 ];
 
@@ -170,13 +172,19 @@ export const ZoneView = () => {
         <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
         <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
         <p className="text-sm text-text-muted">
-          {zone.area} m² · volume {zone.volume} m³ · cultivation method{' '}
+          {formatNumber(zone.area)} m² · volume {formatNumber(zone.volume)} m³ · cultivation method{' '}
           {zone.cultivationMethodId ?? '—'}
         </p>
         <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge tone="success">VPD {zone.environment.vpd.toFixed(2)}</Badge>
-          <Badge tone="default">PPFD {zone.environment.ppfd} µmol</Badge>
-          <Badge tone="default">CO₂ {zone.environment.co2} ppm</Badge>
+          <Badge tone="success">
+            VPD{' '}
+            {formatNumber(zone.environment.vpd, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
+          </Badge>
+          <Badge tone="default">PPFD {formatNumber(zone.environment.ppfd)} µmol</Badge>
+          <Badge tone="default">CO₂ {formatNumber(zone.environment.co2)} ppm</Badge>
         </div>
       </header>
       <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
@@ -186,25 +194,32 @@ export const ZoneView = () => {
               <div className="flex flex-col gap-1 text-sm text-text-muted">
                 <span className="text-xs uppercase text-text-muted">Temperature</span>
                 <span className="text-lg font-semibold text-text">
-                  {zone.environment.temperature.toFixed(1)}°C
+                  {formatNumber(zone.environment.temperature, {
+                    minimumFractionDigits: 1,
+                    maximumFractionDigits: 1,
+                  })}
+                  °C
                 </span>
               </div>
               <div className="flex flex-col gap-1 text-sm text-text-muted">
                 <span className="text-xs uppercase text-text-muted">Relative Humidity</span>
                 <span className="text-lg font-semibold text-text">
-                  {(zone.environment.relativeHumidity * 100).toFixed(0)}%
+                  {formatNumber(zone.environment.relativeHumidity * 100, {
+                    maximumFractionDigits: 0,
+                  })}
+                  %
                 </span>
               </div>
               <div className="flex flex-col gap-1 text-sm text-text-muted">
                 <span className="text-xs uppercase text-text-muted">Transpiration</span>
                 <span className="text-lg font-semibold text-text">
-                  {zone.resources.lastTranspirationLiters} L
+                  {formatNumber(zone.resources.lastTranspirationLiters)} L
                 </span>
               </div>
               <div className="flex flex-col gap-1 text-sm text-text-muted">
                 <span className="text-xs uppercase text-text-muted">Stress</span>
                 <span className="text-lg font-semibold text-text">
-                  {Math.round(zone.metrics.stressLevel * 100)}%
+                  {formatNumber(zone.metrics.stressLevel * 100, { maximumFractionDigits: 0 })}%
                 </span>
               </div>
             </div>
@@ -280,8 +295,12 @@ export const ZoneView = () => {
                     <div className="flex flex-col">
                       <span className="text-sm font-semibold text-text">{device.name}</span>
                       <span className="text-xs text-text-muted">
-                        Runtime {device.runtimeHours} h · Condition{' '}
-                        {Math.round(device.maintenance.condition * 100)}%
+                        Runtime {formatNumber(device.runtimeHours, { maximumFractionDigits: 0 })} h
+                        · Condition{' '}
+                        {formatNumber(device.maintenance.condition * 100, {
+                          maximumFractionDigits: 0,
+                        })}
+                        %
                       </span>
                     </div>
                   </div>
@@ -310,23 +329,29 @@ export const ZoneView = () => {
             <div className="grid gap-3 text-sm text-text-muted">
               <div className="flex items-center justify-between">
                 <span>Water reserve</span>
-                <Badge tone="default">{zone.resources.waterLiters.toLocaleString()} L</Badge>
+                <Badge tone="default">{formatNumber(zone.resources.waterLiters)} L</Badge>
               </div>
               <div className="flex items-center justify-between">
                 <span>Nutrient solution</span>
                 <Badge tone="default">
-                  {zone.resources.nutrientSolutionLiters.toLocaleString()} L
+                  {formatNumber(zone.resources.nutrientSolutionLiters)} L
                 </Badge>
               </div>
               <div className="flex items-center justify-between">
                 <span>Nutrient strength</span>
-                <Badge tone="default">{zone.resources.nutrientStrength.toFixed(2)} EC</Badge>
+                <Badge tone="default">
+                  {formatNumber(zone.resources.nutrientStrength, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}{' '}
+                  EC
+                </Badge>
               </div>
               <div className="flex items-center justify-between">
                 <span>Daily consumption</span>
                 <Badge tone="default">
-                  {zone.supplyStatus?.dailyWaterConsumptionLiters ?? 0} L /{' '}
-                  {zone.supplyStatus?.dailyNutrientConsumptionLiters ?? 0} L
+                  {formatNumber(zone.supplyStatus?.dailyWaterConsumptionLiters ?? 0)} L /{' '}
+                  {formatNumber(zone.supplyStatus?.dailyNutrientConsumptionLiters ?? 0)} L
                 </Badge>
               </div>
             </div>


### PR DESCRIPTION
### **User description**
## Summary
- add a shared `formatNumber` helper that defaults to two decimal places while allowing per-call overrides
- route structure, room, zone, and modal numeric labels through the helper for consistent area, volume, telemetry, and resource rendering
- cover the helper with vitest assertions to guard the default precision and customization behaviour

## Testing
- pnpm run check *(fails: frontend lint configuration still references `import/no-unresolved` which is not installed in the workspace)*
- pnpm --filter @weebbreed/frontend test *(fails: existing ModalHost pause safety test expects `toBeInTheDocument`, which is unavailable under the current Vitest assertion setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d8023c06a88325b6d76712d13f62ad


___

### **PR Type**
Enhancement


___

### **Description**
- Add centralized `formatNumber` utility with configurable precision

- Replace manual number formatting across UI components

- Add comprehensive test coverage for formatting behavior

- Standardize numeric display in modals, views, and badges


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["formatNumber utility"] --> B["ModalHost components"]
  A --> C["RoomView displays"]
  A --> D["StructureView metrics"]
  A --> E["ZoneView telemetry"]
  F["Test coverage"] --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formatNumber.ts</strong><dd><code>Add formatNumber utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/utils/formatNumber.ts

<ul><li>Create utility function using <code>Intl.NumberFormat</code><br> <li> Default to 2 decimal places with locale support<br> <li> Allow custom formatting options override</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-c5e64c5c21e526d60f50cae457d6e17cbd86e9270e02d5e72f6fb9a6c048555a">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Standardize modal number formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Replace <code>toLocaleString()</code> calls with <code>formatNumber</code><br> <li> Apply consistent formatting to areas, costs, dimensions<br> <li> Use zero decimals for currency and percentages<br> <li> Format employee metrics and salary displays</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+32/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RoomView.tsx</strong><dd><code>Standardize room view formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/views/RoomView.tsx

<ul><li>Format room area and zone metrics consistently<br> <li> Apply precision control to temperature and humidity<br> <li> Standardize plant stress and resource displays</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-5a776151e54576d86ff4b51eeb914224d4c081b3955618f2681e12be668f499d">+21/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StructureView.tsx</strong><dd><code>Standardize structure view formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/views/StructureView.tsx

<ul><li>Format structure footprint and volume displays<br> <li> Standardize rent and maintenance percentages<br> <li> Apply consistent room area formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-b0c023aa6f42b52d1145dac689db6999563e52cc46315363337b17111a550b44">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZoneView.tsx</strong><dd><code>Standardize zone view formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/views/ZoneView.tsx

<ul><li>Format environmental telemetry with proper precision<br> <li> Standardize plant health and biomass displays<br> <li> Apply consistent formatting to resource metrics<br> <li> Format device runtime and condition percentages</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-dba4b9f137dd357469bbdd22a9d24fdc7849a451b264578544edf499562e8aaf">+43/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formatNumber.test.ts</strong><dd><code>Add formatNumber test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/__tests__/formatNumber.test.ts

<ul><li>Test default 2-decimal precision behavior<br> <li> Verify custom fraction digit overrides<br> <li> Cover locale-specific formatting scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/252/files#diff-6d7361d73cc2ab40f47e2bdb04a5378cf606c6e5c8a3148f2d864c271b7332ee">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

