### PR TITLE
Add services for device installation and planting intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Documented simulation constant governance in [ADR 0009](docs/system/adr/0009-simulation-constants-governance.md) and cross-linked the constants catalogue.
+- Enabled façade support for `devices.installDevice` and `plants.addPlanting`, including zone compatibility checks,
+  capacity validation, and new `device.installed` / `plant.planted` telemetry events.
 - **Dynamic Structure Blueprint Loading**: The "Rent Structure" modal now dynamically loads available structure blueprints from the backend instead of using hardcoded frontend data. The backend exposes structure blueprints from `/data/blueprints/structures/*.json` through a new `getStructureBlueprints` facade intent. This ensures the frontend always displays the most current and accurate structure options available in the game.
 - Added world facade intents `getStrainBlueprints` and `getDeviceBlueprints` with deterministic catalog payloads (IDs, names, compatibility hints, default settings, and price hints), wired through the simulation facade/socket gateway and documented in the protocol guide.
 

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -89,7 +89,8 @@ Common categories are below.
 
 ### 4.4 Devices
 
-- `installDevice(targetId, deviceId, settings?)` — checks **`allowedRoomPurposes`**.
+- `installDevice(targetId, deviceId, settings?)` — checks **`allowedRoomPurposes`**, clones blueprint defaults,
+  clamps coverage/airflow via zone geometry, and emits `device.installed` telemetry with the created instance ID.
 - `updateDevice(instanceId, settingsPatch)`
 - `moveDevice(instanceId, targetZoneId)` — re‑validate purpose.
 - `removeDevice(instanceId)`
@@ -97,7 +98,8 @@ Common categories are below.
 
 ### 4.5 Plants & Plantings
 
-- `addPlanting(zoneId, { strainId, count, startTick? })`
+- `addPlanting(zoneId, { strainId, count, startTick? })` — enforces cultivation method capacity, strain/method
+  compatibility hints, and emits `plant.planted` telemetry including all generated plant IDs.
 - `cullPlanting(plantingId, count?)`
 - `harvestPlanting(plantingId)` — creates inventory lots, emits events.
 - `applyIrrigation(zoneId, liters)` / `applyFertilizer(zoneId, { N,P,K } in g)` — optional manual overrides.

--- a/src/backend/src/engine/devices/deviceInstallationService.ts
+++ b/src/backend/src/engine/devices/deviceInstallationService.ts
@@ -1,0 +1,157 @@
+import { generateId } from '@/state/initialization/common.js';
+import { DEFAULT_MAINTENANCE_INTERVAL_TICKS } from '@/constants/world.js';
+import type { RngService, RngStream } from '@/lib/rng.js';
+import {
+  type CommandExecutionContext,
+  type CommandResult,
+  type ErrorCode,
+} from '@/facade/index.js';
+import type { GameState, DeviceInstanceState, ZoneState } from '@/state/models.js';
+import type { DeviceBlueprint } from '@/data/schemas/deviceSchema.js';
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import { addDeviceToZone } from '@/state/devices.js';
+import { findZone } from '@/engine/world/stateSelectors.js';
+import { isDeviceCompatibleWithRoomPurpose } from '@/state/initialization/blueprints.js';
+
+export interface DeviceInstallationResult {
+  deviceId: string;
+  warnings?: string[];
+}
+
+export interface DeviceInstallationServiceOptions {
+  state: GameState;
+  rng: RngService;
+  repository: BlueprintRepository;
+}
+
+const DEVICE_INSTALL_STREAM_ID = 'world.devices.install';
+
+const cloneSettings = (settings: Record<string, unknown> | undefined) => {
+  if (!settings) {
+    return {} as Record<string, unknown>;
+  }
+  return JSON.parse(JSON.stringify(settings)) as Record<string, unknown>;
+};
+
+export class DeviceInstallationService {
+  private readonly state: GameState;
+
+  private readonly repository: BlueprintRepository;
+
+  private readonly idStream: RngStream;
+
+  constructor(options: DeviceInstallationServiceOptions) {
+    this.state = options.state;
+    this.repository = options.repository;
+    this.idStream = options.rng.getStream(DEVICE_INSTALL_STREAM_ID);
+  }
+
+  installDevice(
+    targetZoneId: string,
+    deviceBlueprintId: string,
+    overrideSettings: Record<string, unknown> | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DeviceInstallationResult> {
+    const lookup = findZone(this.state, targetZoneId);
+    if (!lookup) {
+      return this.failure('ERR_NOT_FOUND', `Zone ${targetZoneId} was not found.`, [
+        'devices.installDevice',
+        'targetId',
+      ]);
+    }
+
+    const blueprint = this.repository.getDevice(deviceBlueprintId);
+    if (!blueprint) {
+      return this.failure('ERR_NOT_FOUND', `Device blueprint ${deviceBlueprintId} was not found.`, [
+        'devices.installDevice',
+        'deviceId',
+      ]);
+    }
+
+    const roomPurpose = this.repository.getRoomPurpose?.(lookup.room.purposeId);
+    const purposeSlug = roomPurpose?.kind ?? roomPurpose?.id;
+    if (purposeSlug && !isDeviceCompatibleWithRoomPurpose(blueprint, purposeSlug)) {
+      return this.failure(
+        'ERR_INVALID_STATE',
+        `Device ${blueprint.name} is not compatible with room purpose "${purposeSlug}".`,
+        ['devices.installDevice', 'deviceId'],
+      );
+    }
+
+    const instance = this.createDeviceInstance(blueprint, lookup.zone, overrideSettings);
+    const result = addDeviceToZone(lookup.zone, instance);
+
+    if (!result.added || !result.device) {
+      const warning = result.warnings[0];
+      const message = warning?.message ?? 'Unable to install device in the requested zone.';
+      return this.failure('ERR_INVALID_STATE', message, ['devices.installDevice']);
+    }
+
+    const warnings = result.warnings.map((issue) => issue.message);
+
+    context.events.queue(
+      'device.installed',
+      {
+        zoneId: lookup.zone.id,
+        deviceId: result.device.id,
+        blueprintId: blueprint.id,
+        warnings: warnings.length > 0 ? [...warnings] : undefined,
+      },
+      context.tick,
+      'info',
+    );
+
+    return {
+      ok: true,
+      data: {
+        deviceId: result.device.id,
+        warnings: warnings.length > 0 ? warnings : undefined,
+      },
+      warnings: warnings.length > 0 ? warnings : undefined,
+    } satisfies CommandResult<DeviceInstallationResult>;
+  }
+
+  private createDeviceInstance(
+    blueprint: DeviceBlueprint,
+    zone: ZoneState,
+    overrideSettings: Record<string, unknown> | undefined,
+  ): DeviceInstanceState {
+    const settings = { ...cloneSettings(blueprint.settings), ...(overrideSettings ?? {}) };
+    const quality = Number.isFinite(blueprint.quality) ? Number(blueprint.quality) : 1;
+    const sanitizedQuality = Math.max(0, Math.min(1, quality || 1));
+
+    return {
+      id: generateId(this.idStream, 'device'),
+      blueprintId: blueprint.id,
+      kind: blueprint.kind,
+      name: blueprint.name,
+      zoneId: zone.id,
+      status: 'operational',
+      efficiency: sanitizedQuality,
+      runtimeHours: 0,
+      maintenance: {
+        lastServiceTick: 0,
+        nextDueTick: DEFAULT_MAINTENANCE_INTERVAL_TICKS,
+        condition: sanitizedQuality,
+        runtimeHoursAtLastService: 0,
+        degradation: 0,
+      },
+      settings,
+    } satisfies DeviceInstanceState;
+  }
+
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
+    return {
+      ok: false,
+      errors: [
+        {
+          code,
+          message,
+          path,
+        },
+      ],
+    } satisfies CommandResult<T>;
+  }
+}
+
+export default DeviceInstallationService;

--- a/src/backend/src/engine/plants/plantingService.ts
+++ b/src/backend/src/engine/plants/plantingService.ts
@@ -1,0 +1,244 @@
+import { generateId } from '@/state/initialization/common.js';
+import { RNG_STREAM_IDS, type RngService, type RngStream } from '@/lib/rng.js';
+import {
+  type CommandExecutionContext,
+  type CommandResult,
+  type ErrorCode,
+} from '@/facade/index.js';
+import type { GameState, PlantState, ZoneState, PlantHealthState } from '@/state/models.js';
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import type { CultivationMethodBlueprint } from '@/data/schemas/cultivationMethodSchema.js';
+import type { StrainBlueprint } from '@/data/schemas/strainsSchema.js';
+import { findZone } from '@/engine/world/stateSelectors.js';
+
+export interface PlantingResult {
+  plantIds: string[];
+  warnings?: string[];
+}
+
+export interface PlantingServiceOptions {
+  state: GameState;
+  rng: RngService;
+  repository: BlueprintRepository;
+}
+
+const MIN_AREA_PER_PLANT = 0.1;
+const LOW_AFFINITY_WARNING_THRESHOLD = 0.6;
+const INCOMPATIBLE_AFFINITY_THRESHOLD = 0.25;
+
+export class PlantingService {
+  private readonly state: GameState;
+
+  private readonly repository: BlueprintRepository;
+
+  private readonly idStream: RngStream;
+
+  private readonly plantStream: RngStream;
+
+  constructor(options: PlantingServiceOptions) {
+    this.state = options.state;
+    this.repository = options.repository;
+    this.idStream = options.rng.getStream(RNG_STREAM_IDS.ids);
+    this.plantStream = options.rng.getStream(RNG_STREAM_IDS.plants);
+  }
+
+  addPlanting(
+    zoneId: string,
+    strainId: string,
+    count: number,
+    startTick: number | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<PlantingResult> {
+    const lookup = findZone(this.state, zoneId);
+    if (!lookup) {
+      return this.failure('ERR_NOT_FOUND', `Zone ${zoneId} was not found.`, [
+        'plants.addPlanting',
+        'zoneId',
+      ]);
+    }
+
+    if (count <= 0) {
+      return this.failure('ERR_VALIDATION', 'Plant count must be positive.', [
+        'plants.addPlanting',
+        'count',
+      ]);
+    }
+
+    const strain = this.repository.getStrain(strainId);
+    if (!strain) {
+      return this.failure('ERR_NOT_FOUND', `Strain blueprint ${strainId} was not found.`, [
+        'plants.addPlanting',
+        'strainId',
+      ]);
+    }
+
+    const method = this.requireCultivationMethod(lookup.zone);
+
+    const existingStrainId = lookup.zone.strainId;
+    if (existingStrainId && existingStrainId !== strainId && lookup.zone.plants.length > 0) {
+      return this.failure(
+        'ERR_CONFLICT',
+        `Zone ${lookup.zone.name ?? lookup.zone.id} is configured for strain ${lookup.zone.strainId}.`,
+        ['plants.addPlanting', 'strainId'],
+      );
+    }
+
+    const capacityResult = this.validateCapacity(lookup.zone, method, count);
+    if (!capacityResult.ok) {
+      return capacityResult.result;
+    }
+
+    const compatibilityWarnings = this.evaluateCompatibility(strain, method);
+    if (compatibilityWarnings.incompatible) {
+      return this.failure('ERR_INVALID_STATE', compatibilityWarnings.incompatible, [
+        'plants.addPlanting',
+        'strainId',
+      ]);
+    }
+
+    const planted: string[] = [];
+    const plantingTick = startTick ?? context.tick;
+
+    for (let index = 0; index < count; index += 1) {
+      const plant = this.createPlant(lookup.zone, strain, plantingTick, context.tick);
+      lookup.zone.plants.push(plant);
+      this.ensurePlantHealth(lookup.zone, plant);
+      planted.push(plant.id);
+    }
+
+    lookup.zone.strainId = strain.id;
+
+    const warnings = compatibilityWarnings.warnings;
+
+    context.events.queue(
+      'plant.planted',
+      {
+        zoneId,
+        strainId: strain.id,
+        plantIds: [...planted],
+        count,
+        warnings: warnings.length > 0 ? [...warnings] : undefined,
+      },
+      context.tick,
+      'info',
+    );
+
+    return {
+      ok: true,
+      data: { plantIds: planted, warnings: warnings.length > 0 ? warnings : undefined },
+      warnings: warnings.length > 0 ? warnings : undefined,
+    } satisfies CommandResult<PlantingResult>;
+  }
+
+  private createPlant(
+    zone: ZoneState,
+    strain: StrainBlueprint,
+    plantedAtTick: number,
+    currentTick: number,
+  ): PlantState {
+    const height = 0.1 + this.plantStream.nextRange(0, 0.05);
+    return {
+      id: generateId(this.idStream, 'plant'),
+      strainId: strain.id,
+      zoneId: zone.id,
+      stage: 'seedling',
+      plantedAtTick,
+      ageInHours: Math.max(0, (currentTick - plantedAtTick) * this.tickLengthHours()),
+      health: 0.95,
+      stress: 0.05,
+      biomassDryGrams: 0,
+      heightMeters: height,
+      canopyCover: 0.12,
+      yieldDryGrams: 0,
+      quality: 0.8,
+      lastMeasurementTick: currentTick,
+    } satisfies PlantState;
+  }
+
+  private tickLengthHours(): number {
+    const minutes = this.state.metadata.tickLengthMinutes;
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      return 0;
+    }
+    return minutes / 60;
+  }
+
+  private ensurePlantHealth(zone: ZoneState, plant: PlantState): PlantHealthState {
+    const existing = zone.health.plantHealth[plant.id];
+    if (existing) {
+      return existing;
+    }
+    const created: PlantHealthState = { diseases: [], pests: [] };
+    zone.health.plantHealth[plant.id] = created;
+    return created;
+  }
+
+  private requireCultivationMethod(zone: ZoneState): CultivationMethodBlueprint {
+    const blueprint = this.repository.getCultivationMethod(zone.cultivationMethodId);
+    if (!blueprint) {
+      throw new Error(
+        `Unknown cultivation method ${zone.cultivationMethodId} for zone ${zone.id}.`,
+      );
+    }
+    return blueprint;
+  }
+
+  private validateCapacity(
+    zone: ZoneState,
+    method: CultivationMethodBlueprint,
+    count: number,
+  ): { ok: true } | { ok: false; result: CommandResult<PlantingResult> } {
+    const areaPerPlant = Math.max(method.areaPerPlant ?? MIN_AREA_PER_PLANT, MIN_AREA_PER_PLANT);
+    const capacity = Math.max(1, Math.floor(zone.area / areaPerPlant));
+    const remaining = capacity - zone.plants.length;
+    if (remaining < count) {
+      const message = `Zone ${zone.name ?? zone.id} can host ${remaining} additional plants (capacity ${capacity}).`;
+      return {
+        ok: false,
+        result: this.failure('ERR_INVALID_STATE', message, ['plants.addPlanting', 'count']),
+      };
+    }
+    return { ok: true };
+  }
+
+  private evaluateCompatibility(
+    strain: StrainBlueprint,
+    method: CultivationMethodBlueprint,
+  ): { warnings: string[]; incompatible?: string } {
+    const affinity = strain.methodAffinity?.[method.id];
+    if (affinity === undefined) {
+      return { warnings: [] };
+    }
+    if (affinity < INCOMPATIBLE_AFFINITY_THRESHOLD) {
+      return {
+        warnings: [],
+        incompatible: `Strain ${strain.name} is incompatible with cultivation method ${method.name} (affinity ${affinity.toFixed(
+          2,
+        )}).`,
+      };
+    }
+    if (affinity < LOW_AFFINITY_WARNING_THRESHOLD) {
+      return {
+        warnings: [
+          `Strain ${strain.name} has low affinity (${affinity.toFixed(2)}) for cultivation method ${method.name}.`,
+        ],
+      };
+    }
+    return { warnings: [] };
+  }
+
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
+    return {
+      ok: false,
+      errors: [
+        {
+          code,
+          message,
+          path,
+        },
+      ],
+    } satisfies CommandResult<T>;
+  }
+}
+
+export default PlantingService;

--- a/src/backend/src/facade/commands/devices.ts
+++ b/src/backend/src/facade/commands/devices.ts
@@ -10,7 +10,7 @@ import {
 
 const installDeviceSchema = z
   .object({
-    targetId: uuid,
+    targetId: entityIdentifier,
     deviceId: uuid,
     settings: settingsRecord.optional(),
   })

--- a/src/backend/src/facade/commands/plants.ts
+++ b/src/backend/src/facade/commands/plants.ts
@@ -10,7 +10,7 @@ import {
 
 const addPlantingSchema = z
   .object({
-    zoneId: uuid,
+    zoneId: entityIdentifier,
     strainId: uuid,
     count: positiveInteger,
     startTick: nonNegativeNumber.optional(),

--- a/src/backend/src/server/startServer.ts
+++ b/src/backend/src/server/startServer.ts
@@ -37,7 +37,9 @@ import { SimulationLoop, type SimulationPhaseHandler } from '@/sim/loop.js';
 import { BlueprintHotReloadManager } from '@/persistence/hotReload.js';
 import { WorldService } from '@/engine/world/worldService.js';
 import { DeviceGroupService } from '@/engine/devices/deviceGroupService.js';
+import { DeviceInstallationService } from '@/engine/devices/deviceInstallationService.js';
 import { PlantingPlanService } from '@/engine/plants/plantingPlanService.js';
+import { PlantingService } from '@/engine/plants/plantingService.js';
 import { JobMarketService } from '@/engine/workforce/jobMarketService.js';
 import type { UtilityPrices } from '@/data/schemas/index.js';
 
@@ -330,7 +332,13 @@ export const startBackendServer = async (
     difficultyConfig,
   });
   const deviceGroupService = new DeviceGroupService({ state, rng });
+  const deviceInstallationService = new DeviceInstallationService({
+    state,
+    rng,
+    repository,
+  });
   const plantingPlanService = new PlantingPlanService({ state, rng });
+  const plantingService = new PlantingService({ state, rng, repository });
 
   facade.updateServices({
     config: {
@@ -369,10 +377,25 @@ export const startBackendServer = async (
         worldService.duplicateZone(intent.zoneId, intent.name, context),
     },
     devices: {
+      installDevice: (intent, context) =>
+        deviceInstallationService.installDevice(
+          intent.targetId,
+          intent.deviceId,
+          intent.settings,
+          context,
+        ),
       toggleDeviceGroup: (intent, context) =>
         deviceGroupService.toggleDeviceGroup(intent.zoneId, intent.kind, intent.enabled, context),
     },
     plants: {
+      addPlanting: (intent, context) =>
+        plantingService.addPlanting(
+          intent.zoneId,
+          intent.strainId,
+          intent.count,
+          intent.startTick,
+          context,
+        ),
       togglePlantingPlan: (intent, context) =>
         plantingPlanService.togglePlantingPlan(intent.zoneId, intent.enabled, context),
     },


### PR DESCRIPTION
### **User description**
## Summary
- add dedicated services that validate compatibility/capacity before installing devices or planting strains
- hook the new services into the simulation facade and surface domain telemetry for successful installs/plantings
- extend integration coverage and docs to describe the new intents and emitted events

## Testing
- `pnpm --filter @weebbreed/backend test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68d812463ea483258852f2a40d8979fd


___

### **PR Type**
Enhancement


___

### **Description**
- Add device installation service with compatibility validation

- Add planting service with capacity and strain affinity checks

- Integrate services into simulation facade with telemetry events

- Extend test coverage for new installation and planting workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device/Plant Request"] --> B["Validation Services"]
  B --> C["Compatibility Check"]
  C --> D["Capacity Validation"]
  D --> E["State Update"]
  E --> F["Telemetry Events"]
  F --> G["Success Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deviceInstallationService.ts</strong><dd><code>Device installation service implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/devices/deviceInstallationService.ts

<ul><li>Create new service for device installation with validation<br> <li> Implement room purpose compatibility checking<br> <li> Add device instance creation with maintenance tracking<br> <li> Generate telemetry events for successful installations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-d4a0ebd738a1309586d077d6d494b81c469a837b0995df597a8b5e541c463169">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plantingService.ts</strong><dd><code>Plant planting service implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/plants/plantingService.ts

<ul><li>Create planting service with capacity validation<br> <li> Implement strain-method affinity compatibility checks<br> <li> Add plant instance creation with health tracking<br> <li> Generate telemetry events for successful plantings</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-6f6d5d8477fcd21aa800e9c12bb35618008f9f0a7c8baf46666e449a287c38ac">+244/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devices.ts</strong><dd><code>Update device command schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/facade/commands/devices.ts

- Change `targetId` schema from `uuid` to `entityIdentifier`


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-f364ed5b1633043b3fa52cc1c694371c3da893488ecb8d4f6923f35231d3a9f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plants.ts</strong><dd><code>Update plant command schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/facade/commands/plants.ts

- Change `zoneId` schema from `uuid` to `entityIdentifier`


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-9591e2e69f6a25a3d8eb3c78045449d3bf83b2e4fda50148078e9d3542a0c55b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>startServer.ts</strong><dd><code>Service integration in server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/startServer.ts

<ul><li>Wire device installation service into facade<br> <li> Wire planting service into facade<br> <li> Connect services to command handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-c4431a2d11d516ace2935639c61ffc280edf7064d5506e879ba1e253b25b2929">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intent.integration.test.ts</strong><dd><code>Integration tests for new services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/facade/intent.integration.test.ts

<ul><li>Add comprehensive test coverage for device installation<br> <li> Add test coverage for plant planting with validation<br> <li> Test compatibility checks and error handling<br> <li> Verify telemetry event emission</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-0fc31b031d6e27ede376bc51ec4c67dffe923881c50f62ab33be2986bda824c6">+143/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog updates for new features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document new facade support for device installation<br> <li> Document new facade support for plant planting<br> <li> Note compatibility checks and telemetry events</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>facade.md</strong><dd><code>Facade documentation updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/system/facade.md

<ul><li>Update device installation documentation with validation details<br> <li> Update plant planting documentation with capacity checks<br> <li> Document new telemetry events</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/257/files#diff-07977657af8e0646918d79a2ec3945af25eb7325fcefe840a117a0a7b7323c17">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

