### PR TITLE
Ensure UtilityPricing formatting caps decimals

### DIFF
--- a/src/frontend/src/components/finance/UtilityPricing.test.tsx
+++ b/src/frontend/src/components/finance/UtilityPricing.test.tsx
@@ -63,9 +63,9 @@ describe('UtilityPricing component', () => {
   it('renders current utility prices from the snapshot', () => {
     render(<UtilityPricing bridge={bridge} />);
 
-    expect(screen.getByText('€0.150')).toBeInTheDocument();
-    expect(screen.getByText('€0.020')).toBeInTheDocument();
-    expect(screen.getByText('€0.100')).toBeInTheDocument();
+    expect(screen.getByText('€0.15')).toBeInTheDocument();
+    expect(screen.getByText('€0.02')).toBeInTheDocument();
+    expect(screen.getByText('€0.10')).toBeInTheDocument();
   });
 
   it('sends converted payload on save and shows success message', async () => {


### PR DESCRIPTION
### **User description**
## Summary
- use the shared `formatNumber` helper in UtilityPricing to render currency, percentage, and total-impact values with at most two decimals and round pending values accordingly
- tighten the number input to two decimal steps and reuse the helper for its value binding to keep user input consistent with the display
- refresh the UtilityPricing test expectations to match the new two-decimal currency output

## Testing
- pnpm run check *(fails: frontend lint reports missing definition for rule `import/no-unresolved` from the shared ESLint config)*
- pnpm --filter @weebbreed/frontend test -- UtilityPricing.test.tsx *(fails: vitest environment lacks the `toBeInTheDocument` matcher in ModalHost tests even after installing test utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68d80513e8988325bedd50f0c7e922ef


___

### **PR Type**
Enhancement


___

### **Description**
- Standardize decimal formatting to 2 places for currency values

- Replace custom formatting with shared `formatNumber` helper

- Update number input step and validation constraints

- Adjust test expectations for new formatting output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom formatting"] --> B["formatNumber helper"]
  C["3 decimal places"] --> D["2 decimal places"]
  E["Input step 0.001"] --> F["Input step 0.01"]
  G["Test expectations"] --> H["Updated assertions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UtilityPricing.tsx</strong><dd><code>Implement 2-decimal formatting with shared helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/finance/UtilityPricing.tsx

<ul><li>Import <code>formatNumber</code> helper for consistent decimal formatting<br> <li> Add <code>roundToTwoDecimals</code> utility function for value rounding<br> <li> Update <code>formatCurrency</code> to use 2 decimal places instead of 3<br> <li> Modify <code>formatPercentage</code> to accept options and use <code>formatNumber</code><br> <li> Change number input step from 0.001 to 0.01<br> <li> Apply rounding to pending changes and adjusted values</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/253/files#diff-8f3eb27d29796c44be7a90238dbae8e0f7443c929ea8a21c3f9902528961efe8">+26/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UtilityPricing.test.tsx</strong><dd><code>Update test expectations for 2-decimal format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/finance/UtilityPricing.test.tsx

<ul><li>Update test assertions to expect 2-decimal currency format<br> <li> Change from €0.150/€0.020/€0.100 to €0.15/€0.02/€0.10</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/253/files#diff-407b59a1b1d41876ed9450debbb8008f0fb9e2abae5980437fa7fda0bbe8ec44">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

