### PR TITLE
Embed zone health summary in plants card

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -501,6 +501,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                 Plant zone
               </Button>
             }
+            data-testid="zone-plants-card"
           >
             <div
               ref={tableContainerRef}
@@ -566,6 +567,43 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                 No plants assigned to this zone yet. Use "Plant zone" to schedule a new batch.
               </p>
             ) : null}
+            <div
+              className="mt-4 grid gap-3 rounded-2xl border border-border/30 bg-surface-muted/40 p-4"
+              data-testid="zone-health-summary"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col">
+                  <span className="text-xs uppercase tracking-wide text-text-muted">Health</span>
+                  <span className="text-sm font-semibold text-text">
+                    Disease &amp; treatment overview
+                  </span>
+                </div>
+              </div>
+              <div className="grid gap-2 text-sm text-text-muted">
+                <div className="flex items-center justify-between">
+                  <span>Diseases</span>
+                  <Badge tone={zone.health.diseases ? 'warning' : 'success'}>
+                    {zone.health.diseases}
+                  </Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Pests</span>
+                  <Badge tone={zone.health.pests ? 'warning' : 'success'}>
+                    {zone.health.pests}
+                  </Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Pending treatments</span>
+                  <Badge tone={zone.health.pendingTreatments ? 'warning' : 'default'}>
+                    {zone.health.pendingTreatments}
+                  </Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Applied treatments</span>
+                  <Badge tone="default">{zone.health.appliedTreatments}</Badge>
+                </div>
+              </div>
+            </div>
           </Card>
           <Card
             title="Devices"
@@ -697,30 +735,6 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
             </div>
           </Card>
         </div>
-        <Card title="Health" subtitle="Disease & treatment overview">
-          <div className="grid gap-2 text-sm text-text-muted">
-            <div className="flex items-center justify-between">
-              <span>Diseases</span>
-              <Badge tone={zone.health.diseases ? 'warning' : 'success'}>
-                {zone.health.diseases}
-              </Badge>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>Pests</span>
-              <Badge tone={zone.health.pests ? 'warning' : 'success'}>{zone.health.pests}</Badge>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>Pending treatments</span>
-              <Badge tone={zone.health.pendingTreatments ? 'warning' : 'default'}>
-                {zone.health.pendingTreatments}
-              </Badge>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>Applied treatments</span>
-              <Badge tone="default">{zone.health.appliedTreatments}</Badge>
-            </div>
-          </div>
-        </Card>
       </section>
     </div>
   );

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -170,6 +170,53 @@ describe('ZoneView', () => {
     expect(within(devicesCard).getByRole('heading', { name: 'Devices' })).toBeInTheDocument();
   });
 
+  it('renders health summary within the plants card and removes the standalone health card', async () => {
+    const bridge = buildBridge();
+
+    act(() => {
+      useSimulationStore.getState().hydrate({ snapshot: quickstartSnapshot });
+      useNavigationStore.setState({
+        currentView: 'zone',
+        selectedStructureId: structure.id,
+        selectedRoomId: room.id,
+        selectedZoneId: zone.id,
+        isSidebarOpen: false,
+      });
+    });
+
+    render(<ZoneView bridge={bridge} />);
+
+    const summaryHeading = await screen.findByText('Disease & treatment overview');
+    const healthSummary = summaryHeading.closest('div[data-testid="zone-health-summary"]');
+    expect(healthSummary).not.toBeNull();
+
+    const plantsCard = summaryHeading.closest('[data-testid="zone-plants-card"]');
+    expect(plantsCard).not.toBeNull();
+    expect(
+      within(plantsCard as HTMLElement).getByRole('heading', { name: 'Plants' }),
+    ).toBeInTheDocument();
+
+    const labels = ['Diseases', 'Pests', 'Pending treatments', 'Applied treatments'];
+    for (const label of labels) {
+      expect(within(healthSummary as HTMLElement).getByText(label)).toBeInTheDocument();
+    }
+
+    expect(
+      within(healthSummary as HTMLElement).getByText(String(zone.health.diseases)),
+    ).toBeInTheDocument();
+    expect(
+      within(healthSummary as HTMLElement).getByText(String(zone.health.pests)),
+    ).toBeInTheDocument();
+    expect(
+      within(healthSummary as HTMLElement).getByText(String(zone.health.pendingTreatments)),
+    ).toBeInTheDocument();
+    expect(
+      within(healthSummary as HTMLElement).getByText(String(zone.health.appliedTreatments)),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByRole('heading', { name: 'Health' })).not.toBeInTheDocument();
+  });
+
   it('opens the move device modal with zone context', async () => {
     const originalOpenModal = useUIStore.getState().openModal;
     const openModal = vi.fn();


### PR DESCRIPTION
## Summary
- move the zone health metrics into the Plants card and add a contextual header for the merged panel
- remove the redundant standalone Health card while keeping the merged layout readable
- update the ZoneView test suite to expect the health summary inside the Plants card and the old card to be absent

## Testing
- pnpm run check *(fails: frontend lint configuration cannot resolve @eslint/js in this environment)*
- pnpm --filter @weebbreed/frontend test -- src/views/__tests__/ZoneView.test.tsx *(fails: existing ModalHost test still rejects pause command during suite run)*

------
https://chatgpt.com/codex/tasks/task_e_68d92a1f39e88325874aa10813b69573