### PR TITLE
feat(frontend): group zone devices by kind

### DIFF
--- a/src/frontend/src/components/zone/EnvironmentPanel.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.tsx
@@ -438,6 +438,15 @@ export const EnvironmentPanel = ({
   const effectivePpfdTarget = pendingPpfd ?? ppfdTarget;
   const isLightsOn = effectivePpfdTarget > 0;
   const photoperiodDarkHours = Math.round(Math.max(24 - photoperiodValue, MINIMUM_DARK_HOURS));
+  const photoperiodLightHoursLabel = formatNumber(photoperiodValue, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const photoperiodDarkHoursLabel = formatNumber(photoperiodDarkHours, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const photoperiodSummaryLabel = `${photoperiodLightHoursLabel} h light / ${photoperiodDarkHoursLabel} h dark`;
 
   const Container: 'section' | 'div' = variant === 'standalone' ? 'section' : 'div';
   const containerClasses = cx(
@@ -615,23 +624,12 @@ export const EnvironmentPanel = ({
                 />
                 <div className="flex flex-col items-end gap-1 text-right">
                   <span className="flex items-center gap-1 text-sm text-text-muted">
-                    <span className="font-semibold text-text">
-                      {formatNumber(photoperiodValue, {
-                        minimumFractionDigits: 0,
-                        maximumFractionDigits: 0,
-                      })}
-                      h
-                    </span>
-                    <span className="text-xs uppercase tracking-wide text-text-muted">light</span>
-                    <span className="text-text-muted">/</span>
-                    <span className="font-semibold text-text">
-                      {formatNumber(photoperiodDarkHours, {
-                        minimumFractionDigits: 0,
-                        maximumFractionDigits: 0,
-                      })}
-                      h
-                    </span>
+                    <span className="font-semibold text-text">{photoperiodLightHoursLabel} h</span>{' '}
+                    <span className="text-xs uppercase tracking-wide text-text-muted">light</span>{' '}
+                    <span className="text-text-muted">/</span>{' '}
+                    <span className="font-semibold text-text">{photoperiodDarkHoursLabel} h</span>{' '}
                     <span className="text-xs uppercase tracking-wide text-text-muted">dark</span>
+                    <span className="sr-only">{photoperiodSummaryLabel}</span>
                   </span>
                   <span className="text-xs text-text-muted">
                     Dark period adjusts automatically to maintain a 24h day.


### PR DESCRIPTION
## Summary
- group zone devices by configured device groups or kind with aggregated metrics and per-device controls
- expose a consistent photoperiod summary label in the environment panel for accessibility and tests
- update ZoneView tests to cover the grouped layout and guard against group-level actions

## Testing
- pnpm --filter @weebbreed/frontend test --run

------
https://chatgpt.com/codex/tasks/task_e_68d91233c138832582dee69a26fcf160