### PR TITLE
feat: expose blueprint fetchers on simulation bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Documented simulation constant governance in [ADR 0009](docs/system/adr/0009-simulation-constants-governance.md) and cross-linked the constants catalogue.
+- Exposed typed strain/device blueprint catalog fetchers and convenience wrappers for
+  `plants.addPlanting` and `devices.installDevice` on the frontend simulation bridge,
+  including Vitest coverage to lock down the intent envelopes.
 - Enabled façade support for `devices.installDevice` and `plants.addPlanting`, including zone compatibility checks,
   capacity validation, and new `device.installed` / `plant.planted` telemetry events.
 - **Dynamic Structure Blueprint Loading**: The "Rent Structure" modal now dynamically loads available structure blueprints from the backend instead of using hardcoded frontend data. The backend exposes structure blueprints from `/data/blueprints/structures/*.json` through a new `getStructureBlueprints` facade intent. This ensures the frontend always displays the most current and accurate structure options available in the game.

--- a/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
@@ -6,7 +6,27 @@ import { useSimulationStore } from '@/store/simulation';
 import type { SimulationBridge } from '@/facade/systemFacade';
 import type { SimulationSnapshot } from '@/types/simulation';
 
-const bridge = { sendIntent: () => Promise.resolve() } as unknown as SimulationBridge;
+const bridge: SimulationBridge = {
+  connect: () => undefined,
+  loadQuickStart: async () => ({ ok: true }),
+  getStructureBlueprints: async () => ({ ok: true, data: [] }),
+  getStrainBlueprints: async () => ({ ok: true, data: [] }),
+  getDeviceBlueprints: async () => ({ ok: true, data: [] }),
+  getDifficultyConfig: async () => ({ ok: true }),
+  sendControl: async () => ({ ok: true }),
+  sendConfigUpdate: async () => ({ ok: true }),
+  sendIntent: async () => ({ ok: true }),
+  subscribeToUpdates: (_handler: Parameters<SimulationBridge['subscribeToUpdates']>[0]) => {
+    void _handler;
+    return () => undefined;
+  },
+  plants: {
+    addPlanting: async () => ({ ok: true }),
+  },
+  devices: {
+    installDevice: async () => ({ ok: true }),
+  },
+};
 
 const baseSnapshot: SimulationSnapshot = {
   tick: 12,

--- a/src/frontend/src/components/finance/ExpenseBreakdown.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.tsx
@@ -30,6 +30,14 @@ interface ExpenseSubcategory {
   description: string;
 }
 
+interface ExpenseSummary {
+  categories: ExpenseCategory[];
+  totalExpenses: number;
+  capexTotal: number;
+  opexTotal: number;
+  avgExpensePerTick: number;
+}
+
 const CATEGORY_META: Record<
   FinanceLedgerCategory,
   { label: string; icon: string; color: string; type: 'CapEx' | 'OpEx' }
@@ -94,7 +102,7 @@ export const ExpenseBreakdown = ({
 }: ExpenseBreakdownProps) => {
   const snapshot = useSimulationStore((state) => state.snapshot);
 
-  const expenseData = useMemo(() => {
+  const expenseData = useMemo<ExpenseSummary>(() => {
     if (!snapshot?.finance) {
       return {
         categories: [],

--- a/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
@@ -6,7 +6,27 @@ import { useSimulationStore } from '@/store/simulation';
 import type { SimulationBridge } from '@/facade/systemFacade';
 import type { SimulationSnapshot } from '@/types/simulation';
 
-const bridge = { sendIntent: () => Promise.resolve() } as unknown as SimulationBridge;
+const bridge: SimulationBridge = {
+  connect: () => undefined,
+  loadQuickStart: async () => ({ ok: true }),
+  getStructureBlueprints: async () => ({ ok: true, data: [] }),
+  getStrainBlueprints: async () => ({ ok: true, data: [] }),
+  getDeviceBlueprints: async () => ({ ok: true, data: [] }),
+  getDifficultyConfig: async () => ({ ok: true }),
+  sendControl: async () => ({ ok: true }),
+  sendConfigUpdate: async () => ({ ok: true }),
+  sendIntent: async () => ({ ok: true }),
+  subscribeToUpdates: (_handler: Parameters<SimulationBridge['subscribeToUpdates']>[0]) => {
+    void _handler;
+    return () => undefined;
+  },
+  plants: {
+    addPlanting: async () => ({ ok: true }),
+  },
+  devices: {
+    installDevice: async () => ({ ok: true }),
+  },
+};
 
 const baseSnapshot: SimulationSnapshot = {
   tick: 10,

--- a/src/frontend/src/components/modals/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/ModalHost.test.tsx
@@ -49,11 +49,22 @@ describe('ModalHost', () => {
       connect: vi.fn(),
       loadQuickStart: vi.fn(async () => ({ ok: true })),
       getStructureBlueprints: vi.fn(async () => ({ ok: true, data: [] })),
+      getStrainBlueprints: vi.fn(async () => ({ ok: true, data: [] })),
+      getDeviceBlueprints: vi.fn(async () => ({ ok: true, data: [] })),
       getDifficultyConfig: vi.fn(async () => ({ ok: true })),
       sendControl: sendControlMock as unknown as SimulationBridge['sendControl'],
       sendConfigUpdate: vi.fn(async () => ({ ok: true })),
       sendIntent: vi.fn(async () => ({ ok: true })),
-      subscribeToUpdates: vi.fn(() => vi.fn()),
+      subscribeToUpdates: (_handler: Parameters<SimulationBridge['subscribeToUpdates']>[0]) => {
+        void _handler;
+        return () => undefined;
+      },
+      plants: {
+        addPlanting: vi.fn(async () => ({ ok: true })),
+      },
+      devices: {
+        installDevice: vi.fn(async () => ({ ok: true })),
+      },
     };
 
     act(() => {

--- a/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ModalHost } from '@/components/modals/ModalHost';

--- a/src/frontend/src/facade/systemFacade.test.ts
+++ b/src/frontend/src/facade/systemFacade.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SimulationBridge } from './systemFacade';
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    connect: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+    connected: false,
+  })),
+}));
+
+describe('SocketSystemFacade convenience wrappers', () => {
+  let bridge: SimulationBridge;
+  let sendIntentMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    sendIntentMock = vi.fn(async () => ({ ok: true }));
+    const module = await import('./systemFacade');
+    bridge = module.getSimulationBridge();
+    (bridge as unknown as { socket: { connected: boolean } | null }).socket = {
+      connected: true,
+    } as { connected: boolean };
+    (bridge as unknown as { sendIntent: typeof sendIntentMock }).sendIntent = sendIntentMock;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches strain blueprints via the world command', async () => {
+    const response = { ok: true, data: [] };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.getStrainBlueprints();
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'world',
+      action: 'getStrainBlueprints',
+      payload: {},
+    });
+  });
+
+  it('fetches device blueprints via the world command', async () => {
+    const response = { ok: true, data: [] };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.getDeviceBlueprints();
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'world',
+      action: 'getDeviceBlueprints',
+      payload: {},
+    });
+  });
+
+  it('dispatches plants.addPlanting intents with optional startTick', async () => {
+    const response = { ok: true };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.plants.addPlanting({
+      zoneId: 'zone-1',
+      strainId: 'strain-1',
+      count: 4,
+      startTick: 12,
+    });
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'plants',
+      action: 'addPlanting',
+      payload: {
+        zoneId: 'zone-1',
+        strainId: 'strain-1',
+        count: 4,
+        startTick: 12,
+      },
+    });
+  });
+
+  it('omits the optional planting startTick when not provided', async () => {
+    await bridge.plants.addPlanting({
+      zoneId: 'zone-2',
+      strainId: 'strain-2',
+      count: 1,
+    });
+
+    const payload = sendIntentMock.mock.calls.at(-1)?.[0]?.payload as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      zoneId: 'zone-2',
+      strainId: 'strain-2',
+      count: 1,
+    });
+    expect('startTick' in payload).toBe(false);
+  });
+
+  it('dispatches devices.installDevice intents and respects optional settings', async () => {
+    const response = { ok: true };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.devices.installDevice({
+      targetId: 'zone-3',
+      deviceId: 'device-1',
+      settings: { power: 0.75 },
+    });
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'devices',
+      action: 'installDevice',
+      payload: {
+        targetId: 'zone-3',
+        deviceId: 'device-1',
+        settings: { power: 0.75 },
+      },
+    });
+  });
+
+  it('omits installDevice settings when undefined', async () => {
+    await bridge.devices.installDevice({
+      targetId: 'zone-4',
+      deviceId: 'device-2',
+    });
+
+    const payload = sendIntentMock.mock.calls.at(-1)?.[0]?.payload as Record<string, unknown>;
+    expect(payload).toEqual({
+      targetId: 'zone-4',
+      deviceId: 'device-2',
+    });
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- add typed strain and device blueprint interfaces to the frontend simulation bridge
- expose world blueprint fetchers plus plants/devices intent helpers with strict socket connection enforcement
- cover the new bridge helpers with facade tests and refresh finance utility pricing tests to use deterministic stubs

## Testing
- `pnpm --filter @weebbreed/frontend test`
- `pnpm --filter @weebbreed/frontend typecheck`
- `pnpm run check` *(fails: backend package emits pre-existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a30c483c8325a1113c63a9b91e4f


___

### **PR Type**
Enhancement


___

### **Description**
- Add typed strain and device blueprint interfaces

- Expose blueprint fetchers on simulation bridge

- Add convenience wrappers for plants/devices operations

- Enhance test coverage with deterministic stubs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SimulationBridge Interface"] --> B["Blueprint Fetchers"]
  A --> C["Convenience Wrappers"]
  B --> D["getStrainBlueprints()"]
  B --> E["getDeviceBlueprints()"]
  C --> F["plants.addPlanting()"]
  C --> G["devices.installDevice()"]
  H["Test Coverage"] --> I["Facade Tests"]
  H --> J["Component Test Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>systemFacade.test.ts</strong><dd><code>Add comprehensive facade bridge tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-0a2b5f2980940394d2b842a2afb9cff71b46b8726f70aa6a73ac8fdeb23d0ef4">+135/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ExpenseBreakdown.test.tsx</strong><dd><code>Replace mock with deterministic bridge stub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-2a2162e3a1dbe1062005da7bde91ef8c23083ec4ffdba6ba81c92ff9d62abfa2">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RevenueBreakdown.test.tsx</strong><dd><code>Replace mock with deterministic bridge stub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-9e5753b7bb83fb67598400cb374f56a010568553daa4a2ef275500358257212c">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UtilityPricing.test.tsx</strong><dd><code>Refactor to use deterministic bridge implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-407b59a1b1d41876ed9450debbb8008f0fb9e2abae5980437fa7fda0bbe8ec44">+47/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalHost.test.tsx</strong><dd><code>Add missing blueprint methods to bridge mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-8ee6381cf7a28b5cd6e5c13ca6bcebdcde493bf906dc8bf301bcb558c4527383">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalHost.test.tsx</strong><dd><code>Add jest-dom import for test matchers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-e92b53fd6668114772e447043d05f8493203456b0ceec22b803e993a0e821a3b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>systemFacade.ts</strong><dd><code>Add blueprint interfaces and convenience methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-c10fe9533502ad71aeab51f717f7ef1322039ac8389adbb333b4d5ade93e8f23">+171/-12</a></td>

</tr>

<tr>
  <td><strong>ExpenseBreakdown.tsx</strong><dd><code>Add explicit ExpenseSummary interface typing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-aa61780d2dcf636fd6b7a6ee9afad130a03249f8d2a9edce1e0457b59cd7a715">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document blueprint fetchers and convenience wrappers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/258/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

