### PR TITLE
Rework zone header layout with resource summary

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -301,8 +301,11 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
 
   return (
     <div className="grid gap-6">
-      <header className="flex flex-col gap-6 rounded-3xl border border-border/40 bg-surface-elevated/80 p-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+      <header
+        className="grid gap-6 rounded-3xl border border-border/40 bg-surface-elevated/80 p-6"
+        data-testid="zone-view-header"
+      >
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
           <div className="flex flex-col gap-2">
             <span className="text-xs uppercase tracking-wide text-text-muted">Zone</span>
             <h2 className="text-2xl font-semibold text-text">{zone.name}</h2>
@@ -313,13 +316,71 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
           </div>
           <EnvironmentBadgeRow badges={environmentBadges} className="md:justify-end" />
         </div>
-        <EnvironmentPanel
-          zone={zone}
-          setpoints={setpoints}
-          bridge={bridge}
-          variant="embedded"
-          renderBadges={() => null}
-        />
+        <div
+          className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)] md:items-start"
+          data-testid="zone-header-grid-row"
+        >
+          <section
+            className="flex flex-col gap-4 rounded-2xl border border-border/40 bg-surface-muted/30 p-5"
+            aria-labelledby="zone-resources-heading"
+            data-testid="zone-resources-summary"
+          >
+            <div className="flex flex-col gap-1">
+              <h3
+                id="zone-resources-heading"
+                className="text-sm font-semibold tracking-tight text-text"
+              >
+                Resources
+              </h3>
+              <span className="text-xs text-text-muted">Reservoirs &amp; supplies</span>
+            </div>
+            <dl className="grid gap-3 text-sm text-text-muted">
+              <div className="flex items-center justify-between">
+                <dt>Water reserve</dt>
+                <dd>
+                  <Badge tone="default">{formatNumber(zone.resources.waterLiters)} L</Badge>
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Nutrient solution</dt>
+                <dd>
+                  <Badge tone="default">
+                    {formatNumber(zone.resources.nutrientSolutionLiters)} L
+                  </Badge>
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Nutrient strength</dt>
+                <dd>
+                  <Badge tone="default">
+                    {formatNumber(zone.resources.nutrientStrength, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}{' '}
+                    EC
+                  </Badge>
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Daily consumption</dt>
+                <dd>
+                  <Badge tone="default">
+                    {formatNumber(zone.supplyStatus?.dailyWaterConsumptionLiters ?? 0)} L /{' '}
+                    {formatNumber(zone.supplyStatus?.dailyNutrientConsumptionLiters ?? 0)} L
+                  </Badge>
+                </dd>
+              </div>
+            </dl>
+          </section>
+          <EnvironmentPanel
+            zone={zone}
+            setpoints={setpoints}
+            bridge={bridge}
+            variant="embedded"
+            renderBadges={() => null}
+            className="md:justify-self-end"
+          />
+        </div>
       </header>
       <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
         <section className="grid gap-6">
@@ -548,37 +609,6 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
           </Card>
         </section>
         <section className="grid gap-6">
-          <Card title="Resources" subtitle="Reservoirs & supplies">
-            <div className="grid gap-3 text-sm text-text-muted">
-              <div className="flex items-center justify-between">
-                <span>Water reserve</span>
-                <Badge tone="default">{formatNumber(zone.resources.waterLiters)} L</Badge>
-              </div>
-              <div className="flex items-center justify-between">
-                <span>Nutrient solution</span>
-                <Badge tone="default">
-                  {formatNumber(zone.resources.nutrientSolutionLiters)} L
-                </Badge>
-              </div>
-              <div className="flex items-center justify-between">
-                <span>Nutrient strength</span>
-                <Badge tone="default">
-                  {formatNumber(zone.resources.nutrientStrength, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}{' '}
-                  EC
-                </Badge>
-              </div>
-              <div className="flex items-center justify-between">
-                <span>Daily consumption</span>
-                <Badge tone="default">
-                  {formatNumber(zone.supplyStatus?.dailyWaterConsumptionLiters ?? 0)} L /{' '}
-                  {formatNumber(zone.supplyStatus?.dailyNutrientConsumptionLiters ?? 0)} L
-                </Badge>
-              </div>
-            </div>
-          </Card>
           <Card
             title="Plants"
             subtitle="Batch overview"

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -106,6 +106,37 @@ describe('ZoneView', () => {
     expect(within(headerElement).getByText('Temp')).toBeInTheDocument();
   });
 
+  it('positions the resources summary next to environment controls in the header', async () => {
+    const bridge = buildBridge();
+
+    act(() => {
+      useSimulationStore.getState().hydrate({ snapshot: quickstartSnapshot });
+      useNavigationStore.setState({
+        currentView: 'zone',
+        selectedStructureId: structure.id,
+        selectedRoomId: room.id,
+        selectedZoneId: zone.id,
+        isSidebarOpen: false,
+      });
+    });
+
+    render(<ZoneView bridge={bridge} />);
+
+    const headers = await screen.findAllByTestId('zone-view-header');
+    const header = headers.at(-1)!;
+
+    const gridRow = within(header).getByTestId('zone-header-grid-row');
+    const resourcesSummary = within(gridRow).getByTestId('zone-resources-summary');
+    const environmentControls = within(gridRow).getByTestId('environment-panel-root');
+
+    const rowChildren = Array.from(gridRow.children);
+    expect(rowChildren[0]).toBe(resourcesSummary);
+    expect(rowChildren[1]).toBe(environmentControls);
+
+    const resourceSubtitles = within(header).getAllByText('Reservoirs & supplies');
+    expect(resourceSubtitles.length).toBeGreaterThan(0);
+  });
+
   it('opens the move device modal with zone context', async () => {
     const originalOpenModal = useUIStore.getState().openModal;
     const openModal = vi.fn();


### PR DESCRIPTION
## Summary
- redesign the zone header into a two-row grid with inline resource summary and environment controls
- remove the standalone resources card from the lower content area
- extend ZoneView tests to cover the new header layout and resource placement

## Testing
- pnpm run check *(fails: backend loop.golden baseline mismatch unrelated to UI changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d919cf77d08325a60edbe40aa0c508