### PR TITLE
Remove VPD slider from EnvironmentPanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended the frontend `FacadeIntentCommand` domain union with the `config` channel so facade hooks mirror the backend contract for configuration updates.
 - Expanded dashboard game-speed presets to `0.5×/1×/10×/25×/50×/100×/250×`, widened button styling to fit three-digit labels, and refreshed UI documentation to match the new list.
 - Debounced zone EnvironmentPanel setpoint sliders so local adjustments respond instantly while bridge updates batch after a short delay, flushing on blur/mouseup and cancelling on unmount alongside new regression coverage.
+- Removed the EnvironmentPanel VPD slider, keeping the badge summary while routing VPD adjustments through humidity controls only.
 
 ### Fixed
 

--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -32,6 +32,26 @@ describe('EnvironmentPanel', () => {
 
   const baseZone = () => structuredClone(quickstartSnapshot.zones[0]);
 
+  it('shows VPD summary but no direct VPD control', () => {
+    const zone = baseZone();
+    const bridge = buildBridge();
+
+    render(
+      <EnvironmentPanel
+        zone={zone}
+        setpoints={zone.control?.setpoints}
+        bridge={bridge}
+        defaultExpanded
+      />,
+    );
+
+    const panel = within(screen.getAllByTestId('environment-panel-root').at(-1)!);
+    expect(panel.queryByTestId('vpd-slider')).not.toBeInTheDocument();
+
+    const header = panel.getByTestId('environment-panel-toggle');
+    expect(within(header).getByText('VPD')).toBeInTheDocument();
+  });
+
   it('dispatches temperature updates through the simulation bridge', async () => {
     const zone = baseZone();
     const sendConfigUpdate = vi.fn(async () => ({ ok: true }));

--- a/src/frontend/src/components/zone/EnvironmentPanel.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/primitives/Badge';
 import { Button } from '@/components/primitives/Button';
 import { formatNumber } from '@/utils/formatNumber';
 
-type SetpointMetric = 'temperature' | 'relativeHumidity' | 'co2' | 'ppfd' | 'vpd';
+type SetpointMetric = 'temperature' | 'relativeHumidity' | 'co2' | 'ppfd';
 
 interface EnvironmentPanelProps {
   zone: ZoneSnapshot;
@@ -49,7 +49,6 @@ const createDeviceMatcher = (zone: ZoneSnapshot) => {
 
 const temperatureRange = { min: 16, max: 32, step: 0.5 } as const;
 const humidityRange = { min: 35, max: 90, step: 1 } as const;
-const vpdRange = { min: 0, max: 2.5, step: 0.05 } as const;
 const co2Range = { min: 400, max: 1600, step: 25 } as const;
 const ppfdRange = { min: 0, max: 1200, step: 10 } as const;
 
@@ -101,13 +100,11 @@ export const EnvironmentPanel = ({
   const temperatureTarget = setpoints?.temperature ?? zone.environment.temperature;
   const humidityTargetPercent =
     ((setpoints?.humidity ?? zone.environment.relativeHumidity) || 0) * 100;
-  const vpdTarget = setpoints?.vpd ?? zone.environment.vpd;
   const co2Target = setpoints?.co2 ?? zone.environment.co2;
   const ppfdTarget = setpoints?.ppfd ?? zone.environment.ppfd;
 
   const [temperatureValue, setTemperatureValue] = useState<number>(temperatureTarget);
   const [humidityValue, setHumidityValue] = useState<number>(humidityTargetPercent);
-  const [vpdValue, setVpdValue] = useState<number>(vpdTarget);
   const [co2Value, setCo2Value] = useState<number>(co2Target);
   const [ppfdValue, setPpfdValue] = useState<number>(ppfdTarget);
 
@@ -120,10 +117,6 @@ export const EnvironmentPanel = ({
   useEffect(() => {
     setHumidityValue(humidityTargetPercent);
   }, [humidityTargetPercent]);
-
-  useEffect(() => {
-    setVpdValue(vpdTarget);
-  }, [vpdTarget]);
 
   useEffect(() => {
     setCo2Value(co2Target);
@@ -415,37 +408,6 @@ export const EnvironmentPanel = ({
                     maximumFractionDigits: 0,
                   })}
                   %
-                </span>
-              </div>
-            </div>
-
-            <div className="grid gap-2">
-              <label htmlFor={`vpd-${zone.id}`}>
-                <SliderLabel icon="science">VPD Target</SliderLabel>
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  id={`vpd-${zone.id}`}
-                  type="range"
-                  min={vpdRange.min}
-                  max={vpdRange.max}
-                  step={vpdRange.step}
-                  value={vpdValue}
-                  disabled={!canControlHumidity || pendingMetric === 'vpd'}
-                  onChange={(event) => {
-                    const nextValue = Number(event.target.value);
-                    setVpdValue(nextValue);
-                    schedule('vpd', nextValue);
-                  }}
-                  onBlur={() => flush()}
-                  onMouseUp={() => flush()}
-                  onTouchEnd={() => flush()}
-                  className="flex-1 accent-primary"
-                  data-testid="vpd-slider"
-                />
-                <span className="min-w-[64px] text-right text-sm font-semibold text-text">
-                  {formatNumber(vpdValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{' '}
-                  kPa
                 </span>
               </div>
             </div>


### PR DESCRIPTION
### **User description**
## Summary
- remove the VPD slider and related state from the zone EnvironmentPanel while leaving the summary badge intact
- extend the EnvironmentPanel tests to assert the badge remains and the slider is gone
- note the UI change in the changelog

## Testing
- pnpm --filter @weebbreed/frontend test -- src/components/zone/EnvironmentPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8d99d10c88325a9ac38a04fabbc65


___

### **PR Type**
Enhancement


___

### **Description**
- Remove VPD slider from EnvironmentPanel component

- Keep VPD badge summary in panel header

- Add test coverage for VPD control removal

- Update changelog with UI change documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EnvironmentPanel"] --> B["Remove VPD Slider"]
  A --> C["Keep VPD Badge"]
  B --> D["Update Tests"]
  C --> E["Route VPD via Humidity"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document VPD slider removal in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add entry documenting VPD slider removal<br> <li> Note that VPD badge summary remains intact<br> <li> Explain VPD adjustments now route through humidity controls</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/269/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnvironmentPanel.test.tsx</strong><dd><code>Add test coverage for VPD slider removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/zone/EnvironmentPanel.test.tsx

<ul><li>Add test to verify VPD slider is not present<br> <li> Assert VPD badge still appears in panel header<br> <li> Use <code>queryByTestId</code> to confirm slider removal</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/269/files#diff-d4e1dbee0bba8d279097f4925a5d16925b45806a4e03d3b4c4098c800a0a6d64">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnvironmentPanel.tsx</strong><dd><code>Remove VPD slider component and state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/components/zone/EnvironmentPanel.tsx

<ul><li>Remove <code>vpd</code> from SetpointMetric type definition<br> <li> Delete VPD slider component and related state<br> <li> Remove VPD range constants and event handlers<br> <li> Clean up VPD-related useEffect hooks</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/269/files#diff-3f25d5b13282c8f055d66cecb0b5eca6c193a75ed460c58a56dafc24b6079c5b">+1/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

