### PR TITLE
Normalize humidity setpoint aliases in simulation store

### DIFF
--- a/src/frontend/src/store/__tests__/simulation.test.ts
+++ b/src/frontend/src/store/__tests__/simulation.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useSimulationStore } from '../simulation';
+import type { SimulationEvent, SimulationSnapshot } from '@/types/simulation';
+
+const buildSnapshot = (
+  setpoints: Record<string, number | undefined> & {
+    humidity?: number;
+    relativeHumidity?: number;
+  },
+): SimulationSnapshot => ({
+  tick: 42,
+  clock: {
+    tick: 42,
+    isPaused: false,
+    targetTickRate: 1,
+    startedAt: new Date(0).toISOString(),
+    lastUpdatedAt: new Date(0).toISOString(),
+  },
+  structures: [
+    {
+      id: 'structure-1',
+      name: 'Structure 1',
+      status: 'active',
+      footprint: {
+        length: 1,
+        width: 1,
+        height: 1,
+        area: 1,
+        volume: 1,
+      },
+      rentPerTick: 0,
+      roomIds: ['room-1'],
+    },
+  ],
+  rooms: [
+    {
+      id: 'room-1',
+      name: 'Room 1',
+      structureId: 'structure-1',
+      structureName: 'Structure 1',
+      purposeId: 'purpose-1',
+      purposeKind: 'veg',
+      purposeName: 'Vegetation',
+      purposeFlags: {},
+      area: 1,
+      height: 1,
+      volume: 1,
+      cleanliness: 1,
+      maintenanceLevel: 1,
+      zoneIds: ['zone-1'],
+    },
+  ],
+  zones: [
+    {
+      id: 'zone-1',
+      name: 'Zone 1',
+      structureId: 'structure-1',
+      structureName: 'Structure 1',
+      roomId: 'room-1',
+      roomName: 'Room 1',
+      area: 1,
+      ceilingHeight: 1,
+      volume: 1,
+      environment: {
+        temperature: 20,
+        relativeHumidity: 0.5,
+        co2: 500,
+        ppfd: 300,
+        vpd: 1,
+      },
+      resources: {
+        waterLiters: 0,
+        nutrientSolutionLiters: 0,
+        nutrientStrength: 0,
+        substrateHealth: 1,
+        reservoirLevel: 0,
+        lastTranspirationLiters: 0,
+      },
+      metrics: {
+        averageTemperature: 20,
+        averageHumidity: 0.5,
+        averageCo2: 500,
+        averagePpfd: 300,
+        stressLevel: 0,
+        lastUpdatedTick: 42,
+      },
+      devices: [],
+      plants: [],
+      control: {
+        setpoints: {
+          temperature: setpoints.temperature,
+          humidity: setpoints.humidity,
+          co2: setpoints.co2,
+          ppfd: setpoints.ppfd,
+          vpd: setpoints.vpd,
+          relativeHumidity: setpoints.relativeHumidity,
+        },
+      },
+      health: {
+        diseases: 0,
+        pests: 0,
+        pendingTreatments: 0,
+        appliedTreatments: 0,
+      },
+    },
+  ],
+  personnel: {
+    employees: [],
+    applicants: [],
+    overallMorale: 1,
+  },
+  finance: {
+    cashOnHand: 0,
+    reservedCash: 0,
+    totalRevenue: 0,
+    totalExpenses: 0,
+    netIncome: 0,
+    lastTickRevenue: 0,
+    lastTickExpenses: 0,
+  },
+});
+
+const buildEvent = (control: Record<string, number | undefined>): SimulationEvent => ({
+  type: 'env.setpointUpdated',
+  payload: {
+    zoneId: 'zone-1',
+    control,
+  },
+});
+
+const snapshotWithoutControl = buildSnapshot({});
+
+describe('simulation store humidity aliases', () => {
+  beforeEach(() => {
+    useSimulationStore.getState().reset();
+  });
+
+  it('hydrates humidity from snapshot regardless of key alias', () => {
+    const snapshotWithHumidity = buildSnapshot({ humidity: 0.6 });
+    useSimulationStore.getState().hydrate({ snapshot: snapshotWithHumidity });
+    const humidityState = structuredClone(useSimulationStore.getState().zoneSetpoints);
+
+    useSimulationStore.getState().reset();
+
+    const snapshotWithRelativeHumidity = buildSnapshot({ relativeHumidity: 0.6 });
+    useSimulationStore.getState().hydrate({ snapshot: snapshotWithRelativeHumidity });
+    const relativeState = structuredClone(useSimulationStore.getState().zoneSetpoints);
+
+    expect(relativeState).toEqual(humidityState);
+    expect(relativeState['zone-1']?.humidity).toBe(0.6);
+    expect(relativeState['zone-1']).not.toHaveProperty('relativeHumidity');
+  });
+
+  it('applies setpoint events for humidity aliases identically', () => {
+    useSimulationStore.getState().hydrate({ snapshot: snapshotWithoutControl });
+    useSimulationStore.getState().recordEvents([buildEvent({ relativeHumidity: 0.55 })]);
+    const relativeState = structuredClone(useSimulationStore.getState().zoneSetpoints);
+
+    useSimulationStore.getState().reset();
+
+    useSimulationStore.getState().hydrate({ snapshot: snapshotWithoutControl });
+    useSimulationStore.getState().recordEvents([buildEvent({ humidity: 0.55 })]);
+    const humidityState = structuredClone(useSimulationStore.getState().zoneSetpoints);
+
+    expect(relativeState).toEqual(humidityState);
+    expect(relativeState['zone-1']?.humidity).toBe(0.55);
+    expect(relativeState['zone-1']).not.toHaveProperty('relativeHumidity');
+  });
+});

--- a/src/frontend/src/types/simulation.ts
+++ b/src/frontend/src/types/simulation.ts
@@ -23,6 +23,63 @@ export interface ZoneControlSetpoints {
   vpd?: number;
 }
 
+export type ZoneControlSetpointKey = keyof ZoneControlSetpoints;
+
+export const ZONE_CONTROL_SETPOINT_KEYS: ZoneControlSetpointKey[] = [
+  'temperature',
+  'humidity',
+  'co2',
+  'ppfd',
+  'vpd',
+];
+
+export type ZoneControlSetpointsLike = ZoneControlSetpoints & {
+  relativeHumidity?: number;
+};
+
+export const resolveHumiditySetpoint = (
+  setpoints?: Pick<ZoneControlSetpointsLike, 'humidity' | 'relativeHumidity'> | null,
+): number | undefined => {
+  if (!setpoints) {
+    return undefined;
+  }
+  if (typeof setpoints.humidity === 'number') {
+    return setpoints.humidity;
+  }
+  if (typeof setpoints.relativeHumidity === 'number') {
+    return setpoints.relativeHumidity;
+  }
+  return undefined;
+};
+
+export const canonicalizeZoneControlSetpoints = (
+  setpoints?: ZoneControlSetpointsLike | null,
+): ZoneControlSetpoints => {
+  if (!setpoints) {
+    return {};
+  }
+
+  const humidity = resolveHumiditySetpoint(setpoints);
+  const base = { ...setpoints } as ZoneControlSetpoints & {
+    relativeHumidity?: number;
+  };
+  if ('relativeHumidity' in base) {
+    delete base.relativeHumidity;
+  }
+
+  if (humidity === undefined) {
+    if ('humidity' in base && typeof base.humidity !== 'number') {
+      delete base.humidity;
+    }
+    return base;
+  }
+
+  return {
+    ...base,
+    humidity,
+  };
+};
+
 export interface ZoneControlSnapshot {
   setpoints: ZoneControlSetpoints;
 }


### PR DESCRIPTION
### **User description**
## Summary
- add helpers so zone control setpoints canonicalize humidity aliases before use
- ensure the simulation store derives and applies humidity setpoints using the canonical key only
- cover snapshot and event hydration parity for humidity aliases with new vitest cases

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d8d23f219083258ec0560f62387c09


___

### **PR Type**
Enhancement


___

### **Description**
- Normalize humidity setpoint aliases (`humidity` and `relativeHumidity`)

- Add helper functions for canonical humidity handling

- Ensure consistent state management across snapshots and events

- Add comprehensive test coverage for alias normalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw Setpoints"] --> B["canonicalizeZoneControlSetpoints()"]
  B --> C["Canonical Setpoints"]
  C --> D["Simulation Store"]
  E["relativeHumidity alias"] --> B
  F["humidity key"] --> B
  B --> G["Always uses 'humidity' key"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simulation.test.ts</strong><dd><code>Add humidity alias normalization tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/store/__tests__/simulation.test.ts

<ul><li>Add comprehensive test suite for humidity alias normalization<br> <li> Test snapshot hydration with both <code>humidity</code> and <code>relativeHumidity</code> keys<br> <li> Test event handling for both humidity aliases<br> <li> Verify consistent state regardless of input alias</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/265/files#diff-083666059e5e9c2db24c67f85cc54f04d2f05fcf108fa1951e68d35357097e7e">+170/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simulation.ts</strong><dd><code>Integrate humidity alias normalization in store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/store/simulation.ts

<ul><li>Import canonicalization helpers from types module<br> <li> Apply <code>canonicalizeZoneControlSetpoints()</code> in snapshot derivation<br> <li> Normalize control setpoints in event handling<br> <li> Add <code>humidity</code> case to metric switch statement</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/265/files#diff-a39f3164f5647a1ce0530a9f0dc5ac62a822368842e9765d40bba0a74e580d00">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simulation.ts</strong><dd><code>Add humidity setpoint canonicalization utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/types/simulation.ts

<ul><li>Add <code>ZoneControlSetpointsLike</code> type with <code>relativeHumidity</code> support<br> <li> Implement <code>resolveHumiditySetpoint()</code> helper function<br> <li> Add <code>canonicalizeZoneControlSetpoints()</code> normalization function<br> <li> Export <code>ZONE_CONTROL_SETPOINT_KEYS</code> constant array</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/265/files#diff-496e7c3b3984c81d10f204f8a799e414986f37a4f8cfda2fb5ab5ae03b9b999d">+57/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

