### PR TITLE
Ensure embedded environment panels expand by default

### DIFF
--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -354,7 +354,7 @@ describe('EnvironmentPanel', () => {
     });
   });
 
-  it('renders the embedded variant without the standalone section wrapper', () => {
+  it('renders the embedded variant expanded by default without the standalone section wrapper', () => {
     const zone = baseZone();
     const bridge = buildBridge();
 
@@ -368,6 +368,11 @@ describe('EnvironmentPanel', () => {
     );
 
     const roots = screen.getAllByTestId('environment-panel-root');
-    expect(roots.at(-1)?.tagName).toBe('DIV');
+    const panelRoot = roots.at(-1)!;
+    expect(panelRoot.tagName).toBe('DIV');
+
+    const toggle = within(panelRoot).getByTestId('environment-panel-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(within(panelRoot).getAllByTestId('temperature-slider').at(-1)).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/zone/EnvironmentPanel.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.tsx
@@ -84,7 +84,7 @@ export const EnvironmentPanel = ({
   className,
   renderBadges,
 }: EnvironmentPanelProps) => {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [expanded, setExpanded] = useState(() => (variant === 'embedded' ? true : defaultExpanded));
   const [warnings, setWarnings] = useState<string[]>([]);
   const [pendingMetric, setPendingMetric] = useState<SetpointMetric | 'lightingCycle' | null>(null);
 
@@ -351,7 +351,7 @@ export const EnvironmentPanel = ({
     variant === 'standalone' ? 'rounded-3xl px-6 py-4' : 'rounded-2xl px-5 py-4',
   );
   const bodyClasses = cx(
-    'grid gap-6 border-t',
+    'grid gap-6 border-t pt-5',
     variant === 'standalone' ? 'border-border/50 px-6 pb-6' : 'border-border/40 px-5 pb-5',
   );
 

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -376,6 +376,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
             zone={zone}
             setpoints={setpoints}
             bridge={bridge}
+            defaultExpanded
             variant="embedded"
             renderBadges={() => null}
             className="md:h-full"


### PR DESCRIPTION
## Summary
- default embedded environment panels to an expanded state and add spacing above controls
- propagate the embedded default from ZoneView for clarity
- refresh the embedded variant test to assert the panel is open without an explicit prop

## Testing
- pnpm run check *(fails: @weebbreed/frontend lint: `eslint .` cannot resolve "@eslint/js/src/index.js")*

------
https://chatgpt.com/codex/tasks/task_e_68d9308c3c608325a989cf5f747011b3