### PR TITLE
Guard rent modal state updates after unmount

### DIFF
--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -597,26 +597,43 @@ const RentStructureModal = ({
 
   // Load structure blueprints from backend
   useEffect(() => {
+    let isMounted = true;
     const loadBlueprints = async () => {
+      if (isMounted) {
+        setLoading(true);
+      }
       try {
         const response = await bridge.getStructureBlueprints();
+        if (!isMounted) {
+          return;
+        }
         if (response.ok && response.data) {
-          setBlueprints(response.data);
-          if (response.data.length > 0) {
-            setSelected(response.data[0].id);
+          if (isMounted) {
+            setBlueprints(response.data);
+            if (response.data.length > 0) {
+              setSelected(response.data[0].id);
+            }
           }
-        } else {
+        } else if (isMounted) {
           setFeedback('Failed to load structure blueprints from backend.');
         }
       } catch (error) {
         console.error('Failed to load structure blueprints:', error);
-        setFeedback('Connection error while loading structure blueprints.');
+        if (isMounted) {
+          setFeedback('Connection error while loading structure blueprints.');
+        }
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
-    loadBlueprints();
+    void loadBlueprints();
+
+    return () => {
+      isMounted = false;
+    };
   }, [bridge]);
 
   const handleRent = async () => {


### PR DESCRIPTION
### **User description**
## Summary
- guard the rent structure modal blueprint-loading effect with an isMounted flag
- prevent state updates when the modal unmounts while fetching and gate loading feedback on the mounted state

## Testing
- `pnpm run check` *(fails: @weebbreed/frontend lint missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bae785f48325ad6db8204b0df72c


___

### **PR Type**
Bug fix


___

### **Description**
- Add `isMounted` flag to prevent state updates after component unmount

- Guard all state setters in async blueprint loading effect

- Fix potential memory leaks and React warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Component Mount"] --> B["Set isMounted = true"]
  B --> C["Load Blueprints"]
  C --> D["Check isMounted"]
  D --> E["Update State"]
  F["Component Unmount"] --> G["Set isMounted = false"]
  G --> H["Block State Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalHost.tsx</strong><dd><code>Add mount guard to prevent state updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/modals/ModalHost.tsx

<ul><li>Add <code>isMounted</code> flag to track component mount state<br> <li> Guard all state setters with <code>isMounted</code> checks in async effect<br> <li> Add cleanup function to set <code>isMounted</code> to false on unmount<br> <li> Prevent state updates after component unmounts during async operations</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/262/files#diff-f8be898eaa97d20e4d8e1805818f05bc6b84be18175e878f4f7609335e7cf5b3">+24/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

