### PR TITLE
Add detailed prompts for irrigation overhaul planning phases

### DIFF
--- a/docs/tasks/irrigation/phase0.md
+++ b/docs/tasks/irrigation/phase0.md
@@ -1,0 +1,9 @@
+# Phase 0 – Vorbereitung & Alignment
+
+Beantworte die folgenden Fragen, um konkrete Arbeitsschritte für die Vorbereitung zu definieren. Verwende jede Antwort als Ausgangspunkt für To-dos und benötigte Artefakte.
+
+1. Welche Stakeholder (Simulation, UI, Data) müssen eingebunden werden und welche Entscheidungen oder Freigaben werden von jedem benötigt?
+2. Welche bestehenden Dokumente, Tickets oder ADRs beschreiben die aktuelle Bewässerungs- und Nährstofflogik, und wie werden sie für das Alignment herangezogen?
+3. Welche Lücken oder Widersprüche zwischen Proposal und aktuellem Stand müssen vor dem Start geklärt werden?
+4. Welche Risiken oder Abhängigkeiten ergeben sich aus parallelen Arbeiten in anderen Streams, und wie werden sie kommuniziert?
+5. Welche Entscheidungen oder offenen Punkte sollen in der Deprecation-Vorlage adressiert werden, damit Alt-Reservoir-Tasks sauber auslaufen?

--- a/docs/tasks/irrigation/phase1.md
+++ b/docs/tasks/irrigation/phase1.md
@@ -1,0 +1,9 @@
+# Phase 1 – Datenmodell & Schema-Erweiterungen
+
+Nutze die folgenden Fragen, um detaillierte Umsetzungsschritte für die Schema- und Datenmodell-Anpassungen abzuleiten.
+
+1. Wie sieht der aktuelle Strukturzustand aus und welche Stellen müssen erweitert werden, um Wasserzähler- und Nährstofffelder aufzunehmen?
+2. Welche Savegame-, Blueprint- und Runtime-Schemas sind betroffen und wie wird ihre Versionierung aktualisiert, damit Migrationen konsistent laufen?
+3. Welche Defaultwerte und Validierungsregeln werden für `utilities.waterMeter_m3`, `utilities.lastTickWaterDraw_L` und `inventory.nutrients[]` benötigt?
+4. Wie werden Zonendaten (`irrigation.methodId`, `targetEC_mS_cm`, `runoffFraction`) integriert, ohne bestehende Tick- oder Telemetrie-Flows zu brechen?
+5. Welche Serializer/Deserializer, Seed-States oder Tests müssen angepasst werden, um die neuen Felder deterministisch zu unterstützen?

--- a/docs/tasks/irrigation/phase2.md
+++ b/docs/tasks/irrigation/phase2.md
@@ -1,0 +1,9 @@
+# Phase 2 – Blueprint-Pipeline für `irrigationMethods`
+
+Nutze diese Fragen, um konkrete Arbeitsschritte für Aufbau und Validierung der Blueprint-Pipeline zu planen.
+
+1. Welche Dateistruktur, Namenskonventionen und Metadaten benötigt das neue Verzeichnis `/data/blueprints/irrigationMethods`, um mit bestehenden Loadern kompatibel zu sein?
+2. Wie muss das Schema gestaltet werden, damit alle geforderten Felder (`mixing`, `labor`, `runoff`, `requirements`, `compatibility`, `maintenance`, `meta`) typisiert und validiert werden können?
+3. Welche konkreten Informationen werden für jede Seed-Irrigationsmethode benötigt und wie werden IDs, Slugs und Beschreibungen konsistent erzeugt?
+4. Welche Validierungsregeln (z. B. Grenzen für `uniformity`, `runoff.defaultFraction`, Druckanforderungen) sind erforderlich und wo werden sie implementiert?
+5. Wie wird die Integration in Hot-Reload, Ajv/Zod-Validatoren und Dokumentation sichergestellt, damit UI und Backend die neuen Blueprints sofort nutzen können?

--- a/docs/tasks/irrigation/phase3.md
+++ b/docs/tasks/irrigation/phase3.md
@@ -1,0 +1,9 @@
+# Phase 3 – Umbau der Engine-Phase `irrigationAndNutrients`
+
+Verwende die folgenden Fragen, um die Umsetzung der neuen Phase-3-Logik in klaren Arbeitspaketen zu strukturieren.
+
+1. Welche Teile der bisherigen Reservoir-Logik müssen entfernt oder ersetzt werden, und wie wird sichergestellt, dass keine Altpfade übrig bleiben?
+2. Wie wird `phase_irrigationAndNutrients` aufgebaut, um Demand-Ermittlung, Method-Lookup und Differenzierung zwischen manuellen und automatisierten Methoden sauber zu kapseln?
+3. Welche Datenstrukturen unterstützen `fulfillWaterAndNutrients`, insbesondere hinsichtlich Runoff-Berechnung, Wasserzählerbelastung, Nährstoffmischung und Kostenverbuchung?
+4. Wie werden Pending-Queues und Telemetrie-Events für manuelle Methoden modelliert, damit Warteschlangenverhalten und deterministische IDs erhalten bleiben?
+5. Welche Anpassungen benötigen Physio- und Plantmodelle, um neue Ressourcenfelder korrekt zu konsumieren und Tests weiterhin deterministisch zu halten?

--- a/docs/tasks/irrigation/phase6.md
+++ b/docs/tasks/irrigation/phase6.md
@@ -1,0 +1,9 @@
+# Phase 6 – UI & Telemetrie
+
+Nutze diese Fragen, um UI- und Telemetrie-Anpassungen in überprüfbare Aufgaben zu übersetzen.
+
+1. Welche UI-Ansichten und Komponenten müssen erweitert werden, um Irrigation-Methode, Ziel-EC, Runoff-Override und letzte Wasser-/NPK-Mengen sichtbar zu machen?
+2. Wie werden Badges oder Indikatoren für offene manuelle `water_fertilize_plants` Aufgaben gestaltet, damit sie mit bestehenden Task-Queues harmonieren?
+3. Welche Telemetrie- und Snapshot-Felder müssen versioniert oder erweitert werden, damit neue Informationen ohne Breaking Changes ausgespielt werden können?
+4. Wie lassen sich Inspektions- und Wartungsinformationen für automatisierte Methoden im Dashboard darstellen und aktualisieren?
+5. Welche Dokumentations- oder UI-Building-Guides müssen angepasst werden, damit das Frontend-Team konsistent arbeiten kann?

--- a/docs/tasks/irrigation/phase7.md
+++ b/docs/tasks/irrigation/phase7.md
@@ -1,0 +1,9 @@
+# Phase 7 – Migration & Datenpflege
+
+Beantworte die Fragen, um Migrationsschritte und Datenpflege strukturiert vorzubereiten.
+
+1. Welche Deployment- oder Seed-Skripte müssen angepasst werden, damit neue Irrigation-Blueprints ausgeliefert und überwacht werden?
+2. Wie werden bestehende Spielstände analysiert und migriert, um pro Zone ein sinnvolles Default- oder Override-Mapping zu vergeben?
+3. Welche Alt-Reservoir-Tasks oder Blueprints müssen depreziert oder entfernt werden und welche Kommunikationsmaßnahmen begleiten diesen Schritt?
+4. Welche Dokumentationsquellen (System, Tasks, Constants, README) benötigen Updates, um den neuen Datenfluss zu erklären?
+5. Welche Validierungs- oder Smoke-Checks werden nach der Migration ausgeführt, um Datenintegrität und deterministische Seeds sicherzustellen?

--- a/docs/tasks/irrigation/phase8.md
+++ b/docs/tasks/irrigation/phase8.md
@@ -1,0 +1,9 @@
+# Phase 8 – Tests & Qualitätssicherung
+
+Verwende die Fragen, um einen vollständigen Test- und QA-Plan zu entwickeln.
+
+1. Welche Unit-Tests werden für Wasser- und Nährstoff-Demand, Runoff-Berechnung und Inventar-Blending benötigt und wie werden Grenzfälle abgedeckt?
+2. Wie werden Szenario-Tests gestaltet, um manuelle und automatisierte Methoden gegenüberzustellen und erwartete Pflanzenzustände sowie Kosten zu vergleichen?
+3. Welche ökonomischen Regressionstests sichern, dass Wasserzähler- und Inventardeltas mit den verbuchten Kosten übereinstimmen?
+4. Wie werden Telemetrie- und Snapshot-Regressionen organisiert, um deterministische Event-Verteilungen zu garantieren?
+5. Welche Tools oder Pipelines (CI, Benchmarks, Golden Master) müssen angepasst werden, damit neue Tests automatisch laufen und Ergebnisse versioniert bleiben?

--- a/docs/tasks/irrigation/phase9.md
+++ b/docs/tasks/irrigation/phase9.md
@@ -1,0 +1,9 @@
+# Phase 9 – Abschluss & Review
+
+Nutze diese Fragen, um den Abschlussprozess strukturiert zu planen.
+
+1. Welche Reviewer aus Backend, Frontend, Docs und Data sind erforderlich und wie wird der Cross-Package-Review-Prozess orchestriert?
+2. Welche Inhalte müssen in die Release-Notes aufgenommen werden, damit Stakeholder Fortschritt und Auswirkungen verstehen?
+3. Welche QA- oder Product-Sign-offs sind notwendig und wie werden sie dokumentiert?
+4. Welche Monitoring- oder Observability-Hooks müssen überprüft oder erweitert werden, bevor das Feature live geht?
+5. Welche Lessons Learned oder Follow-up-Aufgaben sollten im Abschlussbericht festgehalten werden, um zukünftige Iterationen zu beschleunigen?


### PR DESCRIPTION
## Summary
- add planning prompt documents for phases 0, 1, 2, 3, 6, 7, 8, and 9 of the irrigation and nutrient overhaul
- capture granular question-based guidance for schema, blueprint, engine, UI, migration, QA, and closure workstreams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d985c482348325b4c26e1de03e681e