### PR TITLE
docs: add codex prompts for irrigation overhaul

### DIFF
--- a/docs/tasks/irrigation/phase0.md
+++ b/docs/tasks/irrigation/phase0.md
@@ -1,9 +1,25 @@
-# Phase 0 – Vorbereitung & Alignment
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 0 (Preparation & Alignment)
 
-Beantworte die folgenden Fragen, um konkrete Arbeitsschritte für die Vorbereitung zu definieren. Verwende jede Antwort als Ausgangspunkt für To-dos und benötigte Artefakte.
+You are Codex assisting with the Weed Breed monorepo (TypeScript backend, React frontend). Follow the architectural guardrails from `/AGENTS.md` and the plan in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Stakeholder (Simulation, UI, Data) müssen eingebunden werden und welche Entscheidungen oder Freigaben werden von jedem benötigt?
-2. Welche bestehenden Dokumente, Tickets oder ADRs beschreiben die aktuelle Bewässerungs- und Nährstofflogik, und wie werden sie für das Alignment herangezogen?
-3. Welche Lücken oder Widersprüche zwischen Proposal und aktuellem Stand müssen vor dem Start geklärt werden?
-4. Welche Risiken oder Abhängigkeiten ergeben sich aus parallelen Arbeiten in anderen Streams, und wie werden sie kommuniziert?
-5. Welche Entscheidungen oder offenen Punkte sollen in der Deprecation-Vorlage adressiert werden, damit Alt-Reservoir-Tasks sauber auslaufen?
+## Objective
+
+Establish cross-discipline alignment and gather the artefacts required before implementing the irrigation & nutrient overhaul.
+
+## Required Steps
+
+1. Read the existing irrigation-related code paths, schema definitions, and task pipelines to build an inventory of current behaviour. Document each source file, schema, and blueprint you inspect.
+2. Schedule syncs with the Simulation, UI, and Data domain owners. Capture open questions, approved decisions, and follow-up actions in `/docs/tasks/irrigation/phase0-notes.md` (create if absent).
+3. Analyse the residual “reservoir” task flows. Produce a decision brief summarising which tasks will be deprecated, migrated, or retained; include impact on savegames and telemetry contracts.
+4. Summarise the agreed target state (structure-level water meter & nutrient store, zone irrigation method) and list the artefacts that must be updated in later phases.
+
+## Deliverables
+
+- A written summary (`phase0-notes.md`) covering meetings, decisions, and outstanding risks.
+- A deprecation decision brief appended to `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md` or linked from the notes.
+
+## Constraints & Reminders
+
+- Do not modify executable code in this phase—only notes/decision docs.
+- Ensure stakeholders sign off on the prepared materials before Phase 1 starts.
+- Track any schema or telemetry implications so the downstream phases stay coordinated.

--- a/docs/tasks/irrigation/phase1.md
+++ b/docs/tasks/irrigation/phase1.md
@@ -1,9 +1,31 @@
-# Phase 1 – Datenmodell & Schema-Erweiterungen
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 1 (Data Model & Schemas)
 
-Nutze die folgenden Fragen, um detaillierte Umsetzungsschritte für die Schema- und Datenmodell-Anpassungen abzuleiten.
+You are Codex working on the Weed Breed TypeScript backend. All changes must comply with `/AGENTS.md`, the simulation tick contract, and the Phase 1 goals in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Wie sieht der aktuelle Strukturzustand aus und welche Stellen müssen erweitert werden, um Wasserzähler- und Nährstofffelder aufzunehmen?
-2. Welche Savegame-, Blueprint- und Runtime-Schemas sind betroffen und wie wird ihre Versionierung aktualisiert, damit Migrationen konsistent laufen?
-3. Welche Defaultwerte und Validierungsregeln werden für `utilities.waterMeter_m3`, `utilities.lastTickWaterDraw_L` und `inventory.nutrients[]` benötigt?
-4. Wie werden Zonendaten (`irrigation.methodId`, `targetEC_mS_cm`, `runoffFraction`) integriert, ohne bestehende Tick- oder Telemetrie-Flows zu brechen?
-5. Welche Serializer/Deserializer, Seed-States oder Tests müssen angepasst werden, um die neuen Felder deterministisch zu unterstützen?
+## Objective
+
+Extend structure and zone state, JSON schemas, and save/load pipelines to support the new irrigation utilities.
+
+## Required Steps
+
+1. Catalogue every schema definition affecting structure, zone, and inventory state (runtime, savegame, blueprint validation). Identify the files to update and note required migrations.
+2. Modify the structure schema to include:
+   - `utilities.waterMeter_m3` (default 0).
+   - `utilities.lastTickWaterDraw_L` (default 0).
+   - `inventory.nutrients[]` entries with `id`, `name`, `form`, `npk`, `amount_kg`.
+3. Extend zone schemas with `irrigation.methodId` (required) plus optional `targetEC_mS_cm` and `runoffFraction` fields.
+4. Recompile or regenerate any derived schema bundles/versioned registries so validation remains deterministic.
+5. Update save/load serializers, initial seed state, and schema migrations to ensure new fields persist across round-trips.
+6. Document schema updates in `/docs/system` (append a changelog note) and flag downstream consumers that require adjustments.
+
+## Deliverables
+
+- Updated TypeScript schema modules reflecting the new fields, with defaults and validation constraints.
+- Migration or fallback logic ensuring legacy saves hydrate the new fields safely.
+- Documentation updates summarising the schema expansion and downstream impact.
+
+## Constraints & Reminders
+
+- Maintain SI naming conventions—no unit suffixes in keys, numeric fields in canonical SI (litres, kilograms, etc.).
+- Ensure schema version numbers or hashes are bumped so migrations trigger predictably.
+- Add or update tests that exercise schema validation for the new fields (no skipping or TODOs).

--- a/docs/tasks/irrigation/phase2.md
+++ b/docs/tasks/irrigation/phase2.md
@@ -1,9 +1,36 @@
-# Phase 2 – Blueprint-Pipeline für `irrigationMethods`
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 2 (Irrigation Method Blueprints)
 
-Nutze diese Fragen, um konkrete Arbeitsschritte für Aufbau und Validierung der Blueprint-Pipeline zu planen.
+You are Codex operating within the Weed Breed repository. Use the blueprint governance rules from `/AGENTS.md` and follow Phase 2 requirements described in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Dateistruktur, Namenskonventionen und Metadaten benötigt das neue Verzeichnis `/data/blueprints/irrigationMethods`, um mit bestehenden Loadern kompatibel zu sein?
-2. Wie muss das Schema gestaltet werden, damit alle geforderten Felder (`mixing`, `labor`, `runoff`, `requirements`, `compatibility`, `maintenance`, `meta`) typisiert und validiert werden können?
-3. Welche konkreten Informationen werden für jede Seed-Irrigationsmethode benötigt und wie werden IDs, Slugs und Beschreibungen konsistent erzeugt?
-4. Welche Validierungsregeln (z. B. Grenzen für `uniformity`, `runoff.defaultFraction`, Druckanforderungen) sind erforderlich und wo werden sie implementiert?
-5. Wie wird die Integration in Hot-Reload, Ajv/Zod-Validatoren und Dokumentation sichergestellt, damit UI und Backend die neuen Blueprints sofort nutzen können?
+## Objective
+
+Introduce the irrigation method blueprint pipeline, schemas, and seed data for manual and automated irrigation systems.
+
+## Required Steps
+
+1. Create or update the blueprint schema for irrigation methods (`/data/blueprints/irrigationMethods`). Ensure the schema defines: `id`, `slug`, `name`, `kind`, `description`, `mixing`, `couplesFertilizer`, `flow_L_per_min`, `uniformity`, `labor`, `runoff`, `requirements`, `compatibility`, `maintenance`, and `meta`.
+2. Implement validation constraints:
+   - `uniformity` must be within `[0.6, 1.0]`.
+   - `runoff.defaultFraction` must be within `[0, 0.5]`.
+   - Methods with `mixing: inline` require `requirements.minPressure_bar ≥ 1.0`.
+   - `ManualCan` must enforce `power_kW = 0` and `mixing = batch`.
+   - Compatibility checks must validate against supported zone methods and substrates.
+3. Seed the following blueprints with realistic default values and metadata:
+   - Manual Watering Can.
+   - Drip Inline Fertigation (Basic).
+   - Ebb & Flow Table (Small).
+   - Top-Feed Pump (Timer).
+4. Integrate the new schema into the blueprint loading pipeline (Ajv/Zod validators, hot-reload watchers, index documentation). Update any registries or exports to surface the irrigation methods.
+5. Document the blueprint contract and seed entries in the blueprint index docs, including how maintenance intervals are interpreted later in the engine.
+
+## Deliverables
+
+- Schema definition(s) with tests covering validation rules and error cases.
+- Four blueprint JSON files placed under `/data/blueprints/irrigationMethods/`, fully validated.
+- Updated blueprint loader wiring and documentation referencing the new directory.
+
+## Constraints & Reminders
+
+- Maintain deterministic ordering when loading blueprints (stable sort or keyed maps).
+- Use UUIDv4 (or existing project standard) for `id` fields; ensure slugs are unique and kebab-case.
+- Update any changelog or README sections that enumerate blueprint types.

--- a/docs/tasks/irrigation/phase3.md
+++ b/docs/tasks/irrigation/phase3.md
@@ -1,9 +1,31 @@
-# Phase 3 – Umbau der Engine-Phase `irrigationAndNutrients`
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 3 (Engine Phase Update)
 
-Verwende die folgenden Fragen, um die Umsetzung der neuen Phase-3-Logik in klaren Arbeitspaketen zu strukturieren.
+You are Codex modifying the Weed Breed backend simulation engine. Follow `/AGENTS.md` guardrails and implement the Phase 3 plan from `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Teile der bisherigen Reservoir-Logik müssen entfernt oder ersetzt werden, und wie wird sichergestellt, dass keine Altpfade übrig bleiben?
-2. Wie wird `phase_irrigationAndNutrients` aufgebaut, um Demand-Ermittlung, Method-Lookup und Differenzierung zwischen manuellen und automatisierten Methoden sauber zu kapseln?
-3. Welche Datenstrukturen unterstützen `fulfillWaterAndNutrients`, insbesondere hinsichtlich Runoff-Berechnung, Wasserzählerbelastung, Nährstoffmischung und Kostenverbuchung?
-4. Wie werden Pending-Queues und Telemetrie-Events für manuelle Methoden modelliert, damit Warteschlangenverhalten und deterministische IDs erhalten bleiben?
-5. Welche Anpassungen benötigen Physio- und Plantmodelle, um neue Ressourcenfelder korrekt zu konsumieren und Tests weiterhin deterministisch zu halten?
+## Objective
+
+Replace the legacy reservoir-driven irrigation logic with the new `irrigationAndNutrients` phase flow that consumes irrigation method blueprints and updates zone resources deterministically.
+
+## Required Steps
+
+1. Identify and remove the old reservoir/queue logic tied to irrigation. Map all call sites and ensure no dead references remain.
+2. Implement a new `phase_irrigationAndNutrients` module that:
+   - Iterates zones, calculates water & nutrient demand, and fetches the assigned irrigation method via the blueprint registry.
+   - Branches on method kind (`ManualCan` vs automated) to either enqueue manual tasks or fulfil delivery immediately.
+3. Create helper functions such as `fulfillWaterAndNutrients`, `enqueueWaterTask`, `updateZoneDeliveryStats`, and `scheduleMaintenanceIfDue`, ensuring pure/deterministic behaviour and unit-compliant calculations.
+4. Update zone resource tracking (`zone.resources.pending.*`) for manual methods while preserving existing queue semantics.
+5. For automated methods, apply irrigation instantly, update structure utility counters, and invoke maintenance scheduling hooks.
+6. Integrate with plant physiology modules so water/nutrient availability feeds existing growth/stress models without breaking determinism.
+7. Ensure events and telemetry emitted from this phase have deterministic IDs and adhere to established namespaces (`irrigation.*`, `sim.*`). Add regression tests where necessary.
+
+## Deliverables
+
+- New engine phase module(s) with full TypeScript typings, replacing reservoir logic.
+- Updated unit/integration tests covering manual vs automated flows, maintenance triggers, and deterministic telemetry output.
+- Documentation updates summarising the phase rewrite and any new events.
+
+## Constraints & Reminders
+
+- Preserve the prescribed tick phase order; do not move side-effects into adjacent phases.
+- Avoid duplicating blueprint lookups—cache or inject references as required for performance without compromising determinism.
+- All numeric computations must respect SI units; clearly document any assumptions in JSDoc.

--- a/docs/tasks/irrigation/phase4.md
+++ b/docs/tasks/irrigation/phase4.md
@@ -1,0 +1,29 @@
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 4 (Inventory & Cost Accounting)
+
+You are Codex extending Weed Breed’s resource accounting layer. Honour `/AGENTS.md` constraints and the Phase 4 directives in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
+
+## Objective
+
+Wire the new irrigation flows into structure-level water metering, nutrient inventory deduction, and financial charge pipelines.
+
+## Required Steps
+
+1. Update the structure utility tracking so every fulfilment call increments `utilities.lastTickWaterDraw_L` and accumulates to `utilities.waterMeter_m3` (convert litres → cubic metres during accounting).
+2. Implement `pickInventoryBlend` (greedy solver) to select nutrient products matching demanded NPK grams. Handle shortages explicitly and ensure determinism (stable ordering, no random choice).
+3. Add `deductInventory` helper(s) to mutate nutrient stock, supporting fractional kg consumption and preventing negative values. Emit shortage events if demand exceeds inventory.
+4. Integrate cost booking via the finance service (`chargeWaterCost`, `chargeNutrientCost`) using tick-length-normalised rates. Confirm accounting occurs during the dedicated accounting phase.
+5. For runoff handling, respect zone overrides or method defaults. Capture vs loss must influence water usage and possible reuse metrics.
+6. Extend telemetry/snapshots to expose last tick water draw, cumulative meters, and nutrient inventory changes so the UI can surface resource consumption.
+7. Add regression tests covering water usage, nutrient blending, shortage handling, and cost postings. Include at least one scenario test validating net irrigation vs runoff capture.
+
+## Deliverables
+
+- Inventory and accounting utilities with full TypeScript coverage and deterministic behaviour.
+- Finance hooks/tests demonstrating correct cost calculations relative to tick length.
+- Documentation updates detailing how nutrient blending and water metering work.
+
+## Constraints & Reminders
+
+- Preserve SI units (`L`, `m³`, `kg`); conversions must be explicit and tested.
+- Emit structured events for shortages or anomalies using existing event bus patterns.
+- Ensure the accounting phase remains idempotent when re-running the same tick (no double charges on replay).

--- a/docs/tasks/irrigation/phase5.md
+++ b/docs/tasks/irrigation/phase5.md
@@ -1,0 +1,32 @@
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 5 (Task System & Facade Intents)
+
+You are Codex enhancing Weed Breed’s tasking system and simulation facade. Align with `/AGENTS.md` policies and Phase 5 tasks in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
+
+## Objective
+
+Introduce new irrigation-related tasks, scheduling hooks, and facade intents to orchestrate manual and automated irrigation workflows.
+
+## Required Steps
+
+1. Extend `/data/configs/task_definitions.json` with the four irrigation tasks: `water_fertilize_plants`, `inspect_irrigation_lines`, `clean_irrigation_system`, `mix_nutrient_batch`. Ensure cost models, roles, skills, and descriptions follow existing conventions.
+2. Update task routing logic to respect the new definitions, including permission/skill matrix adjustments so workers with irrigation skills are prioritised appropriately.
+3. Implement scheduling hooks that translate irrigation method maintenance metadata (`inspectionEveryDays`, `cleaningEveryDays`) into recurring tasks. Ensure deterministic scheduling keyed by tick counters.
+4. Integrate manual irrigation methods with the task system: when `phase_irrigationAndNutrients` enqueues pending resources, create corresponding `water_fertilize_plants` tasks through the task facade.
+5. Extend the simulation facade with intents:
+   - `zone.setIrrigationMethod` (validates compatibility and emits `irrigation.methodChanged`).
+   - `inventory.addNutrientStock` (ingests nutrient deliveries with validation).
+   - `task.enqueue.waterFertilizePlants` (exposed for engine/manual overrides).
+6. Update documentation and TypeScript types for the facade API so frontend/automation clients can adopt the new intents safely.
+7. Add unit/integration tests verifying task creation, scheduling cadence, and facade validation (including error cases for incompatible methods).
+
+## Deliverables
+
+- Updated task definitions and routing logic with supporting tests.
+- New facade intent implementations plus documentation describing payload shapes and emitted events.
+- Wiring between irrigation phase outputs and task system inputs.
+
+## Constraints & Reminders
+
+- Keep all new intents idempotent and deterministic; avoid random IDs—derive from tick + zone identifiers.
+- Ensure manual task queues integrate with existing UX expectations (status flags, notifications).
+- Document any new event types in `/docs/system/socket_protocol.md` or related references.

--- a/docs/tasks/irrigation/phase6.md
+++ b/docs/tasks/irrigation/phase6.md
@@ -1,9 +1,36 @@
-# Phase 6 – UI & Telemetrie
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 6 (UI & Telemetry)
 
-Nutze diese Fragen, um UI- und Telemetrie-Anpassungen in überprüfbare Aufgaben zu übersetzen.
+You are Codex updating the Weed Breed React dashboard and telemetry contracts. Follow `/AGENTS.md` guidance, frontend standards, and Phase 6 requirements from `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche UI-Ansichten und Komponenten müssen erweitert werden, um Irrigation-Methode, Ziel-EC, Runoff-Override und letzte Wasser-/NPK-Mengen sichtbar zu machen?
-2. Wie werden Badges oder Indikatoren für offene manuelle `water_fertilize_plants` Aufgaben gestaltet, damit sie mit bestehenden Task-Queues harmonieren?
-3. Welche Telemetrie- und Snapshot-Felder müssen versioniert oder erweitert werden, damit neue Informationen ohne Breaking Changes ausgespielt werden können?
-4. Wie lassen sich Inspektions- und Wartungsinformationen für automatisierte Methoden im Dashboard darstellen und aktualisieren?
-5. Welche Dokumentations- oder UI-Building-Guides müssen angepasst werden, damit das Frontend-Team konsistent arbeiten kann?
+## Objective
+
+Expose the new irrigation state in telemetry payloads and surface it within the dashboard UI (zone details, task queues, structure metrics).
+
+## Required Steps
+
+1. Extend backend snapshot builders and Socket.IO payloads to include:
+   - Zone irrigation method metadata (method name/slug, target EC, runoff overrides, last delivery stats).
+   - Structure water meter readings (`waterMeter_m3`, `lastTickWaterDraw_L`) and nutrient inventory summaries.
+   - Task queue counts for `water_fertilize_plants` when manual methods are active.
+2. Version or annotate telemetry payloads so clients can differentiate the new fields. Update `/docs/system/socket_protocol.md` accordingly.
+3. Update the frontend Zustand store slices to ingest the new telemetry fields while maintaining backward compatibility (default fallbacks when fields missing).
+4. Implement UI components:
+   - Zone detail pill showing irrigation method and maintenance countdowns.
+   - Readouts for target EC and runoff overrides.
+   - Badges/indicators for pending manual irrigation tasks.
+   - Structure-level widgets summarising daily/weekly water usage and nutrient stock levels (with reorder hinting logic, even if disabled).
+5. Ensure automated method maintenance intervals are displayed (next inspection/cleaning based on telemetry or derived in UI).
+6. Add tests (unit for selectors, component tests, or Playwright e2e) verifying the UI renders new data and handles missing fields gracefully.
+7. Update user-facing docs/UX guides (`/docs/ui-building_guide.md`, README snippets) describing the new dashboard panels.
+
+## Deliverables
+
+- Updated telemetry contract with documentation.
+- React components/store updates displaying irrigation state.
+- Test coverage ensuring UI stability and compatibility.
+
+## Constraints & Reminders
+
+- Respect performance constraints: throttle chart updates, memoise selectors when necessary.
+- Coordinate CSS/theming changes with existing design tokens; avoid ad-hoc styles.
+- If mock data or fixtures are used for UI tests, update them to include irrigation fields.

--- a/docs/tasks/irrigation/phase7.md
+++ b/docs/tasks/irrigation/phase7.md
@@ -1,9 +1,29 @@
-# Phase 7 – Migration & Datenpflege
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 7 (Migration & Data Ops)
 
-Beantworte die Fragen, um Migrationsschritte und Datenpflege strukturiert vorzubereiten.
+You are Codex preparing migrations and operational tooling for Weed Breed. Adhere to `/AGENTS.md` policies and Phase 7 tasks in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Deployment- oder Seed-Skripte müssen angepasst werden, damit neue Irrigation-Blueprints ausgeliefert und überwacht werden?
-2. Wie werden bestehende Spielstände analysiert und migriert, um pro Zone ein sinnvolles Default- oder Override-Mapping zu vergeben?
-3. Welche Alt-Reservoir-Tasks oder Blueprints müssen depreziert oder entfernt werden und welche Kommunikationsmaßnahmen begleiten diesen Schritt?
-4. Welche Dokumentationsquellen (System, Tasks, Constants, README) benötigen Updates, um den neuen Datenfluss zu erklären?
-5. Welche Validierungs- oder Smoke-Checks werden nach der Migration ausgeführt, um Datenintegrität und deterministische Seeds sicherzustellen?
+## Objective
+
+Ship migration scripts, deployment updates, and documentation so existing blueprints/savegames adopt the new irrigation model without data loss.
+
+## Required Steps
+
+1. Extend blueprint seed scripts to include the new irrigation method directory. Ensure deployment pipelines copy and validate the additional files.
+2. Implement migration logic that assigns default irrigation methods to existing zones (fallback `manual-watering-can` unless overrides provided). Respect the reference JSON mapping in the task plan.
+3. Add CLI or scripted tooling to apply migrations to historical savegames. Include dry-run and backup options.
+4. Deprecate or remove reservoir-specific tasks and blueprints no longer needed. Document the deprecation path and any replacement guidance.
+5. Update operational documentation (`/docs/system`, `/docs/tasks`, `/docs/constants`, README) describing the new irrigation data flow, migration process, and rollback considerations.
+6. Coordinate with release/DevOps pipelines to ensure environments preload the new blueprints and run migrations during deployment.
+7. Provide validation scripts/tests confirming migrated saves load successfully and match expected telemetry/state snapshots.
+
+## Deliverables
+
+- Migration scripts/tooling with instructions.
+- Updated deployment/seed scripts and documentation.
+- Validation evidence (logs/tests) demonstrating successful migration on sample saves.
+
+## Constraints & Reminders
+
+- Migrations must be deterministic and idempotent—rerunning should yield the same state.
+- Maintain backups and audit logs for savegame migrations to satisfy QA.
+- Communicate deprecation timelines clearly; update changelogs accordingly.

--- a/docs/tasks/irrigation/phase8.md
+++ b/docs/tasks/irrigation/phase8.md
@@ -1,9 +1,33 @@
-# Phase 8 – Tests & Qualitätssicherung
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 8 (Testing & QA)
 
-Verwende die Fragen, um einen vollständigen Test- und QA-Plan zu entwickeln.
+You are Codex leading the testing effort for Weed Breed’s irrigation overhaul. Honour `/AGENTS.md` quality standards and Phase 8 guidance from `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Unit-Tests werden für Wasser- und Nährstoff-Demand, Runoff-Berechnung und Inventar-Blending benötigt und wie werden Grenzfälle abgedeckt?
-2. Wie werden Szenario-Tests gestaltet, um manuelle und automatisierte Methoden gegenüberzustellen und erwartete Pflanzenzustände sowie Kosten zu vergleichen?
-3. Welche ökonomischen Regressionstests sichern, dass Wasserzähler- und Inventardeltas mit den verbuchten Kosten übereinstimmen?
-4. Wie werden Telemetrie- und Snapshot-Regressionen organisiert, um deterministische Event-Verteilungen zu garantieren?
-5. Welche Tools oder Pipelines (CI, Benchmarks, Golden Master) müssen angepasst werden, damit neue Tests automatisch laufen und Ergebnisse versioniert bleiben?
+## Objective
+
+Design and execute comprehensive tests covering unit logic, scenario simulations, and economic regression for the new irrigation systems.
+
+## Required Steps
+
+1. Draft a test matrix enumerating unit, integration, scenario, and regression cases. Include coverage for water/NPK demand fulfilment, runoff capture, inventory blending, and cost postings.
+2. Implement unit tests for:
+   - Demand → fulfilment calculations (manual and automated methods).
+   - Runoff handling with and without capture.
+   - `pickInventoryBlend` shortage detection and event emissions.
+   - Telemetry/event ID determinism.
+3. Build scenario tests comparing manual vs automated methods delivering identical demand. Validate plant states align while labour/cost metrics differ.
+4. Add economic regression tests simulating 7 in-game days; assert that water/nutrient costs align with meter and inventory deltas.
+5. Extend golden-master event fixtures (Phase 3 focus) to include irrigation events, ensuring telemetry stays stable between runs.
+6. Update CI pipelines or scripts (`pnpm run test`, `pnpm run bench`) to include the new test suites. Ensure runtime stays within acceptable limits.
+7. Produce QA documentation summarising test coverage, known gaps, and instructions for manual verification (UI checks, telemetry inspection).
+
+## Deliverables
+
+- Automated test suites (unit, integration, scenario) committed and passing.
+- Updated CI configuration to run the new suites.
+- QA summary document referencing test results and manual verification steps.
+
+## Constraints & Reminders
+
+- Tests must be deterministic; seed RNGs and avoid time-of-day dependencies.
+- Keep golden-master fixtures lightweight but representative; document update procedures.
+- Collaborate with QA to capture any tooling needs (log scrapers, dashboards).

--- a/docs/tasks/irrigation/phase9.md
+++ b/docs/tasks/irrigation/phase9.md
@@ -1,9 +1,29 @@
-# Phase 9 – Abschluss & Review
+# Codex Prompt – Irrigation & Nutrient Overhaul · Phase 9 (Close-Out & Review)
 
-Nutze diese Fragen, um den Abschlussprozess strukturiert zu planen.
+You are Codex coordinating the close-out activities for Weed Breed’s irrigation overhaul. Follow `/AGENTS.md` governance and Phase 9 directives in `/docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 
-1. Welche Reviewer aus Backend, Frontend, Docs und Data sind erforderlich und wie wird der Cross-Package-Review-Prozess orchestriert?
-2. Welche Inhalte müssen in die Release-Notes aufgenommen werden, damit Stakeholder Fortschritt und Auswirkungen verstehen?
-3. Welche QA- oder Product-Sign-offs sind notwendig und wie werden sie dokumentiert?
-4. Welche Monitoring- oder Observability-Hooks müssen überprüft oder erweitert werden, bevor das Feature live geht?
-5. Welche Lessons Learned oder Follow-up-Aufgaben sollten im Abschlussbericht festgehalten werden, um zukünftige Iterationen zu beschleunigen?
+## Objective
+
+Complete cross-package review, release preparation, and observability validation to ship the overhaul confidently.
+
+## Required Steps
+
+1. Organise a multi-package code review involving backend, frontend, docs, and data stakeholders. Track action items and ensure all blockers are resolved.
+2. Compile release notes summarising features, schema changes, migrations, and testing outcomes. Align terminology with the PRD and task plan.
+3. Obtain QA sign-off by presenting automated test results, manual verification logs, and outstanding risk assessments.
+4. Audit logging and monitoring hooks to confirm new irrigation events/metrics are captured. Update observability dashboards or alerts if required.
+5. Verify that documentation (README, `/docs/system`, `/docs/tasks`, `/docs/constants`) reflects the final implementation. Ensure diagrams or tables are refreshed.
+6. Coordinate the final deployment checklist: migrations applied, blueprints seeded, telemetry consumers ready, rollback plan documented.
+7. Archive project artefacts (design docs, test reports, migration logs) in the agreed location for future reference.
+
+## Deliverables
+
+- Review sign-off log capturing approvals from each discipline.
+- Final release notes ready for publication (CHANGELOG entry, release page draft).
+- Observability validation report confirming telemetry/logging coverage.
+
+## Constraints & Reminders
+
+- Ensure no open TODOs or FIXME placeholders remain in code or docs before sign-off.
+- All documentation updates must reference the final schema/telemetry shapes.
+- Capture lessons learned for retrospectives; propose follow-up tasks if scope was deferred.


### PR DESCRIPTION
## Summary
- rewrite the irrigation phase documents into codex-oriented prompts covering objectives, steps, deliverables, and constraints for phases 0–9
- add dedicated guidance for inventory/cost accounting and task/facade integration phases to support the irrigation overhaul roadmap

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9911f5ec88325adf891b2e88f0689