### PR TITLE
Add lighting cycle slider and sync logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an EnvironmentPanel photoperiod slider that programs lighting cycles
+  via the new `devices.adjustLightingCycle` bridge intent, keeps KPI badges in
+  sync through lighting-cycle domain events, and includes Vitest coverage for
+  command payloads and synchronization behaviour.
 - Introduced a zone EnvironmentPanel component with collapsed KPI chips, device-aware setpoint sliders for temperature/humidity/VPD/CO₂/PPFD, and a PPFD lighting toggle wired through the simulation bridge with inline warning feedback.
 - Documented simulation constant governance in [ADR 0009](docs/system/adr/0009-simulation-constants-governance.md) and cross-linked the constants catalogue.
 - Exposed typed strain/device blueprint catalog fetchers and convenience wrappers for

--- a/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
@@ -25,6 +25,7 @@ const bridge: SimulationBridge = {
   },
   devices: {
     installDevice: async () => ({ ok: true }),
+    adjustLightingCycle: async () => ({ ok: true }),
   },
 };
 

--- a/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
@@ -25,6 +25,7 @@ const bridge: SimulationBridge = {
   },
   devices: {
     installDevice: async () => ({ ok: true }),
+    adjustLightingCycle: async () => ({ ok: true }),
   },
 };
 

--- a/src/frontend/src/components/finance/UtilityPricing.test.tsx
+++ b/src/frontend/src/components/finance/UtilityPricing.test.tsx
@@ -74,6 +74,7 @@ describe('UtilityPricing component', () => {
       },
       devices: {
         installDevice: async () => ({ ok: true }),
+        adjustLightingCycle: async () => ({ ok: true }),
       },
     } satisfies SimulationBridge;
     act(() => {

--- a/src/frontend/src/components/modals/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/ModalHost.test.tsx
@@ -64,6 +64,7 @@ describe('ModalHost', () => {
       },
       devices: {
         installDevice: vi.fn(async () => ({ ok: true })),
+        adjustLightingCycle: vi.fn(async () => ({ ok: true })),
       },
     };
 

--- a/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
@@ -261,6 +261,7 @@ describe('Plant and Device modals', () => {
       },
       devices: {
         installDevice: vi.fn(async () => ({ ok: true, warnings: ['Device load near limit.'] })),
+        adjustLightingCycle: vi.fn(async () => ({ ok: true })),
       },
     } satisfies SimulationBridge;
 

--- a/src/frontend/src/facade/systemFacade.ts
+++ b/src/frontend/src/facade/systemFacade.ts
@@ -158,6 +158,15 @@ export interface DeviceInstallationResult {
   warnings?: string[];
 }
 
+export interface AdjustLightingCycleOptions {
+  zoneId: string;
+  photoperiodHours: { on: number; off: number };
+}
+
+export interface AdjustLightingCycleResult {
+  photoperiodHours: { on: number; off: number };
+}
+
 export interface SimulationBridge {
   connect: () => void;
   loadQuickStart: () => Promise<CommandResponse<unknown>>;
@@ -180,6 +189,9 @@ export interface SimulationBridge {
     installDevice: (
       options: InstallDeviceOptions,
     ) => Promise<CommandResponse<DeviceInstallationResult>>;
+    adjustLightingCycle: (
+      options: AdjustLightingCycleOptions,
+    ) => Promise<CommandResponse<AdjustLightingCycleResult>>;
   };
 }
 
@@ -248,6 +260,19 @@ class SocketSystemFacade implements SimulationBridge {
         payload,
       };
       return this.sendIntent<DeviceInstallationResult>(intent);
+    },
+    adjustLightingCycle: async (options: AdjustLightingCycleOptions) => {
+      this.requireConnected();
+      const payload = {
+        zoneId: options.zoneId,
+        photoperiodHours: options.photoperiodHours,
+      } satisfies FacadeIntentCommand['payload'];
+      const intent: FacadeIntentCommand = {
+        domain: 'devices',
+        action: 'adjustLightingCycle',
+        payload,
+      };
+      return this.sendIntent<AdjustLightingCycleResult>(intent);
     },
   };
 

--- a/src/frontend/src/store/__tests__/simulation.test.ts
+++ b/src/frontend/src/store/__tests__/simulation.test.ts
@@ -106,6 +106,9 @@ const buildSnapshot = (
         },
         devices: [],
         plants: [],
+        lighting: {
+          photoperiodHours: { on: 18, off: 6 },
+        },
         control: {
           setpoints: controlSetpoints,
         },
@@ -262,5 +265,29 @@ describe('simulation store setpoint tolerances', () => {
     const nextSetpoints = useSimulationStore.getState().zoneSetpoints;
     expect(nextSetpoints).not.toBe(initialSetpoints);
     expect(nextSetpoints['zone-1']?.ppfd).toBe(484);
+  });
+});
+
+describe('simulation store lighting updates', () => {
+  beforeEach(() => {
+    useSimulationStore.getState().reset();
+  });
+
+  it('updates photoperiod hours when a lighting cycle event arrives', () => {
+    useSimulationStore.getState().hydrate({ snapshot: buildSnapshot({}) });
+
+    const event: SimulationEvent = {
+      type: 'devices.lightingCycleAdjusted',
+      zoneId: 'zone-1',
+      payload: {
+        zoneId: 'zone-1',
+        photoperiodHours: { on: 16, off: 8 },
+      },
+    };
+
+    useSimulationStore.getState().recordEvents([event]);
+
+    const snapshot = useSimulationStore.getState().snapshot;
+    expect(snapshot?.zones[0].lighting?.photoperiodHours).toEqual({ on: 16, off: 8 });
   });
 });


### PR DESCRIPTION
### **User description**
## Summary
- add a photoperiod slider to the zone EnvironmentPanel that displays the light/dark split and routes updates through the new bridge intent
- extend the frontend simulation bridge and store to support `devices.adjustLightingCycle`, keeping badge data in sync with lighting-cycle events
- expand component and store tests plus changelog entries covering the new control and synchronization behaviour

## Testing
- pnpm --filter @weebbreed/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d8de9b3bd483258696b416b73cb839


___

### **PR Type**
Enhancement


___

### **Description**
- Add photoperiod slider to EnvironmentPanel for lighting cycle control

- Implement `devices.adjustLightingCycle` bridge intent with sync logic

- Extend simulation store to handle lighting-cycle events

- Add comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EnvironmentPanel"] --> B["Photoperiod Slider"]
  B --> C["adjustLightingCycle Intent"]
  C --> D["SimulationBridge"]
  D --> E["Store Events"]
  E --> F["Badge Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>systemFacade.ts</strong><dd><code>Add adjustLightingCycle bridge interface and implementation</code></dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-c10fe9533502ad71aeab51f717f7ef1322039ac8389adbb333b4d5ade93e8f23">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>simulation.ts</strong><dd><code>Implement lighting event processing and sync logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-a39f3164f5647a1ce0530a9f0dc5ac62a822368842e9765d40bba0a74e580d00">+166/-14</a></td>

</tr>

<tr>
  <td><strong>EnvironmentPanel.tsx</strong><dd><code>Implement photoperiod slider with debounced lighting cycle control</code></dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-3f25d5b13282c8f055d66cecb0b5eca6c193a75ed460c58a56dafc24b6079c5b">+169/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>simulation.test.ts</strong><dd><code>Add tests for lighting cycle event handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-083666059e5e9c2db24c67f85cc54f04d2f05fcf108fa1951e68d35357097e7e">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExpenseBreakdown.test.tsx</strong><dd><code>Update mock bridge with adjustLightingCycle method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-2a2162e3a1dbe1062005da7bde91ef8c23083ec4ffdba6ba81c92ff9d62abfa2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RevenueBreakdown.test.tsx</strong><dd><code>Update mock bridge with adjustLightingCycle method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-9e5753b7bb83fb67598400cb374f56a010568553daa4a2ef275500358257212c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UtilityPricing.test.tsx</strong><dd><code>Update mock bridge with adjustLightingCycle method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-407b59a1b1d41876ed9450debbb8008f0fb9e2abae5980437fa7fda0bbe8ec44">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModalHost.test.tsx</strong><dd><code>Update mock bridge with adjustLightingCycle method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-8ee6381cf7a28b5cd6e5c13ca6bcebdcde493bf906dc8bf301bcb558c4527383">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PlantAndDeviceModals.test.tsx</strong><dd><code>Update mock bridge with adjustLightingCycle method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-00d29097fb663c0089b20008b04a22c6e08a9e32a31724182b77de22f8d1fac2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EnvironmentPanel.test.tsx</strong><dd><code>Add comprehensive tests for photoperiod slider functionality</code></dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-d4e1dbee0bba8d279097f4925a5d16925b45806a4e03d3b4c4098c800a0a6d64">+96/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document photoperiod slider feature addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/271/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

