### PR TITLE
docs: add simulation facade intent catalog

### DIFF
--- a/docs/intents.md
+++ b/docs/intents.md
@@ -1,0 +1,127 @@
+# Simulation Facade Intents
+
+The simulation exposes a small number of validated intent domains. Each domain groups related commands that are available both through the in-process API and the Socket.IO `facade.intent` envelope. All commands return the shared `CommandResult` contract (`{ ok, data?, warnings?, errors? }`).【F:src/backend/src/facade/commands/commandRegistry.ts†L20-L67】【F:src/backend/src/server/socketGateway.ts†L364-L402】
+
+## Domain Overview
+
+| Domain      | Key actions                                                                                                   | Result data (when applicable)                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `time`      | `start`, `pause`, `resume`, `step`, `setSpeed`                                                                | Updated `TimeStatus` snapshot                        |
+| `world`     | `rentStructure`, blueprint queries, room/zone CRUD, duplication, `renameStructure`, `newGame`, `resetSession` | IDs or catalog data depending on command             |
+| `devices`   | `installDevice`, `updateDevice`, `moveDevice`, `removeDevice`, `toggleDeviceGroup`                            | Toggle returns affected device IDs                   |
+| `plants`    | `addPlanting`, `cullPlanting`, `harvestPlanting`, `applyIrrigation`, `applyFertilizer`, `togglePlantingPlan`  | Toggle returns automation state                      |
+| `health`    | `scheduleScouting`, `applyTreatment`, `quarantineZone`                                                        | –                                                    |
+| `workforce` | `refreshCandidates`, `hire`, `fire`, `setOvertimePolicy`, `assignStructure`, `enqueueTask`                    | Candidate refresh/enqueue return contextual payloads |
+| `finance`   | `sellInventory`, `setUtilityPrices`, `setMaintenancePolicy`                                                   | –                                                    |
+| `config`    | `getDifficultyConfig`                                                                                         | Active difficulty configuration                      |
+
+## Domain Details
+
+### Time (`time.*`)
+
+| Action     | Payload highlights                | Result data  |
+| ---------- | --------------------------------- | ------------ |
+| `start`    | `gameSpeed?`, `maxTicksPerFrame?` | `TimeStatus` |
+| `pause`    | –                                 | `TimeStatus` |
+| `resume`   | –                                 | `TimeStatus` |
+| `step`     | `ticks?` (defaults to 1)          | `TimeStatus` |
+| `setSpeed` | `multiplier` (positive)           | `TimeStatus` |
+
+Definitions live in `commands/time.ts`, and the façade registers the domain automatically during construction.【F:src/backend/src/facade/commands/time.ts†L17-L67】【F:src/backend/src/facade/index.ts†L409-L463】
+
+### World (`world.*`)
+
+| Action                   | Payload highlights                                                           | Result data                                       |
+| ------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| `rentStructure`          | `structureId`                                                                | Duplicate result with new structure identifiers   |
+| `getStructureBlueprints` | –                                                                            | `StructureBlueprint[]`                            |
+| `getStrainBlueprints`    | –                                                                            | `StrainBlueprintCatalogEntry[]`                   |
+| `getDeviceBlueprints`    | –                                                                            | `DeviceBlueprintCatalogEntry[]`                   |
+| `createRoom`             | `structureId`, `room { name, purpose, area, height? }`                       | –                                                 |
+| `updateRoom`             | `roomId`, `patch` with any mutable field                                     | –                                                 |
+| `deleteRoom`             | `roomId`                                                                     | –                                                 |
+| `createZone`             | `roomId`, `zone { name, area, methodId, targetPlantCount? }`                 | Created zone result                               |
+| `updateZone`             | `zoneId`, `patch` with name/area/method/targetPlantCount                     | –                                                 |
+| `deleteZone`             | `zoneId`                                                                     | –                                                 |
+| `renameStructure`        | `structureId`, `name`                                                        | –                                                 |
+| `deleteStructure`        | `structureId`                                                                | –                                                 |
+| `duplicateStructure`     | `structureId`, optional `name` override                                      | Duplicate structure result                        |
+| `duplicateRoom`          | `roomId`, optional `name`                                                    | Duplicate room result                             |
+| `duplicateZone`          | `zoneId`, optional `name`                                                    | Duplicate zone result                             |
+| `resetSession`           | Optional payload (`{}` by default) to wipe current run while keeping rentals | Duplicate structure result reflecting fresh state |
+| `newGame`                | Optional `{ difficulty?, seed?, modifiers? }`                                | –                                                 |
+
+Schemas and handler bindings are defined in `commands/world.ts` and wired into the façade registry.【F:src/backend/src/facade/commands/world.ts†L24-L220】【F:src/backend/src/facade/index.ts†L439-L476】
+
+### Devices (`devices.*`)
+
+| Action              | Payload highlights                          | Result data               |
+| ------------------- | ------------------------------------------- | ------------------------- |
+| `installDevice`     | `targetId`, `deviceId`, optional `settings` | –                         |
+| `updateDevice`      | `instanceId`, non-empty `settings` patch    | –                         |
+| `moveDevice`        | `instanceId`, `targetZoneId`                | –                         |
+| `removeDevice`      | `instanceId`                                | –                         |
+| `toggleDeviceGroup` | `zoneId`, `kind`, `enabled`                 | `{ deviceIds: string[] }` |
+
+Defined in `commands/devices.ts` and registered under the `devices` domain.【F:src/backend/src/facade/commands/devices.ts†L12-L86】【F:src/backend/src/facade/index.ts†L451-L478】
+
+### Plants (`plants.*`)
+
+| Action               | Payload highlights                                  | Result data                   |
+| -------------------- | --------------------------------------------------- | ----------------------------- |
+| `addPlanting`        | `zoneId`, `strainId`, `count`, optional `startTick` | –                             |
+| `cullPlanting`       | `plantingId`, optional `count`                      | –                             |
+| `harvestPlanting`    | `plantingId`                                        | –                             |
+| `applyIrrigation`    | `zoneId`, `liters`                                  | –                             |
+| `applyFertilizer`    | `zoneId`, `nutrients { n, p, k }`                   | –                             |
+| `togglePlantingPlan` | `zoneId`, `enabled`                                 | `{ enabled: boolean }` result |
+
+Configured in `commands/plants.ts` and exposed through the façade registry.【F:src/backend/src/facade/commands/plants.ts†L12-L104】【F:src/backend/src/facade/index.ts†L451-L479】
+
+### Health (`health.*`)
+
+| Action             | Payload highlights   | Result data |
+| ------------------ | -------------------- | ----------- |
+| `scheduleScouting` | `zoneId`             | –           |
+| `applyTreatment`   | `zoneId`, `optionId` | –           |
+| `quarantineZone`   | `zoneId`, `enabled`  | –           |
+
+Specified in `commands/health.ts` and wired into the façade registry.【F:src/backend/src/facade/commands/health.ts†L12-L72】【F:src/backend/src/facade/index.ts†L452-L480】
+
+### Workforce (`workforce.*`)
+
+| Action              | Payload highlights                                          | Result data |
+| ------------------- | ----------------------------------------------------------- | ----------- |
+| `refreshCandidates` | Optional `{ seed?, policyId?, force? }`                     | –           |
+| `hire`              | `candidateId`, `role`, optional `wage`                      | –           |
+| `fire`              | `employeeId`                                                | –           |
+| `setOvertimePolicy` | `policy` (`"payout"` \| `"timeOff"`), optional `multiplier` | –           |
+| `assignStructure`   | `employeeId`, optional `structureId`                        | –           |
+| `enqueueTask`       | `taskKind`, optional `payload` (defaults to `{}`)           | –           |
+
+Schemas live in `commands/workforce.ts`; the façade preprocesses optional payloads before routing to services.【F:src/backend/src/facade/commands/workforce.ts†L12-L112】【F:src/backend/src/facade/index.ts†L452-L481】
+
+### Finance (`finance.*`)
+
+| Action                 | Payload highlights                                                            | Result data |
+| ---------------------- | ----------------------------------------------------------------------------- | ----------- |
+| `sellInventory`        | `lotId`, `grams`                                                              | –           |
+| `setUtilityPrices`     | Any subset of `electricityCostPerKWh`, `waterCostPerM3`, `nutrientsCostPerKg` | –           |
+| `setMaintenancePolicy` | Optional `strategy`, optional `multiplier` (at least one)                     | –           |
+
+Defined in `commands/finance.ts` and registered as the `finance` domain.【F:src/backend/src/facade/commands/finance.ts†L12-L78】【F:src/backend/src/facade/index.ts†L452-L482】
+
+### Config (`config.*`)
+
+| Action                | Payload highlights   | Result data        |
+| --------------------- | -------------------- | ------------------ |
+| `getDifficultyConfig` | – (defaults to `{}`) | `DifficultyConfig` |
+
+Provided by `commands/config.ts` and exposed as `config.getDifficultyConfig` on the façade.【F:src/backend/src/facade/commands/config.ts†L12-L44】【F:src/backend/src/facade/index.ts†L452-L484】
+
+## Accessing the Catalog at Runtime
+
+- `SimulationFacade.listIntentDomains()` returns the available domains (useful for tooling or health checks).【F:src/backend/src/facade/index.ts†L776-L805】
+- `SimulationFacade.getIntentHandler(domain, action)` resolves the runtime invoker that Socket clients ultimately call through `facade.intent`. Unknown domains/actions receive validation errors before execution.【F:src/backend/src/facade/index.ts†L776-L820】【F:src/backend/src/server/socketGateway.ts†L358-L403】
+
+Use this document as the canonical reference for keeping UI workflows, integration tests, and documentation in sync with the currently implemented command surface.

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -54,6 +54,8 @@ Common categories are below.
 
 ## 4) Command Surface (categories)
 
+> See [`docs/intents.md`](../intents.md) for the authoritative, per-domain command matrix.
+
 ### 4.1 Time & Simulation Control
 
 - `start({ gameSpeed?, maxTicksPerFrame? })`
@@ -61,20 +63,17 @@ Common categories are below.
 - `step(nTicks = 1)` — advance deterministically by n ticks.
 - `setSpeed(multiplier: number)`
 
-### 4.2 Data Lifecycle
+### 4.2 Session Lifecycle & Blueprints
 
-- `loadBlueprints(blueprintBundle | paths)` — validate then stage.
-- `hotReload(blueprintBundle | paths)` — validate → stage → atomic swap on tick boundary.
-- `newGame(options)` — seed, initial capital, difficulty.
-- `save(): Snapshot` / `load(snapshot)`
-- `exportState()` / `importState(serialized)`
-
-### 4.3 World Building (Structures → Rooms → Zones)
-
+- `newGame({ difficulty?, seed?, modifiers? })` — bootstraps a fresh state with optional tweaks.
+- `resetSession()` — wipes the current run while retaining rented structures for quick restarts.
 - `getStructureBlueprints()` / `getStrainBlueprints()` /
   `getDeviceBlueprints()` — read-only catalogs with IDs, names,
   compatibility hints (room purposes or method affinity), default settings, and
   price hints sourced from the active blueprint repository.
+
+### 4.3 World Building (Structures → Rooms → Zones)
+
 - `rentStructure(structureId: UUID)` — validates availability; applies CapEx/Fixed cost rules.
 - `renameStructure({ structureId, name })` — trims whitespace, preserves determinism, emits rename events.
 - `deleteStructure(structureId)` — enforces empty structure + accounting clean-up.
@@ -85,6 +84,7 @@ Common categories are below.
 - `updateZone(zoneId, patch)` / `deleteZone(zoneId)`
 - `duplicateZone({ zoneId, name? })` — copies cultivation method, automation, and device placement (subject to allowed purposes).
 - `duplicateStructure({ structureId, name? })` — creates a structure-level clone including rooms/zones; returns `{ structureId }`.
+- `resetSession()` and `newGame()` are also exposed under the world domain; see §4.2 for lifecycle semantics.
 - Guards: geometry, purpose bindings, and blueprint availability validated for every mutation.
 
 ### 4.4 Devices

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -399,12 +399,15 @@ object:
 
 #### Supported actions per domain
 
+- **time** — `start`, `pause`, `resume`, `step`, `setSpeed`. Each call mirrors
+  the in-process scheduler API and resolves with the updated `TimeStatus`.
 - **world** — `getStructureBlueprints`, `getStrainBlueprints`,
   `getDeviceBlueprints`, `rentStructure`, `createRoom`, `updateRoom`,
   `deleteRoom`, `createZone`, `updateZone`, `deleteZone`, `renameStructure`,
-  `deleteStructure`, `duplicateStructure`, `duplicateRoom`, `duplicateZone`.
-  Duplication commands accept an optional `name` override and return
-  `{ structureId | roomId | zoneId }` for the newly created copy.
+  `deleteStructure`, `duplicateStructure`, `duplicateRoom`, `duplicateZone`,
+  `resetSession`, `newGame`. Duplication commands accept an optional `name`
+  override and return `{ structureId | roomId | zoneId }` for the newly
+  created copy.
 - **devices** — `installDevice`, `updateDevice`, `moveDevice`, `removeDevice`,
   `toggleDeviceGroup`. The toggle action returns `{ deviceIds: string[] }` with
   every instance that changed status.
@@ -416,6 +419,7 @@ object:
 - **workforce** — `refreshCandidates`, `hire`, `fire`, `setOvertimePolicy`,
   `assignStructure`, `enqueueTask` (payload defaults to `{}` when omitted).
 - **finance** — `sellInventory`, `setUtilityPrices`, `setMaintenancePolicy`.
+- **config** — `getDifficultyConfig` (payload defaults to `{}`).
 
 ##### Blueprint catalog commands
 


### PR DESCRIPTION
### **User description**
## Summary
- add `/docs/intents.md` with a structured list of the currently supported SimulationFacade intents
- align the facade overview and socket protocol documentation with the new catalog

## Testing
- pnpm run check *(fails: frontend eslint errors in existing workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d4ce54688325a03c96791b9422ec


___

### **PR Type**
Documentation


___

### **Description**
- Add comprehensive simulation facade intents catalog

- Document all 8 command domains with payloads and results

- Update facade and socket protocol documentation references

- Provide runtime access methods for intent discovery


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New intents.md"] --> B["Command Domains"]
  B --> C["time, world, devices"]
  B --> D["plants, health, workforce"]
  B --> E["finance, config"]
  F["facade.md"] --> G["Updated references"]
  H["socket_protocol.md"] --> I["Updated action lists"]
  A --> J["Runtime access methods"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intents.md</strong><dd><code>Add complete simulation facade intents catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/intents.md

<ul><li>Create comprehensive catalog of 8 simulation facade intent domains<br> <li> Document all commands with payloads, result data, and file references<br> <li> Include domain overview table and detailed per-domain breakdowns<br> <li> Add runtime access methods for intent discovery</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/267/files#diff-092b3c5f56761bb9928eb8b3cd83f02bc40ae27a1b9fe68536a210ed59f4ea17">+127/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>facade.md</strong><dd><code>Update facade docs with intents catalog reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/system/facade.md

<ul><li>Add reference to new intents.md as authoritative command matrix<br> <li> Reorganize session lifecycle commands under separate section<br> <li> Update world building section with resetSession and newGame references</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/267/files#diff-07977657af8e0646918d79a2ec3945af25eb7325fcefe840a117a0a7b7323c17">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>socket_protocol.md</strong><dd><code>Update socket protocol with missing intent actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/system/socket_protocol.md

<ul><li>Add time domain actions with TimeStatus result documentation<br> <li> Update world domain with resetSession and newGame actions<br> <li> Add config domain with getDifficultyConfig action</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/267/files#diff-0af8ef4d9194d8affcf445132c4456fd7133e7ceb012b1a1e2bc6b5ef1d12d8c">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

