### PR TITLE
feat(zone-view): add sortable plant table columns

### DIFF
--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -200,6 +200,43 @@ describe('ZoneView', () => {
     expect(within(plantsCard).queryByText('plant-01')).not.toBeInTheDocument();
   });
 
+  it('sorts plant rows by health when toggling the column header', async () => {
+    const bridge = buildBridge();
+
+    act(() => {
+      useSimulationStore.getState().hydrate({ snapshot: quickstartSnapshot });
+      useNavigationStore.setState({
+        currentView: 'zone',
+        selectedStructureId: structure.id,
+        selectedRoomId: room.id,
+        selectedZoneId: zone.id,
+        isSidebarOpen: false,
+      });
+    });
+
+    render(<ZoneView bridge={bridge} />);
+
+    const plantsCard = await screen.findByTestId('zone-plants-card');
+    const getFirstPlantId = () =>
+      plantsCard.querySelector('tbody tr')?.getAttribute('data-plant-id');
+
+    expect(getFirstPlantId()).toBe('plant-01');
+
+    const sortButton = within(plantsCard).getByTestId('plant-table-sort-health');
+
+    act(() => {
+      fireEvent.click(sortButton);
+    });
+
+    expect(getFirstPlantId()).toBe('plant-03');
+
+    act(() => {
+      fireEvent.click(sortButton);
+    });
+
+    expect(getFirstPlantId()).toBe('plant-01');
+  });
+
   it('displays plant health status icons only for affected plants', async () => {
     const bridge = buildBridge();
 


### PR DESCRIPTION
## Summary
- wire the ZoneView plant table into TanStack sorting with sorting state, `getSortedRowModel`, and sortable column headers that render design-system sort indicators
- mark the relevant plant columns as sortable with accessible labels and expose row `data-plant-id` attributes for deterministic inspection
- add a ZoneView test that verifies the health column header toggles row order between ascending and descending

## Testing
- not run (vitest run) *(blocked: suite consistently exceeds acceptable runtime in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d972a9d9e083258d3dcf11e6741d8a