### PR TITLE
Collapse ZoneView device groups by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Collapsed zone device groups by default behind accessible toggle buttons in
+  `ZoneView`, surfacing icons and coverage for the expanded state while
+  extending Vitest coverage for the new behaviour.
 - Expanded the EnvironmentPanel photoperiod slider to cover the full 1–23 hour
   light window with integer steps, refreshed the helper copy, and synced the
   backend lighting-cycle command so zone snapshots persist and broadcast the


### PR DESCRIPTION
## Summary
- collapse ZoneView device groups behind accessible toggle headers and keep per-group collapsed state keyed by zone device group ids
- expand ZoneView test coverage to account for collapsed headers, helper expansion, and the new toggle interaction
- document the UI change in the changelog

## Testing
- pnpm --filter @weebbreed/frontend exec vitest run src/views/__tests__/ZoneView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9324f33988325804d6fd06d8e42a2