### PR TITLE
Remove environment telemetry card from ZoneView

### DIFF
--- a/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ModalHost } from '../ModalHost';
 import { useSimulationStore } from '@/store/simulation';
 import { useUIStore } from '@/store/ui';
@@ -9,19 +8,6 @@ import { useNavigationStore } from '@/store/navigation';
 import { ZoneView } from '@/views/ZoneView';
 import type { SimulationBridge } from '@/facade/systemFacade';
 import type { SimulationSnapshot } from '@/types/simulation';
-
-vi.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
-    <div data-testid="responsive-container">{children}</div>
-  ),
-  LineChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  Line: () => null,
-  XAxis: () => null,
-  YAxis: () => null,
-  Tooltip: () => null,
-  CartesianGrid: () => null,
-  Legend: () => null,
-}));
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: () => ({
@@ -207,6 +193,18 @@ const baseSnapshot: SimulationSnapshot = {
     lastTickRevenue: 0,
     lastTickExpenses: 0,
   },
+};
+
+const expandAllDeviceGroups = async () => {
+  const groups = await screen.findAllByTestId('zone-device-group');
+  for (const group of groups) {
+    const toggle = within(group).getByTestId('device-group-header');
+    if (toggle.getAttribute('aria-expanded') !== 'true') {
+      await act(async () => {
+        toggle.click();
+      });
+    }
+  }
 };
 
 describe('Plant and Device modals', () => {
@@ -509,6 +507,7 @@ describe('Plant and Device modals', () => {
       </>,
     );
 
+    await expandAllDeviceGroups();
     await screen.findByText('LED VegLight 600');
 
     act(() => {
@@ -551,6 +550,7 @@ describe('Plant and Device modals', () => {
       </>,
     );
 
+    await expandAllDeviceGroups();
     await screen.findByText('LED VegLight 600');
 
     act(() => {
@@ -594,6 +594,7 @@ describe('Plant and Device modals', () => {
       </>,
     );
 
+    await expandAllDeviceGroups();
     const [moveButton] = await screen.findAllByRole('button', { name: /Move$/ });
     fireEvent.click(moveButton);
 
@@ -622,6 +623,7 @@ describe('Plant and Device modals', () => {
       </>,
     );
 
+    await expandAllDeviceGroups();
     const [deleteButton] = await screen.findAllByRole('button', { name: /Delete$/ });
     fireEvent.click(deleteButton);
 

--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -308,9 +308,7 @@ describe('EnvironmentPanel', () => {
     );
 
     expect(panel.getByText('16 h light / 8 h dark')).toBeInTheDocument();
-    expect(
-      panel.getByText(/dark period adjusts automatically to maintain a 24h day/i),
-    ).toBeInTheDocument();
+    expect(panel.getByText('Cycle clamped to device coverage.')).toBeInTheDocument();
     const updatedSlider = panel.getByTestId('lighting-cycle-slider') as HTMLInputElement;
     expect(updatedSlider.value).toBe('16');
   });

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -7,20 +7,6 @@ import { useSimulationStore } from '@/store/simulation';
 import { useNavigationStore } from '@/store/navigation';
 import { useUIStore } from '@/store/ui';
 import type { SimulationBridge } from '@/facade/systemFacade';
-import type { ReactNode } from 'react';
-
-vi.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
-    <div data-testid="responsive-container">{children}</div>
-  ),
-  LineChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  Line: () => null,
-  XAxis: () => null,
-  YAxis: () => null,
-  Tooltip: () => null,
-  CartesianGrid: () => null,
-  Legend: () => null,
-}));
 
 const buildBridge = (overrides: Partial<SimulationBridge> = {}): SimulationBridge => ({
   connect: () => undefined,


### PR DESCRIPTION
## Summary
- remove the historical environment telemetry card and Recharts dependency from the zone view
- prune unused history aggregation logic and adjust environment panel expectations
- update zone view and modal interaction tests to expand device groups explicitly now that the chart is gone

## Testing
- pnpm --filter @weebbreed/frontend test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d934bde49083259a4d0513b6c7ead0