### PR TITLE
Fix humidity device per-tick mass scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected humidity device mass scaling so per-tick rates humidify/dehumidify
+  zones consistently regardless of tick length while leaving energy usage tied
+  to the simulated duration.
 - Hardened the frontend seed generator by typing `seed-config.json`, dropping
   unused config overrides, routing weighted picks through the Mulberry32 RNG,
   and enforcing blacklist lookups with `Set<string>` to keep deterministic name

--- a/src/backend/src/engine/environment/deviceEffects.test.ts
+++ b/src/backend/src/engine/environment/deviceEffects.test.ts
@@ -234,7 +234,7 @@ describe('deviceEffects', () => {
       },
     });
 
-    const fullPowerMass = 0.1 * tickHours * 0.85;
+    const fullPowerMass = 0.1 * 0.85;
     const expectedFullPowerDelta =
       fullPowerMass / (geometry.volume * SATURATION_VAPOR_DENSITY_KG_PER_M3);
     const expectedDelta = expectedFullPowerDelta * 0.6;
@@ -277,7 +277,7 @@ describe('deviceEffects', () => {
       },
     });
 
-    const fullPowerMass = 0.12 * tickHours * 0.8;
+    const fullPowerMass = 0.12 * 0.8;
     const expectedFullPowerDelta =
       fullPowerMass / (geometry.volume * SATURATION_VAPOR_DENSITY_KG_PER_M3);
     const expectedDelta = -expectedFullPowerDelta * 0.8;

--- a/src/backend/src/engine/environment/deviceEffects.ts
+++ b/src/backend/src/engine/environment/deviceEffects.ts
@@ -363,7 +363,7 @@ const computeHumidityEffect = (
     return { ...DEFAULT_DEVICE_EFFECT };
   }
 
-  const massAtFullPower = baseRate * tickHours * efficiency;
+  const massAtFullPower = baseRate * efficiency;
   if (massAtFullPower <= 0) {
     return { ...DEFAULT_DEVICE_EFFECT };
   }


### PR DESCRIPTION
### **User description**
## Summary
- treat humidity device water mass rates as per-tick quantities so humidity changes remain consistent regardless of tick duration
- extend humidity environment tests to cover humidify/dehumidify behaviour at 5 and 60 minute ticks and adjust device effect unit tests
- document the corrected humidity behaviour in the changelog for integrators

## Testing
- pnpm run check *(fails: existing TypeScript errors in state initialization/task fixtures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ad51f1548325ab15438c25605df5


___

### **PR Type**
Bug fix


___

### **Description**
- Fix humidity device mass scaling to be per-tick

- Remove tick duration dependency from humidity calculations

- Add comprehensive tests for tick-independent behavior

- Document corrected humidity behavior in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Humidity Device"] --> B["Mass Rate Calculation"]
  B --> C["Remove tickHours Multiplier"]
  C --> D["Per-Tick Consistency"]
  D --> E["Tests Added"]
  E --> F["Documentation Updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deviceEffects.ts</strong><dd><code>Remove tick duration from humidity mass calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/environment/deviceEffects.ts

<ul><li>Remove <code>tickHours</code> multiplication from <code>massAtFullPower</code> calculation<br> <li> Change from <code>baseRate * tickHours * efficiency</code> to <code>baseRate * efficiency</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/259/files#diff-0711b5e64dacef420eb8a35b6e3e6cafb60deb3088a7254ddc5e8e8ef8bfc99c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deviceEffects.test.ts</strong><dd><code>Update humidity device unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/environment/deviceEffects.test.ts

<ul><li>Update test expectations to remove <code>tickHours</code> from mass calculations<br> <li> Fix humidify and dehumidify test cases for per-tick behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/259/files#diff-e29e07054e863c5e0bb42f2df9b9861ec83d6991c33e0aa286e3d4173a71c48b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zoneEnvironment.test.ts</strong><dd><code>Add tick-independent humidity integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/environment/zoneEnvironment.test.ts

<ul><li>Add comprehensive test for tick-independent humidity behavior<br> <li> Test both humidify and dehumidify operations at 5 and 60 minute ticks<br> <li> Import <code>SATURATION_VAPOR_DENSITY_KG_PER_M3</code> constant<br> <li> Verify consistent humidity changes regardless of tick duration</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/259/files#diff-52fbdee603510af49b7902ccecb90f6de91fd1d1cf1905fa58a758587e1d46a6">+115/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document humidity scaling fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document humidity device mass scaling fix in Fixed section<br> <li> Explain per-tick consistency improvement for integrators</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/259/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

