### PR TITLE
Fix currency formatting for modifier inputs

### DIFF
--- a/src/frontend/src/components/modifiers/ModifierInputs.tsx
+++ b/src/frontend/src/components/modifiers/ModifierInputs.tsx
@@ -1,4 +1,5 @@
 //import { useState } from 'react';
+import { formatNumber } from '@/utils/formatNumber';
 import { DifficultyModifiers, getModifierRange } from '../../types/difficulty';
 
 interface ModifierInputsProps {
@@ -12,7 +13,7 @@ const formatCurrency = (value: number): string => {
   } else if (value >= 1000) {
     return `€${(value / 1000).toFixed(0)}K`;
   } else {
-    return `€${value}`;
+    return `€${formatNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   }
 };
 

--- a/src/frontend/src/components/modifiers/__tests__/ModifierInputs.test.tsx
+++ b/src/frontend/src/components/modifiers/__tests__/ModifierInputs.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ModifierInputs } from '../ModifierInputs';
+import type { DifficultyModifiers } from '../../../types/difficulty';
+
+describe('ModifierInputs', () => {
+  it('formats currency values below 1000 with two decimal places', () => {
+    const modifiers: DifficultyModifiers = {
+      plantStress: {
+        optimalRangeMultiplier: 1,
+        stressAccumulationMultiplier: 1,
+      },
+      deviceFailure: {
+        mtbfMultiplier: 1,
+      },
+      economics: {
+        initialCapital: 123.456,
+        itemPriceMultiplier: 1,
+        harvestPriceMultiplier: 1,
+        rentPerSqmStructurePerTick: 0.5,
+        rentPerSqmRoomPerTick: 0.5,
+      },
+    };
+
+    render(<ModifierInputs modifiers={modifiers} onChange={vi.fn()} />);
+
+    expect(screen.getByText('€123.46')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- ensure `formatCurrency` in `ModifierInputs` uses the shared `formatNumber` helper to round values under €1K while keeping the existing K/M abbreviations for larger amounts
- add a dedicated component test that verifies a €123.456 value renders as `€123.46`

## Testing
- pnpm --filter @weebbreed/frontend test *(fails: existing `ModalHost` test lacks `toBeInTheDocument` matcher setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d8093aecc083259a9100d3aefcab29


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix currency formatting for values under €1K to show proper decimal places

- Add component test to verify €123.456 renders as €123.46

- Import shared `formatNumber` helper for consistent number formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["formatCurrency function"] --> B["Import formatNumber helper"]
  B --> C["Round values under €1K to 2 decimals"]
  C --> D["Add component test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModifierInputs.tsx</strong><dd><code>Fix currency formatting for small values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modifiers/ModifierInputs.tsx

<ul><li>Import <code>formatNumber</code> utility from utils<br> <li> Update <code>formatCurrency</code> to use <code>formatNumber</code> for values under €1K<br> <li> Ensure proper decimal formatting with 2 decimal places for small <br>amounts</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/254/files#diff-885c133c29bbdfaef8fe093bd372802b8f736392331723d0f2ec6796a908da2d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModifierInputs.test.tsx</strong><dd><code>Add currency formatting test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modifiers/__tests__/ModifierInputs.test.tsx

<ul><li>Create new test file for ModifierInputs component<br> <li> Add test case verifying currency formatting for values below €1K<br> <li> Test that €123.456 renders as €123.46 with proper decimal places</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/254/files#diff-92f06f9910327c625a9c1034c2fbfbc38e8f4a048dfda9641803b5d50bfff61a">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

