### PR TITLE
Enable ESLint import resolver for frontend path aliases

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,12 @@ importers:
       eslint:
         specifier: ^9.36.0
         version: 9.36.0(jiti@1.21.7)
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7))
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7))
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.36.0(jiti@1.21.7))
@@ -5028,6 +5034,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.36.0(jiti@1.21.7)
+      get-tsconfig: 4.10.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -5036,6 +5057,17 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
+      eslint: 9.36.0(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -5063,6 +5095,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.36.0(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -1,12 +1,28 @@
+import { URL, fileURLToPath } from 'node:url';
+
 import js from '@eslint/js';
 import globals from 'globals';
+import importPlugin from 'eslint-plugin-import';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import * as tseslint from 'typescript-eslint';
 
+const tsconfigPath = fileURLToPath(new URL('./tsconfig.json', import.meta.url));
+
 export default tseslint.config(
   {
     ignores: ['dist'],
+    plugins: {
+      import: importPlugin,
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: tsconfigPath,
+          alwaysTryTypes: true,
+        },
+      },
+    },
   },
   {
     files: ['**/*.{ts,tsx}'],
@@ -22,6 +38,7 @@ export default tseslint.config(
       globals: globals.browser,
     },
     rules: {
+      'import/no-unresolved': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
@@ -38,6 +55,7 @@ export default tseslint.config(
       globals: globals.browser,
     },
     rules: {
+      'import/no-unresolved': 'error',
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -34,6 +34,8 @@
     "@vitejs/plugin-react": "^5.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",

--- a/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-// eslint-disable-next-line import/no-unresolved
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ModalHost } from '@/components/modals/ModalHost';
 import { useUIStore } from '@/store/ui';


### PR DESCRIPTION
### **User description**
## Summary
- add eslint-plugin-import and eslint-import-resolver-typescript to the frontend package
- configure the ESLint flat config to use the import plugin with the TypeScript resolver for @/... aliases and enforce import/no-unresolved
- remove the manual lint disable in ModalHost.test.tsx now that the resolver understands the alias

## Testing
- pnpm --filter @weebbreed/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68d811b43ddc8325b0f963ed31dd1d52


___

### **PR Type**
Enhancement


___

### **Description**
- Add ESLint import plugin with TypeScript resolver

- Configure path alias resolution for `@/` imports

- Enable `import/no-unresolved` rule enforcement

- Remove manual lint disable from test file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ESLint Config"] --> B["Import Plugin"]
  B --> C["TypeScript Resolver"]
  C --> D["Path Alias Resolution"]
  D --> E["@/ imports validated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eslint.config.js</strong><dd><code>Configure ESLint import plugin with TypeScript resolver</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/eslint.config.js

<ul><li>Import <code>eslint-plugin-import</code> and configure TypeScript resolver<br> <li> Add <code>import/no-unresolved</code> rule for both TS and JS files<br> <li> Configure resolver to use <code>tsconfig.json</code> for path mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/256/files#diff-42362a7c58c6b6fb02f81dbf6f17d9e9675ed6aaa9c56dd51ad4eb746137ad3f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Add ESLint import plugin dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<ul><li>Add <code>eslint-plugin-import</code> and <code>eslint-import-resolver-typescript</code> <br>dependencies<br> <li> Update dependency snapshots with new package versions</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/256/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add import linting dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/package.json

<ul><li>Add <code>eslint-import-resolver-typescript</code> version ^3.6.1<br> <li> Add <code>eslint-plugin-import</code> version ^2.31.0</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/256/files#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.test.tsx</strong><dd><code>Remove manual ESLint disable for imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/__tests__/ModalHost.test.tsx

<ul><li>Remove manual <code>eslint-disable-next-line import/no-unresolved</code> comment<br> <li> Clean up now that resolver understands <code>@/</code> aliases</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/256/files#diff-e92b53fd6668114772e447043d05f8493203456b0ceec22b803e993a0e821a3b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

