### PR TITLE
feat: surface environment badges in zone header

### DIFF
--- a/src/frontend/src/components/zone/EnvironmentBadgeRow.tsx
+++ b/src/frontend/src/components/zone/EnvironmentBadgeRow.tsx
@@ -1,0 +1,45 @@
+import cx from 'clsx';
+import { Icon } from '@/components/common/Icon';
+import { Badge } from '@/components/primitives/Badge';
+import type { BadgeTone, EnvironmentBadgeDescriptor } from './environmentBadges';
+
+const KpiBadge = ({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+  tone: BadgeTone;
+}) => (
+  <Badge
+    tone={tone === 'default' ? 'default' : tone}
+    className="flex items-center gap-1 px-3 py-1 text-[11px]"
+  >
+    <Icon name={icon} size={16} className="text-xs text-inherit" />
+    <span>{label}</span>
+    <span className="normal-case font-semibold tracking-tight text-text">{value}</span>
+  </Badge>
+);
+
+export const EnvironmentBadgeRow = ({
+  badges,
+  className,
+}: {
+  badges: EnvironmentBadgeDescriptor[];
+  className?: string;
+}) => (
+  <div className={cx('flex flex-wrap gap-2', className)}>
+    {badges.map((badge) => (
+      <KpiBadge
+        key={badge.key}
+        icon={badge.icon}
+        label={badge.label}
+        value={badge.value}
+        tone={badge.tone}
+      />
+    ))}
+  </div>
+);

--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -57,6 +57,29 @@ describe('EnvironmentPanel', () => {
     expect(within(header).getByText('VPD')).toBeInTheDocument();
   });
 
+  it('supports custom badge rendering', () => {
+    const zone = baseZone();
+    const bridge = buildBridge();
+
+    render(
+      <EnvironmentPanel
+        zone={zone}
+        setpoints={zone.control?.setpoints}
+        bridge={bridge}
+        defaultExpanded
+        renderBadges={(badges) => (
+          <div data-testid="custom-badge-row">{badges.map((badge) => badge.label).join(',')}</div>
+        )}
+      />,
+    );
+
+    const panel = within(screen.getAllByTestId('environment-panel-root').at(-1)!);
+    const header = panel.getByTestId('environment-panel-toggle');
+    expect(within(header).getByTestId('custom-badge-row')).toHaveTextContent(
+      'Temp,Humidity,VPD,CO₂,PPFD,Cycle',
+    );
+  });
+
   it('dispatches temperature updates through the simulation bridge', async () => {
     const zone = baseZone();
     const sendConfigUpdate = vi.fn(async () => ({ ok: true }));

--- a/src/frontend/src/components/zone/environmentBadges.ts
+++ b/src/frontend/src/components/zone/environmentBadges.ts
@@ -1,0 +1,119 @@
+import { formatNumber } from '@/utils/formatNumber';
+import type { ZoneSnapshot, ZoneControlSetpoints } from '@/types/simulation';
+
+export type BadgeTone = 'default' | 'success' | 'warning' | 'danger';
+
+const determineTone = (
+  current: number,
+  target?: number,
+  thresholds?: { success: number; warning: number },
+): BadgeTone => {
+  if (typeof target !== 'number') {
+    return 'default';
+  }
+  const delta = Math.abs(current - target);
+  if (!thresholds) {
+    return delta < Number.EPSILON ? 'success' : 'default';
+  }
+  if (delta <= thresholds.success) {
+    return 'success';
+  }
+  if (delta <= thresholds.warning) {
+    return 'warning';
+  }
+  return 'danger';
+};
+
+export type EnvironmentBadgeDescriptor = {
+  key: string;
+  icon: string;
+  label: string;
+  value: string;
+  tone: BadgeTone;
+};
+
+export const buildEnvironmentBadgeDescriptors = (
+  zone: ZoneSnapshot,
+  setpoints?: ZoneControlSetpoints,
+): EnvironmentBadgeDescriptor[] => [
+  {
+    key: 'temp',
+    icon: 'thermostat',
+    label: 'Temp',
+    value: `${formatNumber(zone.environment.temperature, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })}°C`,
+    tone: determineTone(zone.environment.temperature, setpoints?.temperature, {
+      success: 1,
+      warning: 3,
+    }),
+  },
+  {
+    key: 'humidity',
+    icon: 'water_drop',
+    label: 'Humidity',
+    value: `${formatNumber(zone.environment.relativeHumidity * 100, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })}%`,
+    tone: determineTone(
+      zone.environment.relativeHumidity * 100,
+      setpoints?.humidity ? setpoints.humidity * 100 : undefined,
+      {
+        success: 5,
+        warning: 10,
+      },
+    ),
+  },
+  {
+    key: 'vpd',
+    icon: 'science',
+    label: 'VPD',
+    value: `${formatNumber(zone.environment.vpd, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })} kPa`,
+    tone: determineTone(zone.environment.vpd, setpoints?.vpd, {
+      success: 0.15,
+      warning: 0.35,
+    }),
+  },
+  {
+    key: 'co2',
+    icon: 'co2',
+    label: 'CO₂',
+    value: `${formatNumber(zone.environment.co2, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })} ppm`,
+    tone: determineTone(zone.environment.co2, setpoints?.co2, {
+      success: 100,
+      warning: 250,
+    }),
+  },
+  {
+    key: 'ppfd',
+    icon: 'sunny',
+    label: 'PPFD',
+    value: `${formatNumber(zone.environment.ppfd, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })} µmol`,
+    tone: determineTone(zone.environment.ppfd, setpoints?.ppfd, {
+      success: 50,
+      warning: 150,
+    }),
+  },
+  {
+    key: 'cycle',
+    icon: 'schedule',
+    label: 'Cycle',
+    value:
+      zone.lighting?.photoperiodHours?.on !== undefined &&
+      zone.lighting?.photoperiodHours?.off !== undefined
+        ? `${zone.lighting.photoperiodHours.on}h/${zone.lighting.photoperiodHours.off}h`
+        : '—',
+    tone: 'default',
+  },
+];

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -28,6 +28,8 @@ import type { ZoneHistoryPoint } from '@/store/simulation';
 import { formatNumber } from '@/utils/formatNumber';
 import type { SimulationBridge } from '@/facade/systemFacade';
 import { EnvironmentPanel } from '@/components/zone/EnvironmentPanel';
+import { EnvironmentBadgeRow } from '@/components/zone/EnvironmentBadgeRow';
+import { buildEnvironmentBadgeDescriptors } from '@/components/zone/environmentBadges';
 
 const columnHelper = createColumnHelper<PlantSnapshot>();
 
@@ -70,6 +72,13 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
   const openModal = useUIStore((state) => state.openModal);
 
   const zone = snapshot?.zones.find((item) => item.id === selectedZoneId);
+  const setpoints = zone ? zoneSetpoints[zone.id] : undefined;
+  const environmentBadges = useMemo(() => {
+    if (!zone) {
+      return [];
+    }
+    return buildEnvironmentBadgeDescriptors(zone, setpoints);
+  }, [zone, setpoints]);
 
   const table = useReactTable({
     data: zone?.plants ?? [],
@@ -275,8 +284,6 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
     return null;
   }
 
-  const setpoints = zoneSetpoints[zone.id];
-
   const chartData = aggregateHistory.length
     ? aggregateHistory
     : [
@@ -295,15 +302,24 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
   return (
     <div className="grid gap-6">
       <header className="flex flex-col gap-6 rounded-3xl border border-border/40 bg-surface-elevated/80 p-6">
-        <div className="flex flex-col gap-2">
-          <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
-          <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
-          <p className="text-sm text-text-muted">
-            {formatNumber(zone.area)} m² · volume {formatNumber(zone.volume)} m³ · cultivation
-            method {zone.cultivationMethodId ?? '—'}
-          </p>
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="flex flex-col gap-2">
+            <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
+            <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
+            <p className="text-sm text-text-muted">
+              {formatNumber(zone.area)} m² · volume {formatNumber(zone.volume)} m³ · cultivation
+              method {zone.cultivationMethodId ?? '—'}
+            </p>
+          </div>
+          <EnvironmentBadgeRow badges={environmentBadges} className="md:justify-end" />
         </div>
-        <EnvironmentPanel zone={zone} setpoints={setpoints} bridge={bridge} variant="embedded" />
+        <EnvironmentPanel
+          zone={zone}
+          setpoints={setpoints}
+          bridge={bridge}
+          variant="embedded"
+          renderBadges={() => null}
+        />
       </header>
       <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
         <section className="grid gap-6">

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -99,6 +99,11 @@ describe('ZoneView', () => {
     const header = panels[0]?.closest('header');
     expect(header).not.toBeNull();
     expect(header).toContainElement(panels[0]!);
+
+    const headerElement = header as HTMLElement;
+    const toggle = within(panels[0]!).getByTestId('environment-panel-toggle');
+    expect(within(toggle).queryByText('Temp')).not.toBeInTheDocument();
+    expect(within(headerElement).getByText('Temp')).toBeInTheDocument();
   });
 
   it('opens the move device modal with zone context', async () => {


### PR DESCRIPTION
## Summary
- add shared helpers and presentation for environment KPI badges
- allow EnvironmentPanel consumers to override badge rendering while keeping standalone defaults
- render zone KPI badges beside the ZoneView title block and update related tests

## Testing
- CI=1 pnpm run check *(fails: backend simulation golden test mismatch unrelated to frontend changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d916865e6483259e9dfc8196f4910a