### PR TITLE
feat: add zone planting and device install modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including Vitest coverage to lock down the intent envelopes.
 - Enabled façade support for `devices.installDevice` and `plants.addPlanting`, including zone compatibility checks,
   capacity validation, and new `device.installed` / `plant.planted` telemetry events.
+- Added zone-level "Plant zone" and "Install device" flows that launch capacity-aware modals backed by blueprint catalogs and new Vitest coverage.【F:src/frontend/src/views/ZoneView.tsx†L286-L398】【F:src/frontend/src/components/modals/ModalHost.tsx†L104-L470】【F:src/frontend/src/components/modals/**tests**/PlantAndDeviceModals.test.tsx†L64-L149】
 - **Dynamic Structure Blueprint Loading**: The "Rent Structure" modal now dynamically loads available structure blueprints from the backend instead of using hardcoded frontend data. The backend exposes structure blueprints from `/data/blueprints/structures/*.json` through a new `getStructureBlueprints` facade intent. This ensures the frontend always displays the most current and accurate structure options available in the game.
 - Added world facade intents `getStrainBlueprints` and `getDeviceBlueprints` with deterministic catalog payloads (IDs, names, compatibility hints, default settings, and price hints), wired through the simulation facade/socket gateway and documented in the protocol guide.
 

--- a/docs/ui-building_guide.md
+++ b/docs/ui-building_guide.md
@@ -250,7 +250,7 @@ The application follows a structure → room → zone drill-down supported by pe
 
 ### Modal Components
 
-- **AddDeviceModal**: install device form using `FormSelect`, `FormInput`, `PrimaryButton` for zone context.【F:docs/ui/ui-components-desciption.md†L360-L420】
+- **InstallDeviceModal**: loads device blueprints via the facade, validates JSON overrides, and emits `devices.installDevice` with compatibility hints.【F:src/frontend/src/components/modals/ModalHost.tsx†L325-L470】【F:src/frontend/src/components/modals/**tests**/PlantAndDeviceModals.test.tsx†L104-L149】
 - **CreateRoomModal**: collects name, purpose, area, height; enforces geometry; uses `useZoneStore.createRoom`; tested via `ModalHost`.【F:docs/ui/ui-components-desciption.md†L360-L420】
 - **CreateZoneModal**: allocates footprint, selects method, optional plant count; dispatches `world.createZone`; validated in tests.【F:docs/ui/ui-components-desciption.md†L360-L420】
 - **DuplicateStructureModal/DuplicateRoomModal/DuplicateZoneModal**: review footprint, device counts, names before cloning via respective intents; confirm actions handled through zone store helpers and regression tests.【F:docs/ui/ui-components-desciption.md†L360-L460】
@@ -259,7 +259,7 @@ The application follows a structure → room → zone drill-down supported by pe
 - **InfoModal**: surfaces pest/disease blueprint details (symptoms, controls).【F:docs/ui/ui-components-desciption.md†L440-L451】
 - **NewGameModal**: collects company/CEO name and deterministic seed; uses `FormInput` + `PrimaryButton`.【F:docs/ui/ui-components-desciption.md†L333-L347】
 - **PlantDetailModal**: shows plant stats with harvest/trash actions using `CutIcon` and `TrashIcon`; harvest disabled until ready.【F:docs/ui/ui-components-desciption.md†L440-L462】
-- **PlantStrainModal**: plants new strain; populates options from snapshot; uses forms primitives.【F:docs/ui/ui-components-desciption.md†L440-L462】
+- **PlantZoneModal**: fetches strain catalogs, projects capacity from cultivation methods, and dispatches `plants.addPlanting` with surfaced warnings.【F:src/frontend/src/components/modals/ModalHost.tsx†L104-L323】【F:src/frontend/src/components/modals/**tests**/PlantAndDeviceModals.test.tsx†L64-L103】
 - **InstallDeviceModal/UpdateDeviceModal/MoveDeviceModal**: manage device lifecycle (install JSON validation, patch existing settings, relocate hardware) through zone-store helpers and `SimulationFacade` intents.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **Device removal confirmation**: reuses confirmation modal to call `devices.removeDevice` via zone store helper.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **RentStructureModal**: rents new structure with affordability gating; uses forms primitives.【F:docs/ui/ui-components-desciption.md†L533-L540】
@@ -271,6 +271,7 @@ The application follows a structure → room → zone drill-down supported by pe
 - **ZoneCard**: compact zone summary with navigation click and `ActionIcons`; includes progress bars for plant growth.【F:docs/ui/ui-components-desciption.md†L420-L440】
 - **ZoneDeviceList**: groups devices by name, aggregates counts, exposes install/update/move/remove actions; draws from zone store helpers.【F:docs/ui/ui-components-desciption.md†L421-L533】
 - **ZonePlantPanel**: grid of plants with inspection mode (tooltips, direct actions) and selection mode enabling `BatchActionBar` for Harvest/Trash/Treat; integrates pest/disease info and automation toggles.【F:docs/ui/ui-components-desciption.md†L440-L462】
+- **ZoneView**: renders device and plant CTAs that open the install/plant modals with the active zone context, reinforcing empty-state guidance when lists are empty.【F:src/frontend/src/views/ZoneView.tsx†L286-L398】
 
 ### View Components (Composition Level)
 

--- a/docs/ui/ui-components-desciption.md
+++ b/docs/ui/ui-components-desciption.md
@@ -276,13 +276,17 @@ These components define the main structure and layout of the application interfa
 
 These components define the content for various modals used for user input and information display.
 
-### `AddDeviceModal.tsx`
+### `PlantZoneModal` (`ModalHost`)
 
-- **Purpose:** A form for installing a new device in a zone.
-- **Props:** `onSubmit`, `zoneId`, `onClose`.
-- **Icons Used:** None.
-- **Dependencies:** `FormSelect`, `FormInput`, `PrimaryButton`.
-- **Usage Context:** Displayed when the user clicks "Install Device" in the `ZoneDeviceList`.
+- **Purpose:** Gathers strain and count for a zone planting, loads the strain catalog via the facade, and surfaces cultivation-method capacity and affinity hints before dispatching `plants.addPlanting`.
+- **State:** Manages async catalog loading, selection state, capacity feedback, and warning surfaces from the command response.
+- **Usage Context:** Triggered from the zone detail "Plant zone" CTA; modal pausing handled by `ModalHost` ensures safe execution.【F:src/frontend/src/views/ZoneView.tsx†L380-L398】【F:src/frontend/src/components/modals/ModalHost.tsx†L104-L323】【F:src/frontend/src/components/modals/**tests**/PlantAndDeviceModals.test.tsx†L64-L103】
+
+### `InstallDeviceModal` (`ModalHost`)
+
+- **Purpose:** Presents the device catalog with coverage/compatibility hints, allows JSON overrides for settings, and submits `devices.installDevice` while relaying facade warnings back to the user.
+- **State:** Tracks catalog loading, editable JSON text, parse errors, and facade warnings so the modal only closes on clean installs.
+- **Usage Context:** Invoked from the zone detail "Install device" CTA; complements device list empty states and hooks into the shared modal pause/resume workflow.【F:src/frontend/src/views/ZoneView.tsx†L286-L305】【F:src/frontend/src/components/modals/ModalHost.tsx†L325-L470】【F:src/frontend/src/components/modals/**tests**/PlantAndDeviceModals.test.tsx†L104-L149】
 
 ### `CreateRoomModal.tsx`
 
@@ -360,36 +364,10 @@ These components define the content for various modals used for user input and i
 - **Dependencies:** `CutIcon`, `TrashIcon`.
 - **Usage Context:** Displayed when a user clicks on a plant card in the `ZonePlantPanel` (when not in selection mode).
 
-### `PlantStrainModal.tsx`
-
-- **Purpose:** A form for planting a new strain of plants in a zone. The dropdown is dynamically populated with strains available in the game state.
-- **Props:** `onSubmit`, `zoneId`, `availableStrains`, `onClose`.
-- **Icons Used:** None.
-- **Dependencies:** `FormSelect`, `FormInput`, `PrimaryButton`.
-- **Usage Context:** Displayed when the "Plant New" button is clicked in the `ZonePlantPanel`.
-
-### `InstallDeviceModal.tsx`
-
-- **Purpose:** Captures the target blueprint (and optional JSON settings) for installing a device into a zone, then emits `devices.installDevice` through the zone store helper.【F:src/frontend/src/views/zone/modals/InstallDeviceModal.tsx†L1-L154】【F:src/frontend/src/components/ModalHost.tsx†L1-L260】
-- **Props:** `zone`, `blueprintOptions?`, `onSubmit`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Triggered from the “Install device” button in the zone device inventory panel; the modal enforces JSON validation before dispatching the façade intent.【F:src/frontend/src/views/ZoneDetail.tsx†L1019-L1050】
-
-### `UpdateDeviceModal.tsx`
-
-- **Purpose:** Allows operators to submit a JSON patch for an existing device instance; on submit the component calls `devices.updateDevice` via the zone store.【F:src/frontend/src/views/zone/modals/UpdateDeviceModal.tsx†L1-L114】【F:src/frontend/src/components/ModalHost.tsx†L1-L260】
-- **Props:** `device`, `onSubmit`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Reached through the “Adjust settings” action in the device inventory; it pre-fills the current settings and requires at least one key before enabling the send.【F:src/frontend/src/views/ZoneDetail.tsx†L1038-L1072】
-
-### `MoveDeviceModal.tsx`
-
-- **Purpose:** Presents a dropdown of eligible zones and forwards the selection to `devices.moveDevice`, ensuring the facade validates room-purpose constraints.【F:src/frontend/src/views/zone/modals/MoveDeviceModal.tsx†L1-L129】【F:src/frontend/src/components/ModalHost.tsx†L1-L260】
-- **Props:** `device`, `currentZone`, `availableZones`, `onSubmit`, `onCancel`, `title?`, `description?`.
-- **Usage Context:** Launched from the “Move” action in the device inventory list when relocating hardware between zones.【F:src/frontend/src/views/ZoneDetail.tsx†L1046-L1072】
-
 ### Device removal confirmation
 
-- **Purpose:** Device removal reuses `ConfirmDeletionModal`, injecting device-specific copy before emitting `devices.removeDevice` through `useZoneStore.removeDevice` so the facade handles bookkeeping.【F:src/frontend/src/components/ModalHost.tsx†L1-L260】【F:src/frontend/src/store/zoneStore.ts†L435-L456】
-- **Usage Context:** Available from the “Remove” button in the device inventory panel; once confirmed the zone snapshot updates after the façade acknowledges the command.【F:src/frontend/src/views/ZoneDetail.tsx†L1072-L1086】
+- **Purpose:** Device removal reuses `ConfirmDeletionModal`, injecting device-specific copy before emitting `devices.removeDevice` so the facade handles bookkeeping.【F:src/frontend/src/components/modals/ModalHost.tsx†L1356-L1371】
+- **Usage Context:** Available from the “Remove” button in the device inventory panel; once confirmed the zone snapshot updates after the façade acknowledges the command.【F:src/frontend/src/components/modals/ModalHost.tsx†L1356-L1371】
 
 ### `RentStructureModal.tsx`
 

--- a/docs/ui/ui_interactions_spec.md
+++ b/docs/ui/ui_interactions_spec.md
@@ -128,7 +128,7 @@ The interface is hierarchical and supports a strategic (macro) and operational (
 - **AddZoneModal** → `facade.world.createZone({ roomId, zone: { name, area, methodId, targetPlantCount? } })`.
 - **InstallDeviceModal** → `facade.devices.installDevice({ targetId, deviceId, settings })` (enforces `allowedRoomPurposes`).
 - **AddSupplyModal** → `facade.plants.applyIrrigation({ zoneId, liters })` / `facade.plants.applyFertilizer({ zoneId, nutrients })`.
-- **PlantStrainModal** → `facade.plants.addPlanting({ zoneId, strainId, count })`.
+- **PlantZoneModal** → `facade.plants.addPlanting({ zoneId, strainId, count })` with capacity and method affinity hints sourced from the cultivation method blueprint.【F:src/frontend/src/components/modals/ModalHost.tsx†L104-L323】
 - **BreedStrainModal** → select two parent strains by **UUID `id`** to create a new strain (lineage stores parent UUIDs; empty parents ⇒ ur‑plant).
 
 **Management & Editing**

--- a/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ModalHost } from '../ModalHost';
+import { useSimulationStore } from '@/store/simulation';
+import { useUIStore } from '@/store/ui';
+import type { SimulationBridge } from '@/facade/systemFacade';
+import type { SimulationSnapshot } from '@/types/simulation';
+
+const baseSnapshot: SimulationSnapshot = {
+  tick: 0,
+  clock: {
+    tick: 0,
+    isPaused: true,
+    targetTickRate: 1,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+  },
+  structures: [],
+  rooms: [
+    {
+      id: 'room-1',
+      name: 'Cultivation Room',
+      structureId: 'structure-1',
+      structureName: 'Structure One',
+      purposeId: 'growroom',
+      purposeKind: 'growroom',
+      purposeName: 'Grow Room',
+      area: 50,
+      height: 3,
+      volume: 150,
+      cleanliness: 1,
+      maintenanceLevel: 1,
+      zoneIds: ['zone-1'],
+    },
+  ],
+  zones: [
+    {
+      id: 'zone-1',
+      name: 'Zone One',
+      structureId: 'structure-1',
+      structureName: 'Structure One',
+      roomId: 'room-1',
+      roomName: 'Cultivation Room',
+      area: 20,
+      ceilingHeight: 2.8,
+      volume: 56,
+      cultivationMethodId: '659ba4d7-a5fc-482e-98d4-b614341883ac',
+      environment: {
+        temperature: 24,
+        relativeHumidity: 0.6,
+        co2: 950,
+        ppfd: 520,
+        vpd: 1.2,
+      },
+      resources: {
+        waterLiters: 0,
+        nutrientSolutionLiters: 0,
+        nutrientStrength: 1,
+        substrateHealth: 1,
+        reservoirLevel: 1,
+        lastTranspirationLiters: 0,
+      },
+      metrics: {
+        averageTemperature: 24,
+        averageHumidity: 0.6,
+        averageCo2: 950,
+        averagePpfd: 520,
+        stressLevel: 0.2,
+        lastUpdatedTick: 0,
+      },
+      devices: [],
+      plants: [],
+      health: { diseases: 0, pests: 0, pendingTreatments: 0, appliedTreatments: 0 },
+    },
+  ],
+  personnel: { employees: [], applicants: [], overallMorale: 1 },
+  finance: {
+    cashOnHand: 0,
+    reservedCash: 0,
+    totalRevenue: 0,
+    totalExpenses: 0,
+    netIncome: 0,
+    lastTickRevenue: 0,
+    lastTickExpenses: 0,
+  },
+};
+
+describe('Plant and Device modals', () => {
+  let bridge: SimulationBridge;
+
+  beforeEach(() => {
+    bridge = {
+      connect: vi.fn(),
+      loadQuickStart: vi.fn(async () => ({ ok: true })),
+      getStructureBlueprints: vi.fn(async () => ({ ok: true, data: [] })),
+      getStrainBlueprints: vi.fn(async () => ({
+        ok: true,
+        data: [
+          {
+            id: 'strain-1',
+            slug: 'strain-1',
+            name: 'Aurora',
+            lineage: {},
+            genotype: {},
+            chemotype: {},
+            generalResilience: 0.8,
+            germinationRate: 0.95,
+            compatibility: { methodAffinity: { '659ba4d7-a5fc-482e-98d4-b614341883ac': 0.9 } },
+            defaults: {},
+            traits: {},
+            methodAffinity: { '659ba4d7-a5fc-482e-98d4-b614341883ac': 0.9 },
+          },
+        ],
+      })),
+      getDeviceBlueprints: vi.fn(async () => ({
+        ok: true,
+        data: [
+          {
+            id: 'device-1',
+            kind: 'lighting',
+            name: 'LED VegLight 600',
+            quality: 0.95,
+            complexity: 0.2,
+            lifetimeHours: 5000,
+            compatibility: { roomPurposes: ['growroom'] },
+            defaults: { settings: { coverageArea: 1.5, power: 0.7 } },
+            maintenance: {},
+            metadata: {},
+            price: {
+              capitalExpenditure: 0,
+              baseMaintenanceCostPerTick: 0,
+              costIncreasePer1000Ticks: 0,
+            },
+            roomPurposes: ['growroom'],
+            coverage: { maxArea_m2: 1.5 },
+            limits: {},
+            settings: { coverageArea: 1.5, power: 0.7 },
+          },
+        ],
+      })),
+      getDifficultyConfig: vi.fn(async () => ({ ok: true })),
+      sendControl: vi.fn(async () => ({ ok: true })),
+      sendConfigUpdate: vi.fn(async () => ({ ok: true })),
+      sendIntent: vi.fn(async () => ({ ok: true })),
+      subscribeToUpdates: () => () => undefined,
+      plants: {
+        addPlanting: vi.fn(async () => ({
+          ok: true,
+          warnings: ['Capacity tight, monitor stress.'],
+        })),
+      },
+      devices: {
+        installDevice: vi.fn(async () => ({ ok: true, warnings: ['Device load near limit.'] })),
+      },
+    } satisfies SimulationBridge;
+
+    act(() => {
+      useSimulationStore.setState({
+        snapshot: structuredClone(baseSnapshot),
+        events: [],
+        timeStatus: null,
+        connectionStatus: 'connected',
+        zoneHistory: {},
+        lastTick: 0,
+      });
+      useUIStore.setState({ activeModal: null, modalQueue: [] });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    act(() => {
+      useSimulationStore.getState().reset();
+      useUIStore.setState({ activeModal: null, modalQueue: [] });
+    });
+  });
+
+  it('surfaces planting capacity hints and warnings', async () => {
+    render(<ModalHost bridge={bridge} />);
+
+    act(() => {
+      useUIStore.getState().openModal({
+        id: 'plant-zone',
+        type: 'plantZone',
+        title: 'Plant zone',
+        context: { zoneId: 'zone-1' },
+      });
+    });
+
+    expect(await screen.findByText(/Capacity 80 plants/i)).toBeInTheDocument();
+    expect(screen.getByText(/Good fit/i)).toBeInTheDocument();
+
+    const countInput = screen.getByLabelText('Plant count');
+    fireEvent.change(countInput, { target: { value: '120' } });
+    expect(screen.getByText(/would exceed the estimated capacity/i)).toBeInTheDocument();
+
+    fireEvent.change(countInput, { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Plant zone' }));
+
+    await screen.findByText('Capacity tight, monitor stress.');
+    expect(bridge.plants.addPlanting).toHaveBeenCalledWith({
+      zoneId: 'zone-1',
+      strainId: 'strain-1',
+      count: 10,
+    });
+  });
+
+  it('validates device settings JSON and reports facade warnings', async () => {
+    render(<ModalHost bridge={bridge} />);
+
+    act(() => {
+      useUIStore.getState().openModal({
+        id: 'install-device',
+        type: 'installDevice',
+        title: 'Install device',
+        context: { zoneId: 'zone-1' },
+      });
+    });
+
+    expect(await screen.findByText(/Covers up to/i)).toBeInTheDocument();
+
+    const textarea = screen.getByLabelText('Settings (JSON)');
+    fireEvent.change(textarea, { target: { value: '{"power":' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Install device' }));
+    expect(await screen.findByText('Settings must be valid JSON.')).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: '{"power":0.5}' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Install device' }));
+
+    await screen.findByText('Device load near limit.');
+    expect(bridge.devices.installDevice).toHaveBeenCalledWith({
+      targetId: 'zone-1',
+      deviceId: 'device-1',
+      settings: { power: 0.5 },
+    });
+  });
+});

--- a/src/frontend/src/facade/systemFacade.ts
+++ b/src/frontend/src/facade/systemFacade.ts
@@ -90,6 +90,7 @@ export interface StrainBlueprint {
   traits: StrainTraits;
   metadata?: Record<string, unknown>;
   price?: StrainPriceEntry;
+  methodAffinity?: Record<string, number>;
 }
 
 export interface DeviceCompatibilityHints {
@@ -108,6 +109,12 @@ export interface DevicePriceEntry {
   costIncreasePer1000Ticks: number;
 }
 
+export interface DeviceCoverageMetadata {
+  maxArea_m2?: number;
+  coverageArea?: number;
+  [key: string]: unknown;
+}
+
 export interface DeviceBlueprint {
   id: string;
   kind: string;
@@ -122,6 +129,10 @@ export interface DeviceBlueprint {
   maintenance?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   price?: DevicePriceEntry;
+  roomPurposes?: string[];
+  coverage?: DeviceCoverageMetadata;
+  limits?: Record<string, unknown>;
+  settings?: Record<string, unknown>;
 }
 
 export interface AddPlantingOptions {

--- a/src/frontend/src/store/ui.ts
+++ b/src/frontend/src/store/ui.ts
@@ -19,7 +19,9 @@ type ModalType =
   | 'hireApplicant'
   | 'fireEmployee'
   | 'rejectApplicant'
-  | 'employeeDetails';
+  | 'employeeDetails'
+  | 'plantZone'
+  | 'installDevice';
 
 export interface ModalDescriptor {
   id: string;

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -283,7 +283,27 @@ export const ZoneView = () => {
               </ResponsiveContainer>
             </div>
           </Card>
-          <Card title="Devices" subtitle="Operations & maintenance">
+          <Card
+            title="Devices"
+            subtitle="Operations & maintenance"
+            action={
+              <Button
+                size="sm"
+                variant="secondary"
+                icon={<Icon name="precision_manufacturing" />}
+                onClick={() =>
+                  openModal({
+                    id: `install-${zone.id}`,
+                    type: 'installDevice',
+                    title: `Install device in ${zone.name}`,
+                    context: { zoneId: zone.id },
+                  })
+                }
+              >
+                Install device
+              </Button>
+            }
+          >
             <div className="grid gap-3">
               {zone.devices.map((device) => (
                 <div
@@ -356,7 +376,27 @@ export const ZoneView = () => {
               </div>
             </div>
           </Card>
-          <Card title="Plants" subtitle="Batch overview">
+          <Card
+            title="Plants"
+            subtitle="Batch overview"
+            action={
+              <Button
+                size="sm"
+                variant="secondary"
+                icon={<Icon name="local_florist" />}
+                onClick={() =>
+                  openModal({
+                    id: `plant-${zone.id}`,
+                    type: 'plantZone',
+                    title: `Plant ${zone.name}`,
+                    context: { zoneId: zone.id },
+                  })
+                }
+              >
+                Plant zone
+              </Button>
+            }
+          >
             <div
               ref={tableContainerRef}
               className="max-h-96 overflow-y-auto rounded-2xl border border-border/30"
@@ -417,7 +457,9 @@ export const ZoneView = () => {
               </table>
             </div>
             {zone.plants.length === 0 ? (
-              <p className="mt-3 text-sm text-text-muted">No plants assigned to this zone yet.</p>
+              <p className="mt-3 text-sm text-text-muted">
+                No plants assigned to this zone yet. Use "Plant zone" to schedule a new batch.
+              </p>
             ) : null}
           </Card>
           <Card title="Health" subtitle="Disease & treatment overview">


### PR DESCRIPTION
### **User description**
## Summary
- add PlantZoneModal and InstallDeviceModal that load facade catalogs and surface capacity/compatibility hints
- expose new modal types and zone view CTA buttons that open the modals with the active zone context
- cover the new flows with component tests and refresh UI docs and changelog entries

## Testing
- pnpm --filter @weebbreed/frontend test *(fails: vitest cannot resolve clsx dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8aca7561c8325b98e8fd2227047a6


___

### **PR Type**
Enhancement


___

### **Description**
- Add PlantZoneModal and InstallDeviceModal with facade catalog integration

- Surface capacity hints and compatibility warnings for zone operations

- Expose modal CTAs in ZoneView for planting and device installation

- Add comprehensive test coverage for new modal workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZoneView CTAs"] --> B["PlantZoneModal"]
  A --> C["InstallDeviceModal"]
  B --> D["Strain Catalog"]
  C --> E["Device Catalog"]
  D --> F["Capacity Validation"]
  E --> F
  F --> G["Facade Intent"]
  G --> H["Warning Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>systemFacade.ts</strong><dd><code>Add device coverage and strain affinity interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-c10fe9533502ad71aeab51f717f7ef1322039ac8389adbb333b4d5ade93e8f23">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ui.ts</strong><dd><code>Register plantZone and installDevice modal types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-b43acf03ee1e3acee6b71947b742d915d0f7530663682122bcc816a8ce37ec54">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalHost.tsx</strong><dd><code>Implement PlantZoneModal and InstallDeviceModal components</code></dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+544/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ZoneView.tsx</strong><dd><code>Add Plant zone and Install device CTA buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-dba4b9f137dd357469bbdd22a9d24fdc7849a451b264578544edf499562e8aaf">+45/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document new zone-level planting and device flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ui-building_guide.md</strong><dd><code>Update modal component documentation for new flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-401dd116d03f992298b30fefb03d195eaba6eab702429a68c67db35be701750f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ui-components-desciption.md</strong><dd><code>Replace old modal docs with new component descriptions</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-f41fbb8d75d7b2fbe96dceb50fe54f349bae5657ea1492ea80605a564bebec72">+12/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ui_interactions_spec.md</strong><dd><code>Update PlantZoneModal interaction specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-d9c89b0323a81e753872b2ed5338cdf3552663950112c7582e3e73c829dbaf3e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PlantAndDeviceModals.test.tsx</strong><dd><code>Add comprehensive test coverage for new modals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/260/files#diff-00d29097fb663c0089b20008b04a22c6e08a9e32a31724182b77de22f8d1fac2">+239/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

