### PR TITLE
Surface volume-based device coverage in Install Device modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the EnvironmentPanel VPD slider, keeping the badge summary while routing VPD adjustments through humidity controls only.
 - Reworked the Install Device modal to expose blueprint target defaults as structured inputs, validate overrides inline, and
   submit only changed setpoints when installing devices.
+- Surfaced blueprint coverage limits in the Install Device modal, presenting area and volume capacities (deriving floor
+  coverage from room height when only volume is supplied) and extending Vitest coverage for both metrics.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- add a resolveCoverageCapacity helper that understands area and volume limits
- update the Install Device modal to render area/volume copy, warn on undersized devices, and translate volume using room height
- refresh the device modal tests with volume fixtures and coverage expectations plus a CHANGELOG note

## Testing
- pnpm lint
- pnpm exec prettier --check CHANGELOG.md src/frontend/src/components/modals/ModalHost.tsx src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
- pnpm --filter @weebbreed/frontend exec vitest run src/components/modals/__tests__/PlantAndDeviceModals.test.tsx --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68d901d3eb9c8325aa952838573df3ab