### PR TITLE
Fix canopy interception scaling

### DIFF
--- a/docs/system/simulation-engine.md
+++ b/docs/system/simulation-engine.md
@@ -95,6 +95,9 @@ Plants respond to environment and resources; **stress** reduces **health**; **he
    Additional penalties from **active diseases/pests** and **resource deficits**.
 5. **Potential growth**
    - **Light response** (rectangular hyperbola/saturation over PPFD), **temperature response** (Gaussian), **CO₂ factor** (half-saturation).
+   - **Canopy interception** applies the Beer–Lambert law using only the leaf-area index: `interception = 1 − exp(−k × LAI)`.
+     The interception fraction is dimensionless; total absorbed photons are computed as `incidentMol_m2 × canopyArea × interception`
+     and explicitly capped so they never exceed the photons delivered to that canopy area.
    - Apply phase caps and **LUE** to get `potentialGrowth_g_dry_per_tick`.
    - Apply health & stress: `actualGrowth = potentialGrowth * health * (1 − γ * stress)`.
    - Accrue `biomassDry_g`; enforce `maxBiomassDry_g` and phase harvest index.


### PR DESCRIPTION
## Summary
- update the canopy interception model to apply the Beer–Lambert exponent to LAI only and bound absorption by available photons
- apply canopy area when converting PPFD to absorbed photons so biomass gains reflect the corrected interception fraction
- add a regression test and documentation clarifying the revised canopy interception formula

## Testing
- pnpm run check *(fails: frontend eslint loader error prevents lint step)*
- pnpm --filter @weebbreed/backend test -- src/engine/plants/growthModel.test.ts *(fails: simulation loop golden baseline now differs after photon absorption change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ecc3ee948325b37902150d20788a