### PR TITLE
Embed zone environment controls in header

### DIFF
--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -321,4 +321,21 @@ describe('EnvironmentPanel', () => {
       value: 27,
     });
   });
+
+  it('renders the embedded variant without the standalone section wrapper', () => {
+    const zone = baseZone();
+    const bridge = buildBridge();
+
+    render(
+      <EnvironmentPanel
+        zone={zone}
+        setpoints={zone.control?.setpoints}
+        bridge={bridge}
+        variant="embedded"
+      />,
+    );
+
+    const roots = screen.getAllByTestId('environment-panel-root');
+    expect(roots.at(-1)?.tagName).toBe('DIV');
+  });
 });

--- a/src/frontend/src/components/zone/EnvironmentPanel.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.tsx
@@ -14,6 +14,8 @@ interface EnvironmentPanelProps {
   setpoints?: ZoneControlSetpoints;
   bridge: SimulationBridge;
   defaultExpanded?: boolean;
+  variant?: 'standalone' | 'embedded';
+  className?: string;
 }
 
 type BadgeTone = 'default' | 'success' | 'warning' | 'danger';
@@ -112,6 +114,8 @@ export const EnvironmentPanel = ({
   setpoints,
   bridge,
   defaultExpanded = false,
+  variant = 'standalone',
+  className,
 }: EnvironmentPanelProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [warnings, setWarnings] = useState<string[]>([]);
@@ -434,14 +438,27 @@ export const EnvironmentPanel = ({
   const isLightsOn = effectivePpfdTarget > 0;
   const photoperiodDarkHours = Math.max(24 - photoperiodValue, MINIMUM_DARK_HOURS);
 
+  const Container: 'section' | 'div' = variant === 'standalone' ? 'section' : 'div';
+  const containerClasses = cx(
+    variant === 'standalone'
+      ? 'rounded-3xl border border-border/50 bg-surface-elevated/70'
+      : 'rounded-2xl border border-border/40 bg-surface-muted/30',
+    className,
+  );
+  const toggleClasses = cx(
+    'flex w-full flex-col gap-4 text-left transition hover:bg-surface-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+    variant === 'standalone' ? 'rounded-3xl px-6 py-4' : 'rounded-2xl px-5 py-4',
+  );
+  const bodyClasses = cx(
+    'grid gap-6 border-t',
+    variant === 'standalone' ? 'border-border/50 px-6 pb-6' : 'border-border/40 px-5 pb-5',
+  );
+
   return (
-    <section
-      className="rounded-3xl border border-border/50 bg-surface-elevated/70"
-      data-testid="environment-panel-root"
-    >
+    <Container className={containerClasses} data-testid="environment-panel-root">
       <button
         type="button"
-        className="flex w-full flex-col gap-4 rounded-3xl px-6 py-4 text-left transition hover:bg-surface-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className={toggleClasses}
         onClick={() => setExpanded((value) => !value)}
         aria-expanded={expanded}
         data-testid="environment-panel-toggle"
@@ -470,7 +487,7 @@ export const EnvironmentPanel = ({
         </div>
       </button>
       {expanded ? (
-        <div className="grid gap-6 border-t border-border/50 px-6 pb-6">
+        <div className={bodyClasses}>
           <div className="grid gap-5 md:grid-cols-2">
             <div className="grid gap-2">
               <label htmlFor={`temperature-${zone.id}`}>
@@ -653,6 +670,6 @@ export const EnvironmentPanel = ({
           ) : null}
         </div>
       ) : null}
-    </section>
+    </Container>
   );
 };

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -173,26 +173,17 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
 
   return (
     <div className="grid gap-6">
-      <header className="flex flex-col gap-2 rounded-3xl border border-border/40 bg-surface-elevated/80 p-6">
-        <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
-        <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
-        <p className="text-sm text-text-muted">
-          {formatNumber(zone.area)} m² · volume {formatNumber(zone.volume)} m³ · cultivation method{' '}
-          {zone.cultivationMethodId ?? '—'}
-        </p>
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge tone="success">
-            VPD{' '}
-            {formatNumber(zone.environment.vpd, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </Badge>
-          <Badge tone="default">PPFD {formatNumber(zone.environment.ppfd)} µmol</Badge>
-          <Badge tone="default">CO₂ {formatNumber(zone.environment.co2)} ppm</Badge>
+      <header className="flex flex-col gap-6 rounded-3xl border border-border/40 bg-surface-elevated/80 p-6">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
+          <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
+          <p className="text-sm text-text-muted">
+            {formatNumber(zone.area)} m² · volume {formatNumber(zone.volume)} m³ · cultivation
+            method {zone.cultivationMethodId ?? '—'}
+          </p>
         </div>
+        <EnvironmentPanel zone={zone} setpoints={setpoints} bridge={bridge} variant="embedded" />
       </header>
-      <EnvironmentPanel zone={zone} setpoints={setpoints} bridge={bridge} />
       <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
         <section className="grid gap-6">
           <Card title="Environment" subtitle="Telemetry snapshot vs. historical trend">

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, render, screen } from '@testing-library/react';
+import { ZoneView } from '../ZoneView';
+import { quickstartSnapshot } from '@/data/mockTelemetry';
+import { useSimulationStore } from '@/store/simulation';
+import { useNavigationStore } from '@/store/navigation';
+import type { SimulationBridge } from '@/facade/systemFacade';
+import type { ReactNode } from 'react';
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  CartesianGrid: () => null,
+  Legend: () => null,
+}));
+
+const buildBridge = (overrides: Partial<SimulationBridge> = {}): SimulationBridge => ({
+  connect: () => undefined,
+  loadQuickStart: async () => ({ ok: true }),
+  getStructureBlueprints: async () => ({ ok: true, data: [] }),
+  getStrainBlueprints: async () => ({ ok: true, data: [] }),
+  getDeviceBlueprints: async () => ({ ok: true, data: [] }),
+  getDifficultyConfig: async () => ({ ok: true }),
+  sendControl: async () => ({ ok: true }),
+  sendConfigUpdate: async () => ({ ok: true }),
+  sendIntent: async () => ({ ok: true }),
+  subscribeToUpdates: () => () => undefined,
+  plants: { addPlanting: async () => ({ ok: true }) },
+  devices: {
+    installDevice: async () => ({ ok: true }),
+    adjustLightingCycle: async () => ({ ok: true }),
+  },
+  ...overrides,
+});
+
+describe('ZoneView', () => {
+  const zone = quickstartSnapshot.zones[0];
+  const structure = quickstartSnapshot.structures[0];
+  const room = quickstartSnapshot.rooms[0];
+
+  beforeAll(() => {
+    class MockResizeObserver {
+      constructor(_callback: ResizeObserverCallback) {
+        void _callback;
+      }
+      observe(_target: Element, _options?: ResizeObserverOptions) {
+        void _target;
+        void _options;
+      }
+      unobserve(_target: Element) {
+        void _target;
+      }
+      disconnect() {}
+    }
+
+    (globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  beforeEach(() => {
+    useSimulationStore.getState().reset();
+    useNavigationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useSimulationStore.getState().reset();
+    useNavigationStore.getState().reset();
+  });
+
+  it('renders environment controls inside the header card', () => {
+    const bridge = buildBridge();
+
+    act(() => {
+      useSimulationStore.getState().hydrate({ snapshot: quickstartSnapshot });
+      useNavigationStore.setState({
+        currentView: 'zone',
+        selectedStructureId: structure.id,
+        selectedRoomId: room.id,
+        selectedZoneId: zone.id,
+        isSidebarOpen: false,
+      });
+    });
+
+    render(<ZoneView bridge={bridge} />);
+
+    const panels = screen.getAllByTestId('environment-panel-root');
+    expect(panels).toHaveLength(1);
+
+    const header = panels[0]?.closest('header');
+    expect(header).not.toBeNull();
+    expect(header).toContainElement(panels[0]!);
+  });
+});


### PR DESCRIPTION
## Summary
- embed the EnvironmentPanel directly inside the zone header card and drop redundant KPI badges
- extend EnvironmentPanel with an embedded variant so it can share styling with surrounding cards
- cover the new layout with updated EnvironmentPanel expectations and a ZoneView regression test

## Testing
- pnpm run check *(fails: backend typecheck currently reports existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e7b28e2c83258d2436ef745e5a34