### PR TITLE
Refine device install modal inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded dashboard game-speed presets to `0.5×/1×/10×/25×/50×/100×/250×`, widened button styling to fit three-digit labels, and refreshed UI documentation to match the new list.
 - Debounced zone EnvironmentPanel setpoint sliders so local adjustments respond instantly while bridge updates batch after a short delay, flushing on blur/mouseup and cancelling on unmount alongside new regression coverage.
 - Removed the EnvironmentPanel VPD slider, keeping the badge summary while routing VPD adjustments through humidity controls only.
+- Reworked the Install Device modal to expose blueprint target defaults as structured inputs, validate overrides inline, and
+  submit only changed setpoints when installing devices.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- render structured target inputs in InstallDeviceModal derived from blueprint defaults and validate overrides before sending
- fall back to blueprint defaults when no targets are editable while surfacing inline feedback for invalid entries
- update modal tests to exercise the new install flow and assert that only modified targets are sent to the bridge

## Testing
- pnpm --filter @weebbreed/frontend test -- src/components/modals/__tests__/PlantAndDeviceModals.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8fd30598c8325981a03f2ee4b3a6e