### PR TITLE
Adjust zone header grid layout

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -317,11 +317,11 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
           <EnvironmentBadgeRow badges={environmentBadges} className="md:justify-end" />
         </div>
         <div
-          className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)] md:items-start"
+          className="grid gap-4 md:grid-cols-2 md:items-start"
           data-testid="zone-header-grid-row"
         >
           <section
-            className="flex flex-col gap-4 rounded-2xl border border-border/40 bg-surface-muted/30 p-5"
+            className="flex flex-col gap-4 rounded-2xl border border-border/40 bg-surface-muted/30 p-5 md:h-full"
             aria-labelledby="zone-resources-heading"
             data-testid="zone-resources-summary"
           >
@@ -378,7 +378,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
             bridge={bridge}
             variant="embedded"
             renderBadges={() => null}
-            className="md:justify-self-end"
+            className="md:h-full"
           />
         </div>
       </header>

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -126,12 +126,15 @@ describe('ZoneView', () => {
     const header = headers.at(-1)!;
 
     const gridRow = within(header).getByTestId('zone-header-grid-row');
+    expect(gridRow).toHaveClass('md:grid-cols-2');
     const resourcesSummary = within(gridRow).getByTestId('zone-resources-summary');
     const environmentControls = within(gridRow).getByTestId('environment-panel-root');
 
     const rowChildren = Array.from(gridRow.children);
     expect(rowChildren[0]).toBe(resourcesSummary);
     expect(rowChildren[1]).toBe(environmentControls);
+    expect(resourcesSummary).toHaveClass('md:h-full');
+    expect(environmentControls).toHaveClass('md:h-full');
 
     const resourceSubtitles = within(header).getAllByText('Reservoirs & supplies');
     expect(resourceSubtitles.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- update the ZoneView header grid to use two equal columns and let both panels fill their respective columns
- extend the ZoneView layout test to assert the updated grid and height helper classes

## Testing
- pnpm run check *(fails: @eslint/js cannot be resolved in the current environment)*
- pnpm --filter @weebbreed/frontend test -- --runTestsByPath src/views/__tests__/ZoneView.test.tsx *(fails: unrelated vitest cases for EnvironmentPanel expect specific warning text)*

------
https://chatgpt.com/codex/tasks/task_e_68d92f894c108325a4911faeb897403b