### PR TITLE
Add strain and device blueprint catalog commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented simulation constant governance in [ADR 0009](docs/system/adr/0009-simulation-constants-governance.md) and cross-linked the constants catalogue.
 - **Dynamic Structure Blueprint Loading**: The "Rent Structure" modal now dynamically loads available structure blueprints from the backend instead of using hardcoded frontend data. The backend exposes structure blueprints from `/data/blueprints/structures/*.json` through a new `getStructureBlueprints` facade intent. This ensures the frontend always displays the most current and accurate structure options available in the game.
+- Added world facade intents `getStrainBlueprints` and `getDeviceBlueprints` with deterministic catalog payloads (IDs, names, compatibility hints, default settings, and price hints), wired through the simulation facade/socket gateway and documented in the protocol guide.
 
 - **Enhanced Seed Generation System**: Implemented sophisticated seed generation for the New Game view based on `/reports/start_new_game-changes.md`. Features include:
   - **MULLBERRY32 PRNG**: Replaced simple LCG with high-quality MULLBERRY32 algorithm for better randomness distribution

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -71,6 +71,10 @@ Common categories are below.
 
 ### 4.3 World Building (Structures → Rooms → Zones)
 
+- `getStructureBlueprints()` / `getStrainBlueprints()` /
+  `getDeviceBlueprints()` — read-only catalogs with IDs, names,
+  compatibility hints (room purposes or method affinity), default settings, and
+  price hints sourced from the active blueprint repository.
 - `rentStructure(structureId: UUID)` — validates availability; applies CapEx/Fixed cost rules.
 - `renameStructure({ structureId, name })` — trims whitespace, preserves determinism, emits rename events.
 - `deleteStructure(structureId)` — enforces empty structure + accounting clean-up.

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -399,11 +399,12 @@ object:
 
 #### Supported actions per domain
 
-- **world** — `rentStructure`, `createRoom`, `updateRoom`, `deleteRoom`,
-  `createZone`, `updateZone`, `deleteZone`, `renameStructure`, `deleteStructure`,
-  `duplicateStructure`, `duplicateRoom`, `duplicateZone`. Duplication commands
-  accept an optional `name` override and return `{ structureId | roomId | zoneId
-}` for the newly created copy.
+- **world** — `getStructureBlueprints`, `getStrainBlueprints`,
+  `getDeviceBlueprints`, `rentStructure`, `createRoom`, `updateRoom`,
+  `deleteRoom`, `createZone`, `updateZone`, `deleteZone`, `renameStructure`,
+  `deleteStructure`, `duplicateStructure`, `duplicateRoom`, `duplicateZone`.
+  Duplication commands accept an optional `name` override and return
+  `{ structureId | roomId | zoneId }` for the newly created copy.
 - **devices** — `installDevice`, `updateDevice`, `moveDevice`, `removeDevice`,
   `toggleDeviceGroup`. The toggle action returns `{ deviceIds: string[] }` with
   every instance that changed status.
@@ -415,6 +416,77 @@ object:
 - **workforce** — `refreshCandidates`, `hire`, `fire`, `setOvertimePolicy`,
   `assignStructure`, `enqueueTask` (payload defaults to `{}` when omitted).
 - **finance** — `sellInventory`, `setUtilityPrices`, `setMaintenancePolicy`.
+
+##### Blueprint catalog commands
+
+- `getStructureBlueprints` returns the raw `StructureBlueprint[]` catalog
+  (geometry, rent, upfront fee). Payload defaults to `{}`.
+- `getStrainBlueprints` returns an alphabetised strain catalog with compatibility
+  and defaults. Example entry:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000401",
+  "slug": "helios",
+  "name": "Helios",
+  "lineage": { "parents": [] },
+  "genotype": { "sativa": 0.6, "indica": 0.4, "ruderalis": 0 },
+  "chemotype": { "thcContent": 0.22, "cbdContent": 0.01 },
+  "generalResilience": 0.8,
+  "germinationRate": 0.95,
+  "compatibility": {
+    "methodAffinity": { "85cc0916-0e8a-495e-af8f-50291abe6855": 0.85 },
+    "stressTolerance": { "temp_C": 1, "vpd_kPa": 0.15 }
+  },
+  "defaults": {
+    "envBands": { "default": { "temp_C": { "green": [23, 27] } } },
+    "phaseDurations": { "vegDays": 21, "flowerDays": 63 },
+    "photoperiod": { "vegetationTime": 2419200, "floweringTime": 5443200 },
+    "nutrientDemand": { "dailyNutrientDemand": { "flowering": { "nitrogen": 0.07 } } },
+    "waterDemand": { "dailyWaterUsagePerSquareMeter": { "flowering": 0.54 } },
+    "growthModel": { "maxBiomassDry": 0.18 },
+    "yieldModel": { "baseGmPerPlant": 45 }
+  },
+  "traits": {
+    "morphology": { "growthRate": 1, "yieldFactor": 1 },
+    "noise": { "enabled": true, "pct": 0.02 }
+  },
+  "metadata": { "description": "Hybrid strain tuned for balanced growth." },
+  "price": { "seedPrice": 1.1, "harvestPricePerGram": 4.4 }
+}
+```
+
+- `getDeviceBlueprints` returns device catalog entries with compatibility and
+  default settings:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000501",
+  "kind": "Lamp",
+  "name": "Orion Lamp",
+  "quality": 0.95,
+  "complexity": 0.5,
+  "lifetimeHours": 72000,
+  "capexEur": 1350,
+  "efficiencyDegeneration": 0.01,
+  "compatibility": { "roomPurposes": ["growroom"] },
+  "defaults": {
+    "settings": { "power": 0.68, "ppfd": 810, "coverageArea": 8 },
+    "coverage": { "maxArea_m2": 12 },
+    "limits": { "maxPPFD": 1000 }
+  },
+  "maintenance": { "intervalDays": 90, "costPerService_eur": 80, "hoursPerService": 2 },
+  "metadata": { "description": "Balanced flowering lamp" },
+  "price": {
+    "capitalExpenditure": 1350,
+    "baseMaintenanceCostPerTick": 0.0023,
+    "costIncreasePer1000Ticks": 0.0005
+  }
+}
+```
+
+Each response is regenerated from the active blueprint repository on demand to
+avoid stale caches.
 
 Clients may optimistically update UI state after receiving a successful
 `*.intent.result` packet but must still observe follow-up telemetry for the

--- a/src/backend/src/facade/blueprintCatalog.ts
+++ b/src/backend/src/facade/blueprintCatalog.ts
@@ -1,0 +1,210 @@
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import type {
+  DeviceBlueprint,
+  DevicePriceEntry,
+  StrainBlueprint,
+  StrainPriceEntry,
+} from '@/data/schemas/index.js';
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const sortByName = <T extends { name: string }>(a: T, b: T) => a.name.localeCompare(b.name, 'en');
+
+export interface StrainCompatibilityHints {
+  methodAffinity: Record<string, number>;
+  stressTolerance?: Record<string, number>;
+}
+
+export interface StrainDefaultSettings {
+  envBands?: StrainBlueprint['envBands'];
+  phaseDurations?: StrainBlueprint['phaseDurations'];
+  photoperiod?: StrainBlueprint['photoperiod'];
+  nutrientDemand?: StrainBlueprint['nutrientDemand'];
+  waterDemand?: StrainBlueprint['waterDemand'];
+  growthModel?: StrainBlueprint['growthModel'];
+  yieldModel?: StrainBlueprint['yieldModel'];
+}
+
+export interface StrainTraits {
+  morphology?: StrainBlueprint['morphology'];
+  noise?: StrainBlueprint['noise'];
+}
+
+export interface StrainBlueprintCatalogEntry {
+  id: string;
+  slug: string;
+  name: string;
+  lineage: StrainBlueprint['lineage'];
+  genotype: StrainBlueprint['genotype'];
+  chemotype: StrainBlueprint['chemotype'];
+  generalResilience: number;
+  germinationRate: number;
+  compatibility: StrainCompatibilityHints;
+  defaults: StrainDefaultSettings;
+  traits: StrainTraits;
+  metadata?: StrainBlueprint['meta'];
+  price?: StrainPriceEntry;
+}
+
+export interface DeviceCompatibilityHints {
+  roomPurposes: DeviceBlueprint['roomPurposes'];
+}
+
+export interface DeviceDefaultSettings {
+  settings: DeviceBlueprint['settings'];
+  coverage?: DeviceBlueprint['coverage'];
+  limits?: DeviceBlueprint['limits'];
+}
+
+export interface DeviceBlueprintCatalogEntry {
+  id: string;
+  kind: string;
+  name: string;
+  quality: number;
+  complexity: number;
+  lifetimeHours: number;
+  capexEur?: number;
+  efficiencyDegeneration?: number;
+  compatibility: DeviceCompatibilityHints;
+  defaults: DeviceDefaultSettings;
+  maintenance?: DeviceBlueprint['maintenance'];
+  metadata?: DeviceBlueprint['meta'];
+  price?: DevicePriceEntry;
+}
+
+const buildStrainPriceMap = (repository: BlueprintRepository): Map<string, StrainPriceEntry> => {
+  if (typeof repository.listStrainPrices !== 'function') {
+    return new Map();
+  }
+  return new Map(repository.listStrainPrices());
+};
+
+const buildDevicePriceMap = (repository: BlueprintRepository): Map<string, DevicePriceEntry> => {
+  if (typeof repository.listDevicePrices !== 'function') {
+    return new Map();
+  }
+  return new Map(repository.listDevicePrices());
+};
+
+export const buildStrainBlueprintCatalog = (
+  repository: BlueprintRepository,
+): StrainBlueprintCatalogEntry[] => {
+  const prices = buildStrainPriceMap(repository);
+
+  return repository
+    .listStrains()
+    .map((strain) => {
+      const defaults: StrainDefaultSettings = {};
+      if (strain.envBands) {
+        defaults.envBands = clone(strain.envBands);
+      }
+      if (strain.phaseDurations) {
+        defaults.phaseDurations = clone(strain.phaseDurations);
+      }
+      if (strain.photoperiod) {
+        defaults.photoperiod = clone(strain.photoperiod);
+      }
+      if (strain.nutrientDemand) {
+        defaults.nutrientDemand = clone(strain.nutrientDemand);
+      }
+      if (strain.waterDemand) {
+        defaults.waterDemand = clone(strain.waterDemand);
+      }
+      if (strain.growthModel) {
+        defaults.growthModel = clone(strain.growthModel);
+      }
+      if (strain.yieldModel) {
+        defaults.yieldModel = clone(strain.yieldModel);
+      }
+
+      const traits: StrainTraits = {};
+      if (strain.morphology) {
+        traits.morphology = clone(strain.morphology);
+      }
+      if (strain.noise) {
+        traits.noise = clone(strain.noise);
+      }
+
+      const compatibility: StrainCompatibilityHints = {
+        methodAffinity: clone(strain.methodAffinity ?? {}),
+      };
+      if (strain.stressTolerance) {
+        compatibility.stressTolerance = clone(strain.stressTolerance);
+      }
+
+      const entry: StrainBlueprintCatalogEntry = {
+        id: strain.id,
+        slug: strain.slug,
+        name: strain.name,
+        lineage: clone(strain.lineage),
+        genotype: clone(strain.genotype),
+        chemotype: clone(strain.chemotype),
+        generalResilience: strain.generalResilience,
+        germinationRate: strain.germinationRate,
+        compatibility,
+        defaults,
+        traits,
+      };
+
+      if (strain.meta) {
+        entry.metadata = clone(strain.meta);
+      }
+
+      const price = prices.get(strain.id);
+      if (price) {
+        entry.price = clone(price);
+      }
+
+      return entry;
+    })
+    .sort(sortByName);
+};
+
+export const buildDeviceBlueprintCatalog = (
+  repository: BlueprintRepository,
+): DeviceBlueprintCatalogEntry[] => {
+  const prices = buildDevicePriceMap(repository);
+
+  return repository
+    .listDevices()
+    .map((device) => {
+      const defaults: DeviceDefaultSettings = {
+        settings: clone(device.settings),
+      };
+      if (device.coverage) {
+        defaults.coverage = clone(device.coverage);
+      }
+      if (device.limits) {
+        defaults.limits = clone(device.limits);
+      }
+
+      const entry: DeviceBlueprintCatalogEntry = {
+        id: device.id,
+        kind: device.kind,
+        name: device.name,
+        quality: device.quality,
+        complexity: device.complexity,
+        lifetimeHours: device.lifetime_h ?? device.lifespan ?? 0,
+        capexEur: device.capex_eur,
+        efficiencyDegeneration: device.efficiencyDegeneration,
+        compatibility: { roomPurposes: clone(device.roomPurposes) },
+        defaults,
+      };
+
+      if (device.maintenance) {
+        entry.maintenance = clone(device.maintenance);
+      }
+
+      if (device.meta) {
+        entry.metadata = clone(device.meta);
+      }
+
+      const price = prices.get(device.id);
+      if (price) {
+        entry.price = clone(price);
+      }
+
+      return entry;
+    })
+    .sort(sortByName);
+};

--- a/src/backend/src/facade/commands/world.ts
+++ b/src/backend/src/facade/commands/world.ts
@@ -7,6 +7,10 @@ import type {
   DuplicateZoneResult,
 } from '@/engine/world/worldService.js';
 import type { StructureBlueprint } from '@/state/models.js';
+import type {
+  DeviceBlueprintCatalogEntry,
+  StrainBlueprintCatalogEntry,
+} from '@/facade/blueprintCatalog.js';
 import {
   emptyObjectSchema,
   entityIdentifier,
@@ -29,6 +33,8 @@ const rentStructureSchema = z
   .strict();
 
 const getStructureBlueprintsSchema = emptyObjectSchema;
+const getStrainBlueprintsSchema = emptyObjectSchema;
+const getDeviceBlueprintsSchema = emptyObjectSchema;
 const createRoomSchema = z
   .object({
     structureId: entityIdentifier,
@@ -173,6 +179,8 @@ const duplicateZoneSchema = z
 
 export type RentStructureIntent = z.infer<typeof rentStructureSchema>;
 export type GetStructureBlueprintsIntent = z.infer<typeof getStructureBlueprintsSchema>;
+export type GetStrainBlueprintsIntent = z.infer<typeof getStrainBlueprintsSchema>;
+export type GetDeviceBlueprintsIntent = z.infer<typeof getDeviceBlueprintsSchema>;
 export type CreateRoomIntent = z.infer<typeof createRoomSchema>;
 export type UpdateRoomIntent = z.infer<typeof updateRoomSchema>;
 export type DeleteRoomIntent = z.infer<typeof deleteRoomSchema>;
@@ -190,6 +198,14 @@ export type DuplicateZoneIntent = z.infer<typeof duplicateZoneSchema>;
 export interface WorldIntentHandlers {
   rentStructure: ServiceCommandHandler<RentStructureIntent, DuplicateStructureResult>;
   getStructureBlueprints: ServiceCommandHandler<GetStructureBlueprintsIntent, StructureBlueprint[]>;
+  getStrainBlueprints: ServiceCommandHandler<
+    GetStrainBlueprintsIntent,
+    StrainBlueprintCatalogEntry[]
+  >;
+  getDeviceBlueprints: ServiceCommandHandler<
+    GetDeviceBlueprintsIntent,
+    DeviceBlueprintCatalogEntry[]
+  >;
   createRoom: ServiceCommandHandler<CreateRoomIntent, CreateRoomResult>;
   updateRoom: ServiceCommandHandler<UpdateRoomIntent>;
   deleteRoom: ServiceCommandHandler<DeleteRoomIntent>;
@@ -208,6 +224,14 @@ export interface WorldIntentHandlers {
 export interface WorldCommandRegistry {
   rentStructure: CommandRegistration<RentStructureIntent, DuplicateStructureResult>;
   getStructureBlueprints: CommandRegistration<GetStructureBlueprintsIntent, StructureBlueprint[]>;
+  getStrainBlueprints: CommandRegistration<
+    GetStrainBlueprintsIntent,
+    StrainBlueprintCatalogEntry[]
+  >;
+  getDeviceBlueprints: CommandRegistration<
+    GetDeviceBlueprintsIntent,
+    DeviceBlueprintCatalogEntry[]
+  >;
   createRoom: CommandRegistration<CreateRoomIntent>;
   updateRoom: CommandRegistration<UpdateRoomIntent>;
   deleteRoom: CommandRegistration<DeleteRoomIntent>;
@@ -242,6 +266,18 @@ export const buildWorldCommands = ({
     'world.getStructureBlueprints',
     getStructureBlueprintsSchema,
     () => services().getStructureBlueprints,
+    onMissingHandler,
+  ),
+  getStrainBlueprints: createServiceCommand(
+    'world.getStrainBlueprints',
+    getStrainBlueprintsSchema,
+    () => services().getStrainBlueprints,
+    onMissingHandler,
+  ),
+  getDeviceBlueprints: createServiceCommand(
+    'world.getDeviceBlueprints',
+    getDeviceBlueprintsSchema,
+    () => services().getDeviceBlueprints,
     onMissingHandler,
   ),
   createRoom: createServiceCommand<CreateRoomIntent, CreateRoomResult>(
@@ -329,6 +365,8 @@ export const buildWorldCommands = ({
 export const schemas = {
   rentStructureSchema,
   getStructureBlueprintsSchema,
+  getStrainBlueprintsSchema,
+  getDeviceBlueprintsSchema,
   createRoomSchema,
   updateRoomSchema,
   deleteRoomSchema,

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -74,6 +74,8 @@ import {
   type WorldIntentHandlers,
   type RentStructureIntent,
   type GetStructureBlueprintsIntent,
+  type GetStrainBlueprintsIntent,
+  type GetDeviceBlueprintsIntent,
   type CreateRoomIntent,
   type UpdateRoomIntent,
   type DeleteRoomIntent,
@@ -103,6 +105,10 @@ import {
   type MissingCommandHandler,
 } from './commands/commandRegistry.js';
 import type { GameState, StructureBlueprint } from '@/state/models.js';
+import type {
+  DeviceBlueprintCatalogEntry,
+  StrainBlueprintCatalogEntry,
+} from './blueprintCatalog.js';
 import { SimulationLoop, type SimulationLoopAccountingOptions } from '@/sim/loop.js';
 import { SimulationScheduler } from '@/sim/simScheduler.js';
 import type { SimulationSchedulerOptions } from '@/sim/simScheduler.js';
@@ -141,6 +147,8 @@ export type {
 export type {
   RentStructureIntent,
   GetStructureBlueprintsIntent,
+  GetStrainBlueprintsIntent,
+  GetDeviceBlueprintsIntent,
   CreateRoomIntent,
   UpdateRoomIntent,
   DeleteRoomIntent,
@@ -156,6 +164,10 @@ export type {
   DuplicateZoneIntent,
   WorldIntentHandlers,
 } from './commands/world.js';
+export type {
+  StrainBlueprintCatalogEntry,
+  DeviceBlueprintCatalogEntry,
+} from './blueprintCatalog.js';
 export type {
   InstallDeviceIntent,
   UpdateDeviceIntent,
@@ -248,6 +260,12 @@ export interface WorldIntentAPI {
   getStructureBlueprints(
     intent?: GetStructureBlueprintsIntent,
   ): Promise<CommandResult<StructureBlueprint[]>>;
+  getStrainBlueprints(
+    intent?: GetStrainBlueprintsIntent,
+  ): Promise<CommandResult<StrainBlueprintCatalogEntry[]>>;
+  getDeviceBlueprints(
+    intent?: GetDeviceBlueprintsIntent,
+  ): Promise<CommandResult<DeviceBlueprintCatalogEntry[]>>;
   createRoom(intent: CreateRoomIntent): Promise<CommandResult>;
   updateRoom(intent: UpdateRoomIntent): Promise<CommandResult>;
   deleteRoom(intent: DeleteRoomIntent): Promise<CommandResult>;

--- a/src/backend/src/server/startServer.ts
+++ b/src/backend/src/server/startServer.ts
@@ -19,6 +19,10 @@ import {
   type CommandResult,
   type CommandExecutionContext,
 } from '@/facade/index.js';
+import {
+  buildDeviceBlueprintCatalog,
+  buildStrainBlueprintCatalog,
+} from '@/facade/blueprintCatalog.js';
 import { SocketGateway } from '@/server/socketGateway.js';
 import { SseGateway } from '@/server/sseGateway.js';
 import { bootstrap } from '@/bootstrap.js';
@@ -338,6 +342,16 @@ export const startBackendServer = async (
     world: {
       rentStructure: (intent, context) => worldService.rentStructure(intent.structureId, context),
       getStructureBlueprints: () => worldService.getStructureBlueprints(),
+      getStrainBlueprints: () =>
+        ({
+          ok: true,
+          data: buildStrainBlueprintCatalog(repository),
+        }) satisfies CommandResult<ReturnType<typeof buildStrainBlueprintCatalog>>,
+      getDeviceBlueprints: () =>
+        ({
+          ok: true,
+          data: buildDeviceBlueprintCatalog(repository),
+        }) satisfies CommandResult<ReturnType<typeof buildDeviceBlueprintCatalog>>,
       createRoom: (intent, context) => worldService.createRoom(intent, context),
       createZone: (intent, context) => worldService.createZone(intent, context),
       renameStructure: (intent, context) =>


### PR DESCRIPTION
### **User description**
## Summary
- add typed blueprint catalog builder and expose `world.getStrainBlueprints` / `world.getDeviceBlueprints`
- wire the simulation facade and server start-up to serve fresh catalogs from the blueprint repository
- document the socket contract for the new payloads and extend integration coverage for facade and gateway intents

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d807bf8c0483258b7547d376a593e3


___

### **PR Type**
Enhancement


___

### **Description**
- Add strain and device blueprint catalog commands

- Expose `world.getStrainBlueprints` and `world.getDeviceBlueprints` intents

- Wire simulation facade and server startup for fresh catalogs

- Document socket contract and extend integration test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blueprint Repository"] --> B["Catalog Builder"]
  B --> C["Facade Commands"]
  C --> D["Socket Gateway"]
  D --> E["Client Interface"]
  B --> F["Integration Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>blueprintCatalog.ts</strong><dd><code>Create typed blueprint catalog builder functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-602f08ae33e8331f6daf15f9ac137133681be420dbf813f1fbb296c65e92e85b">+210/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>world.ts</strong><dd><code>Add strain and device blueprint command schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-4eff4c2cc23e11b3ac2f3d85164efec230f0ee451fe62ce7f247ef511f8faf84">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export new blueprint catalog types and intents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-af16b94f90c68e774020b86f3f1f6bb2d924eb966d3b8912b95a3892a225bdce">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>startServer.ts</strong><dd><code>Wire blueprint catalog handlers in server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-c4431a2d11d516ace2935639c61ffc280edf7064d5506e879ba1e253b25b2929">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>intent.integration.test.ts</strong><dd><code>Add integration tests for blueprint catalog commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-0fc31b031d6e27ede376bc51ec4c67dffe923881c50f62ab33be2986bda824c6">+120/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>socketGateway.integration.test.ts</strong><dd><code>Add socket gateway tests for blueprint intents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-61720f7c0e2f6a10ea2d4a9b4e1202718b9d1f36d3cc88be588cd5d09b0854cc">+105/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document new blueprint catalog facade intents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>facade.md</strong><dd><code>Document blueprint catalog commands in facade guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-07977657af8e0646918d79a2ec3945af25eb7325fcefe840a117a0a7b7323c17">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>socket_protocol.md</strong><dd><code>Document blueprint catalog socket contract and payloads</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/255/files#diff-0af8ef4d9194d8affcf445132c4456fd7133e7ceb012b1a1e2bc6b5ef1d12d8c">+77/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

