### PR TITLE
Adjust method affinity thresholds for planting modals

### DIFF
--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -170,7 +170,7 @@ const PlantZoneModal = ({
         : 'Assign a cultivation method to compute capacity hints.';
     }
     const affinityPct = affinity * 100;
-    if (affinityPct >= 80) {
+    if (affinityPct >= 95) {
       return `Excellent fit (${formatNumber(affinityPct, { maximumFractionDigits: 0 })}% affinity)`;
     }
     if (affinityPct >= 60) {

--- a/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
@@ -111,6 +111,20 @@ describe('Plant and Device modals', () => {
             traits: {},
             methodAffinity: { '659ba4d7-a5fc-482e-98d4-b614341883ac': 0.9 },
           },
+          {
+            id: 'strain-2',
+            slug: 'strain-2',
+            name: 'Nova',
+            lineage: {},
+            genotype: {},
+            chemotype: {},
+            generalResilience: 0.85,
+            germinationRate: 0.96,
+            compatibility: { methodAffinity: { '659ba4d7-a5fc-482e-98d4-b614341883ac': 0.96 } },
+            defaults: {},
+            traits: {},
+            methodAffinity: { '659ba4d7-a5fc-482e-98d4-b614341883ac': 0.96 },
+          },
         ],
       })),
       getDeviceBlueprints: vi.fn(async () => ({
@@ -190,9 +204,16 @@ describe('Plant and Device modals', () => {
     });
 
     expect(await screen.findByText(/Capacity 80 plants/i)).toBeInTheDocument();
-    expect(screen.getByText(/Good fit/i)).toBeInTheDocument();
+    const strainSelect = await screen.findByLabelText('Strain');
+    expect(screen.getByText(/Good fit \(90% affinity\)/i)).toBeInTheDocument();
 
-    const countInput = screen.getByLabelText('Plant count');
+    fireEvent.change(strainSelect, { target: { value: 'strain-2' } });
+    expect(await screen.findByText(/Excellent fit \(96% affinity\)/i)).toBeInTheDocument();
+
+    fireEvent.change(strainSelect, { target: { value: 'strain-1' } });
+    expect(await screen.findByText(/Good fit \(90% affinity\)/i)).toBeInTheDocument();
+
+    const countInput = await screen.findByLabelText(/Plant count/i);
     fireEvent.change(countInput, { target: { value: '120' } });
     expect(screen.getByText(/would exceed the estimated capacity/i)).toBeInTheDocument();
 


### PR DESCRIPTION
### **User description**
## Summary
- raise the Excellent fit threshold in the planting modal so 90% affinity remains a Good fit
- extend the planting modal test fixture with an additional strain and assertions for the updated affinity boundaries

## Testing
- pnpm --filter @weebbreed/frontend test -- PlantAndDeviceModals.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8b8fc233883259c80dd78ed20f898


___

### **PR Type**
Enhancement


___

### **Description**
- Raise Excellent fit threshold from 80% to 95% affinity

- Add new strain fixture with 96% affinity for testing

- Update test assertions for affinity boundary validation

- Enhance strain selection testing in planting modal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Affinity Threshold"] --> B["80% → 95%"]
  B --> C["Excellent Fit"]
  D["Test Fixture"] --> E["Add Nova Strain"]
  E --> F["96% Affinity"]
  C --> G["Updated Modal Logic"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Update affinity threshold for Excellent fit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Changed Excellent fit threshold from 80% to 95% affinity<br> <li> Maintains Good fit threshold at 60% affinity</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/261/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PlantAndDeviceModals.test.tsx</strong><dd><code>Expand test coverage for affinity thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx

<ul><li>Added new strain fixture 'Nova' with 96% affinity<br> <li> Enhanced test assertions for affinity boundary validation<br> <li> Added strain selection testing with fireEvent changes<br> <li> Updated plant count input selector to use regex</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/261/files#diff-00d29097fb663c0089b20008b04a22c6e08a9e32a31724182b77de22f8d1fac2">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

