### PR TITLE
feat: surface estimated yield in zone plant table

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -39,10 +39,10 @@ const plantColumns = [
     header: 'Stress',
     cell: (info) => `${formatNumber(info.getValue() * 100, { maximumFractionDigits: 0 })}%`,
   }),
-  columnHelper.accessor('biomassDryGrams', {
-    header: 'Biomass (g)',
+  columnHelper.accessor('yieldDryGrams', {
+    header: () => <span title="Estimated dry harvest yield in grams">Est. yield</span>,
     cell: (info) =>
-      formatNumber(info.getValue(), { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+      `${formatNumber(info.getValue(), { minimumFractionDigits: 1, maximumFractionDigits: 1 })} g`,
   }),
 ];
 


### PR DESCRIPTION
## Summary
- show the estimated dry harvest yield metric in the zone plant table with an inline tooltip
- format yield values with gram units to reflect the new accessor

## Testing
- pnpm --filter @weebbreed/frontend test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d94eae36bc8325bd5cb098240cd78c