### PR TITLE
feat: add plant lifecycle commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented a device removal engine service that clears unsupported zone setpoints, emits
   `device.removed` telemetry, and exposes the facade command with unit and integration
   coverage.
+- Added a plant lifecycle service with single-plant harvest/cull commands that honor zone
+  safety restrictions, wiring the backend facade, socket intents, and frontend bridge
+  contracts to return typed results.
 - Erstellt den Alignment-Report zu Phase 0 der Irrigation-&-Nutrient-Überarbeitung mit Stakeholder-Bestätigungen,
   Quellensichtung und Deprecation-Empfehlungen für Reservoir-Aufgaben (`docs/tasks/irrigation/phase0-alignment-report.md`).
 - Added an `isHarvestable` flag to plant snapshots, plumbing the backend UI snapshot,

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -67,14 +67,16 @@ Defined in `commands/devices.ts` and registered under the `devices` domain.【F:
 
 ### Plants (`plants.*`)
 
-| Action               | Payload highlights                                  | Result data                   |
-| -------------------- | --------------------------------------------------- | ----------------------------- |
-| `addPlanting`        | `zoneId`, `strainId`, `count`, optional `startTick` | –                             |
-| `cullPlanting`       | `plantingId`, optional `count`                      | –                             |
-| `harvestPlanting`    | `plantingId`                                        | –                             |
-| `applyIrrigation`    | `zoneId`, `liters`                                  | –                             |
-| `applyFertilizer`    | `zoneId`, `nutrients { n, p, k }`                   | –                             |
-| `togglePlantingPlan` | `zoneId`, `enabled`                                 | `{ enabled: boolean }` result |
+| Action               | Payload highlights                                  | Result data                                |
+| -------------------- | --------------------------------------------------- | ------------------------------------------ |
+| `addPlanting`        | `zoneId`, `strainId`, `count`, optional `startTick` | –                                          |
+| `cullPlanting`       | `plantingId`, optional `count`                      | –                                          |
+| `harvestPlanting`    | `plantingId`                                        | –                                          |
+| `harvestPlant`       | `plantId`                                           | `{ harvestBatchId, weightGrams, quality }` |
+| `cullPlant`          | `plantId`                                           | `{ plantId, stage }`                       |
+| `applyIrrigation`    | `zoneId`, `liters`                                  | –                                          |
+| `applyFertilizer`    | `zoneId`, `nutrients { n, p, k }`                   | –                                          |
+| `togglePlantingPlan` | `zoneId`, `enabled`                                 | `{ enabled: boolean }` result              |
 
 Configured in `commands/plants.ts` and exposed through the façade registry.【F:src/backend/src/facade/commands/plants.ts†L12-L104】【F:src/backend/src/facade/index.ts†L451-L479】
 

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -102,6 +102,11 @@ Common categories are below.
   compatibility hints, and emits `plant.planted` telemetry including all generated plant IDs.
 - `cullPlanting(plantingId, count?)`
 - `harvestPlanting(plantingId)` — creates inventory lots, emits events.
+- `harvestPlant(plantId)` — removes a single plant, honoring zone safety
+  restrictions and returning `{ harvestBatchId, weightGrams, quality }` plus
+  optional warnings.
+- `cullPlant(plantId)` — discards a plant while respecting re-entry and
+  pre-harvest locks, returning `{ plantId, stage }` with warning propagation.
 - `applyIrrigation(zoneId, liters)` / `applyFertilizer(zoneId, { N,P,K } in g)` — optional manual overrides.
 - `togglePlantingPlan({ zoneId, enabled })` — activates/deactivates automation; returns `{ enabled }` plus a follow-up task event.
 

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -412,10 +412,12 @@ object:
 - **devices** — `installDevice`, `updateDevice`, `moveDevice`, `removeDevice`,
   `toggleDeviceGroup`. The toggle action returns `{ deviceIds: string[] }` with
   every instance that changed status.
-- **plants** — `addPlanting`, `cullPlanting`, `harvestPlanting`,
-  `applyIrrigation`, `applyFertilizer`, `togglePlantingPlan`. The automation
-  toggle responds with `{ enabled: boolean }` and emits a follow-up maintenance
-  task when the state flips.
+- **plants** — `addPlanting`, `cullPlanting`, `harvestPlanting`, `harvestPlant`,
+  `cullPlant`, `applyIrrigation`, `applyFertilizer`, `togglePlantingPlan`. The
+  automation toggle responds with `{ enabled: boolean }` and emits a follow-up
+  maintenance task when the state flips. `harvestPlant` returns `{ plantId,
+harvestBatchId, weightGrams, quality }` alongside optional warnings, and
+  `cullPlant` yields `{ plantId, stage }` with matching warning propagation.
 - **health** — `scheduleScouting`, `applyTreatment`, `quarantineZone`.
 - **workforce** — `refreshCandidates`, `hire`, `fire`, `setOvertimePolicy`,
   `assignStructure`, `enqueueTask` (payload defaults to `{}` when omitted).

--- a/src/backend/src/engine/index.ts
+++ b/src/backend/src/engine/index.ts
@@ -9,6 +9,7 @@ export * from './plants/phenology.js';
 export * from './plants/resourceDemand.js';
 export * from './plants/growthModel.js';
 export * from './plants/plantingPlanService.js';
+export * from './plants/plantLifecycleService.js';
 export * from './health/models.js';
 export * from './health/healthEngine.js';
 export * from './workforce/index.js';

--- a/src/backend/src/engine/plants/plantLifecycleService.ts
+++ b/src/backend/src/engine/plants/plantLifecycleService.ts
@@ -1,0 +1,319 @@
+import { generateId } from '@/state/initialization/common.js';
+import { RNG_STREAM_IDS, type RngService, type RngStream } from '@/lib/rng.js';
+import type { CommandExecutionContext, CommandResult, ErrorCode } from '@/facade/index.js';
+import type {
+  GameState,
+  HarvestBatch,
+  PlantStage,
+  PlantState,
+  RoomState,
+  StructureState,
+  ZoneState,
+} from '@/state/models.js';
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
+
+export interface HarvestPlantResult {
+  plantId: string;
+  zoneId: string;
+  roomId: string;
+  structureId: string;
+  harvestBatchId: string;
+  weightGrams: number;
+  quality: number;
+  warnings?: string[];
+}
+
+export interface DiscardPlantResult {
+  plantId: string;
+  zoneId: string;
+  roomId: string;
+  structureId: string;
+  stage: PlantStage;
+  warnings?: string[];
+}
+
+export interface PlantLifecycleServiceOptions {
+  state: GameState;
+  rng: RngService;
+}
+
+interface PlantLookupResult {
+  structure: StructureState;
+  room: RoomState;
+  zone: ZoneState;
+  plant: PlantState;
+  plantIndex: number;
+}
+
+export class PlantLifecycleService {
+  private readonly state: GameState;
+
+  private readonly idStream: RngStream;
+
+  constructor(options: PlantLifecycleServiceOptions) {
+    this.state = options.state;
+    this.idStream = options.rng.getStream(RNG_STREAM_IDS.ids);
+  }
+
+  harvestPlant(
+    plantId: string,
+    context: CommandExecutionContext,
+  ): CommandResult<HarvestPlantResult> {
+    const lookup = this.findPlant(plantId);
+    if (!lookup) {
+      return this.failure('ERR_NOT_FOUND', `Plant ${plantId} was not found.`, [
+        'plants.harvestPlant',
+        'plantId',
+      ]);
+    }
+
+    const { plant, zone, room, structure } = lookup;
+
+    const restrictionFailure = this.checkZoneAccess(zone, context.tick, 'plants.harvestPlant');
+    if (restrictionFailure) {
+      return restrictionFailure;
+    }
+
+    if (plant.stage !== 'harvestReady') {
+      return this.failure(
+        'ERR_INVALID_STATE',
+        `Plant ${plant.id} is not ready for harvest (stage: ${plant.stage}).`,
+        ['plants.harvestPlant', 'plantId'],
+      );
+    }
+
+    const warnings: string[] = [];
+
+    const batch = this.createHarvestBatch(plant, context.tick);
+    if (batch.weightGrams <= 0) {
+      warnings.push('Plant did not produce any harvestable yield.');
+    }
+
+    this.removePlantFromZone(lookup);
+    this.ensureHarvestInventory().push(batch);
+
+    const payload: Record<string, unknown> = {
+      plantId: plant.id,
+      zoneId: zone.id,
+      roomId: room.id,
+      structureId: structure.id,
+      strainId: plant.strainId,
+      harvestBatchId: batch.id,
+      weightGrams: batch.weightGrams,
+      quality: batch.quality,
+    };
+    if (warnings.length > 0) {
+      payload.warnings = [...warnings];
+    }
+
+    context.events.queue('plant.harvested', payload, context.tick, 'info');
+
+    const resultWarnings = warnings.length > 0 ? [...warnings] : undefined;
+    return {
+      ok: true,
+      data: {
+        plantId: plant.id,
+        zoneId: zone.id,
+        roomId: room.id,
+        structureId: structure.id,
+        harvestBatchId: batch.id,
+        weightGrams: batch.weightGrams,
+        quality: batch.quality,
+        warnings: resultWarnings,
+      },
+      warnings: resultWarnings,
+    } satisfies CommandResult<HarvestPlantResult>;
+  }
+
+  discardPlant(
+    plantId: string,
+    context: CommandExecutionContext,
+  ): CommandResult<DiscardPlantResult> {
+    const lookup = this.findPlant(plantId);
+    if (!lookup) {
+      return this.failure('ERR_NOT_FOUND', `Plant ${plantId} was not found.`, [
+        'plants.cullPlant',
+        'plantId',
+      ]);
+    }
+
+    const { plant, zone, room, structure } = lookup;
+
+    const restrictionFailure = this.checkZoneAccess(zone, context.tick, 'plants.cullPlant');
+    if (restrictionFailure) {
+      return restrictionFailure;
+    }
+
+    if (plant.stage === 'drying' || plant.stage === 'cured') {
+      return this.failure(
+        'ERR_INVALID_STATE',
+        `Plant ${plant.id} is already processed (stage: ${plant.stage}).`,
+        ['plants.cullPlant', 'plantId'],
+      );
+    }
+
+    const warnings: string[] = [];
+    if (plant.stage === 'dead') {
+      warnings.push('Plant was already dead prior to culling.');
+    }
+
+    this.removePlantFromZone(lookup);
+
+    const payload: Record<string, unknown> = {
+      plantId: plant.id,
+      zoneId: zone.id,
+      roomId: room.id,
+      structureId: structure.id,
+      strainId: plant.strainId,
+      stage: plant.stage,
+    };
+    if (warnings.length > 0) {
+      payload.warnings = [...warnings];
+    }
+
+    context.events.queue('plant.discarded', payload, context.tick, 'info');
+
+    const resultWarnings = warnings.length > 0 ? [...warnings] : undefined;
+    return {
+      ok: true,
+      data: {
+        plantId: plant.id,
+        zoneId: zone.id,
+        roomId: room.id,
+        structureId: structure.id,
+        stage: plant.stage,
+        warnings: resultWarnings,
+      },
+      warnings: resultWarnings,
+    } satisfies CommandResult<DiscardPlantResult>;
+  }
+
+  private createHarvestBatch(plant: PlantState, tick: number): HarvestBatch {
+    const weight = Math.max(0, plant.yieldDryGrams);
+    const quality = clamp(plant.quality, 0, 1);
+
+    return {
+      id: generateId(this.idStream, 'harvest'),
+      strainId: plant.strainId,
+      weightGrams: weight,
+      quality,
+      stage: 'fresh',
+      harvestedAtTick: tick,
+    } satisfies HarvestBatch;
+  }
+
+  private ensureHarvestInventory(): HarvestBatch[] {
+    if (!this.state.inventory.harvest) {
+      this.state.inventory.harvest = [];
+    }
+    return this.state.inventory.harvest;
+  }
+
+  private removePlantFromZone(lookup: PlantLookupResult): void {
+    const { zone, plantIndex, plant } = lookup;
+    zone.plants.splice(plantIndex, 1);
+
+    if (zone.health?.plantHealth) {
+      delete zone.health.plantHealth[plant.id];
+      this.pruneTreatmentReferences(zone, plant.id);
+    }
+  }
+
+  private pruneTreatmentReferences(zone: ZoneState, plantId: string): void {
+    const health = zone.health;
+    if (!health) {
+      return;
+    }
+
+    for (let index = health.pendingTreatments.length - 1; index >= 0; index -= 1) {
+      const pending = health.pendingTreatments[index]!;
+      pending.plantIds = pending.plantIds.filter((id) => id !== plantId);
+      if (pending.plantIds.length === 0) {
+        health.pendingTreatments.splice(index, 1);
+      }
+    }
+
+    for (let index = health.appliedTreatments.length - 1; index >= 0; index -= 1) {
+      const applied = health.appliedTreatments[index]!;
+      applied.plantIds = applied.plantIds.filter((id) => id !== plantId);
+      if (applied.plantIds.length === 0) {
+        health.appliedTreatments.splice(index, 1);
+      }
+    }
+  }
+
+  private checkZoneAccess(
+    zone: ZoneState,
+    tick: number,
+    command: string,
+  ): CommandResult<never> | undefined {
+    const { health } = zone;
+
+    const reentryRestrictedUntilTick = health?.reentryRestrictedUntilTick;
+    if (typeof reentryRestrictedUntilTick === 'number' && reentryRestrictedUntilTick > tick) {
+      return this.failure(
+        'ERR_FORBIDDEN',
+        `Zone ${zone.name ?? zone.id} is restricted until tick ${reentryRestrictedUntilTick} due to safety requirements.`,
+        [command, 'zoneId'],
+      );
+    }
+
+    const preHarvestRestrictedUntilTick = health?.preHarvestRestrictedUntilTick;
+    if (typeof preHarvestRestrictedUntilTick === 'number' && preHarvestRestrictedUntilTick > tick) {
+      return this.failure(
+        'ERR_FORBIDDEN',
+        `Zone ${zone.name ?? zone.id} cannot be handled until tick ${preHarvestRestrictedUntilTick} because of a pre-harvest interval.`,
+        [command, 'zoneId'],
+      );
+    }
+
+    return undefined;
+  }
+
+  private findPlant(plantId: string): PlantLookupResult | undefined {
+    for (const structure of this.state.structures) {
+      for (const room of structure.rooms) {
+        for (const zone of room.zones) {
+          const plantIndex = zone.plants.findIndex((candidate) => candidate.id === plantId);
+          if (plantIndex >= 0) {
+            return {
+              structure,
+              room,
+              zone,
+              plant: zone.plants[plantIndex]!,
+              plantIndex,
+            } satisfies PlantLookupResult;
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
+    return {
+      ok: false,
+      errors: [
+        {
+          code,
+          message,
+          path,
+        },
+      ],
+    } satisfies CommandResult<T>;
+  }
+}
+
+export default PlantLifecycleService;

--- a/src/backend/src/facade/commands/plants.ts
+++ b/src/backend/src/facade/commands/plants.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import type { PlantingPlanToggleResult } from '@/engine/plants/plantingPlanService.js';
+import type {
+  DiscardPlantResult,
+  HarvestPlantResult,
+} from '@/engine/plants/plantLifecycleService.js';
 import { entityIdentifier, nonNegativeNumber, positiveInteger, uuid } from './commonSchemas.js';
 import {
   createServiceCommand,
@@ -27,6 +31,18 @@ const cullPlantingSchema = z
 const harvestPlantingSchema = z
   .object({
     plantingId: uuid,
+  })
+  .strict();
+
+const harvestPlantSchema = z
+  .object({
+    plantId: entityIdentifier,
+  })
+  .strict();
+
+const cullPlantSchema = z
+  .object({
+    plantId: entityIdentifier,
   })
   .strict();
 
@@ -60,6 +76,8 @@ const togglePlantingPlanSchema = z
 export type AddPlantingIntent = z.infer<typeof addPlantingSchema>;
 export type CullPlantingIntent = z.infer<typeof cullPlantingSchema>;
 export type HarvestPlantingIntent = z.infer<typeof harvestPlantingSchema>;
+export type HarvestPlantIntent = z.infer<typeof harvestPlantSchema>;
+export type CullPlantIntent = z.infer<typeof cullPlantSchema>;
 export type ApplyIrrigationIntent = z.infer<typeof applyIrrigationSchema>;
 export type ApplyFertilizerIntent = z.infer<typeof applyFertilizerSchema>;
 export type TogglePlantingPlanIntent = z.infer<typeof togglePlantingPlanSchema>;
@@ -68,6 +86,8 @@ export interface PlantIntentHandlers {
   addPlanting: ServiceCommandHandler<AddPlantingIntent>;
   cullPlanting: ServiceCommandHandler<CullPlantingIntent>;
   harvestPlanting: ServiceCommandHandler<HarvestPlantingIntent>;
+  harvestPlant: ServiceCommandHandler<HarvestPlantIntent, HarvestPlantResult>;
+  cullPlant: ServiceCommandHandler<CullPlantIntent, DiscardPlantResult>;
   applyIrrigation: ServiceCommandHandler<ApplyIrrigationIntent>;
   applyFertilizer: ServiceCommandHandler<ApplyFertilizerIntent>;
   togglePlantingPlan: ServiceCommandHandler<TogglePlantingPlanIntent, PlantingPlanToggleResult>;
@@ -77,6 +97,8 @@ export interface PlantCommandRegistry {
   addPlanting: CommandRegistration<AddPlantingIntent>;
   cullPlanting: CommandRegistration<CullPlantingIntent>;
   harvestPlanting: CommandRegistration<HarvestPlantingIntent>;
+  harvestPlant: CommandRegistration<HarvestPlantIntent, HarvestPlantResult>;
+  cullPlant: CommandRegistration<CullPlantIntent, DiscardPlantResult>;
   applyIrrigation: CommandRegistration<ApplyIrrigationIntent>;
   applyFertilizer: CommandRegistration<ApplyFertilizerIntent>;
   togglePlantingPlan: CommandRegistration<TogglePlantingPlanIntent, PlantingPlanToggleResult>;
@@ -109,6 +131,18 @@ export const buildPlantCommands = ({
     () => services().harvestPlanting,
     onMissingHandler,
   ),
+  harvestPlant: createServiceCommand<HarvestPlantIntent, HarvestPlantResult>(
+    'plants.harvestPlant',
+    harvestPlantSchema,
+    () => services().harvestPlant,
+    onMissingHandler,
+  ),
+  cullPlant: createServiceCommand<CullPlantIntent, DiscardPlantResult>(
+    'plants.cullPlant',
+    cullPlantSchema,
+    () => services().cullPlant,
+    onMissingHandler,
+  ),
   applyIrrigation: createServiceCommand(
     'plants.applyIrrigation',
     applyIrrigationSchema,
@@ -133,6 +167,8 @@ export const schemas = {
   addPlantingSchema,
   cullPlantingSchema,
   harvestPlantingSchema,
+  harvestPlantSchema,
+  cullPlantSchema,
   applyIrrigationSchema,
   applyFertilizerSchema,
   togglePlantingPlanSchema,

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -50,6 +50,8 @@ import {
   type AddPlantingIntent,
   type CullPlantingIntent,
   type HarvestPlantingIntent,
+  type HarvestPlantIntent,
+  type CullPlantIntent,
   type ApplyIrrigationIntent,
   type ApplyFertilizerIntent,
   type TogglePlantingPlanIntent,
@@ -123,6 +125,10 @@ import type {
 } from '@/engine/world/worldService.js';
 import type { DeviceGroupToggleResult } from '@/engine/devices/deviceGroupService.js';
 import type { PlantingPlanToggleResult } from '@/engine/plants/plantingPlanService.js';
+import type {
+  HarvestPlantResult,
+  DiscardPlantResult,
+} from '@/engine/plants/plantLifecycleService.js';
 import type { DifficultyConfig } from '@/data/configs/difficulty.js';
 
 const cloneState = <T>(value: T): T => {
@@ -184,11 +190,17 @@ export type {
   AddPlantingIntent,
   CullPlantingIntent,
   HarvestPlantingIntent,
+  HarvestPlantIntent,
+  CullPlantIntent,
   ApplyIrrigationIntent,
   ApplyFertilizerIntent,
   TogglePlantingPlanIntent,
   PlantIntentHandlers,
 } from './commands/plants.js';
+export type {
+  HarvestPlantResult,
+  DiscardPlantResult,
+} from '@/engine/plants/plantLifecycleService.js';
 export type {
   ScheduleScoutingIntent,
   ApplyTreatmentIntent,
@@ -304,6 +316,8 @@ export interface PlantIntentAPI {
   addPlanting(intent: AddPlantingIntent): Promise<CommandResult>;
   cullPlanting(intent: CullPlantingIntent): Promise<CommandResult>;
   harvestPlanting(intent: HarvestPlantingIntent): Promise<CommandResult>;
+  harvestPlant(intent: HarvestPlantIntent): Promise<CommandResult<HarvestPlantResult>>;
+  cullPlant(intent: CullPlantIntent): Promise<CommandResult<DiscardPlantResult>>;
   applyIrrigation(intent: ApplyIrrigationIntent): Promise<CommandResult>;
   applyFertilizer(intent: ApplyFertilizerIntent): Promise<CommandResult>;
   togglePlantingPlan(

--- a/src/backend/src/server/socketGateway.test.ts
+++ b/src/backend/src/server/socketGateway.test.ts
@@ -438,6 +438,8 @@ class StubFacade {
     addPlanting: (payload: unknown) => this.resolveIntent('plants', 'addPlanting', payload),
     cullPlanting: (payload: unknown) => this.resolveIntent('plants', 'cullPlanting', payload),
     harvestPlanting: (payload: unknown) => this.resolveIntent('plants', 'harvestPlanting', payload),
+    harvestPlant: (payload: unknown) => this.resolveIntent('plants', 'harvestPlant', payload),
+    cullPlant: (payload: unknown) => this.resolveIntent('plants', 'cullPlant', payload),
     applyIrrigation: (payload: unknown) => this.resolveIntent('plants', 'applyIrrigation', payload),
     applyFertilizer: (payload: unknown) => this.resolveIntent('plants', 'applyFertilizer', payload),
   };

--- a/src/backend/src/server/startServer.ts
+++ b/src/backend/src/server/startServer.ts
@@ -42,6 +42,7 @@ import { DeviceInstallationService } from '@/engine/devices/deviceInstallationSe
 import { DeviceRemovalService } from '@/engine/devices/deviceRemovalService.js';
 import { PlantingPlanService } from '@/engine/plants/plantingPlanService.js';
 import { PlantingService } from '@/engine/plants/plantingService.js';
+import { PlantLifecycleService } from '@/engine/plants/plantLifecycleService.js';
 import { JobMarketService } from '@/engine/workforce/jobMarketService.js';
 import type { UtilityPrices } from '@/data/schemas/index.js';
 
@@ -343,6 +344,7 @@ export const startBackendServer = async (
   const lightingCycleService = new LightingCycleService({ state });
   const plantingPlanService = new PlantingPlanService({ state, rng });
   const plantingService = new PlantingService({ state, rng, repository });
+  const plantLifecycleService = new PlantLifecycleService({ state, rng });
 
   facade.updateServices({
     config: {
@@ -404,6 +406,9 @@ export const startBackendServer = async (
           intent.startTick,
           context,
         ),
+      harvestPlant: (intent, context) =>
+        plantLifecycleService.harvestPlant(intent.plantId, context),
+      cullPlant: (intent, context) => plantLifecycleService.discardPlant(intent.plantId, context),
       togglePlantingPlan: (intent, context) =>
         plantingPlanService.togglePlantingPlan(intent.zoneId, intent.enabled, context),
     },

--- a/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/ExpenseBreakdown.test.tsx
@@ -22,6 +22,8 @@ const bridge: SimulationBridge = {
   },
   plants: {
     addPlanting: async () => ({ ok: true }),
+    harvestPlant: async () => ({ ok: true }),
+    cullPlant: async () => ({ ok: true }),
   },
   devices: {
     installDevice: async () => ({ ok: true }),

--- a/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
+++ b/src/frontend/src/components/finance/RevenueBreakdown.test.tsx
@@ -22,6 +22,8 @@ const bridge: SimulationBridge = {
   },
   plants: {
     addPlanting: async () => ({ ok: true }),
+    harvestPlant: async () => ({ ok: true }),
+    cullPlant: async () => ({ ok: true }),
   },
   devices: {
     installDevice: async () => ({ ok: true }),

--- a/src/frontend/src/components/finance/UtilityPricing.test.tsx
+++ b/src/frontend/src/components/finance/UtilityPricing.test.tsx
@@ -71,6 +71,8 @@ describe('UtilityPricing component', () => {
       },
       plants: {
         addPlanting: async () => ({ ok: true }),
+        harvestPlant: async () => ({ ok: true }),
+        cullPlant: async () => ({ ok: true }),
       },
       devices: {
         installDevice: async () => ({ ok: true }),

--- a/src/frontend/src/components/modals/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/ModalHost.test.tsx
@@ -61,6 +61,8 @@ describe('ModalHost', () => {
       },
       plants: {
         addPlanting: vi.fn(async () => ({ ok: true })),
+        harvestPlant: vi.fn(async () => ({ ok: true })),
+        cullPlant: vi.fn(async () => ({ ok: true })),
       },
       devices: {
         installDevice: vi.fn(async () => ({ ok: true })),

--- a/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/PlantAndDeviceModals.test.tsx
@@ -321,6 +321,8 @@ describe('Plant and Device modals', () => {
           ok: true,
           warnings: ['Capacity tight, monitor stress.'],
         })),
+        harvestPlant: vi.fn(async () => ({ ok: true })),
+        cullPlant: vi.fn(async () => ({ ok: true })),
       },
       devices: {
         installDevice: installDeviceMock as unknown as SimulationBridge['devices']['installDevice'],

--- a/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
+++ b/src/frontend/src/components/zone/EnvironmentPanel.test.tsx
@@ -16,7 +16,11 @@ const buildBridge = (overrides: Partial<SimulationBridge> = {}): SimulationBridg
   sendConfigUpdate: async () => ({ ok: true }),
   sendIntent: async () => ({ ok: true }),
   subscribeToUpdates: () => () => undefined,
-  plants: { addPlanting: async () => ({ ok: true }) },
+  plants: {
+    addPlanting: async () => ({ ok: true }),
+    harvestPlant: async () => ({ ok: true }),
+    cullPlant: async () => ({ ok: true }),
+  },
   devices: {
     installDevice: async () => ({ ok: true }),
     adjustLightingCycle: async () => ({ ok: true }),

--- a/src/frontend/src/facade/systemFacade.ts
+++ b/src/frontend/src/facade/systemFacade.ts
@@ -147,6 +147,34 @@ export interface PlantingResult {
   warnings?: string[];
 }
 
+export interface HarvestPlantOptions {
+  plantId: string;
+}
+
+export interface HarvestPlantResult {
+  plantId: string;
+  zoneId: string;
+  roomId: string;
+  structureId: string;
+  harvestBatchId: string;
+  weightGrams: number;
+  quality: number;
+  warnings?: string[];
+}
+
+export interface CullPlantOptions {
+  plantId: string;
+}
+
+export interface CullPlantResult {
+  plantId: string;
+  zoneId: string;
+  roomId: string;
+  structureId: string;
+  stage: string;
+  warnings?: string[];
+}
+
 export interface InstallDeviceOptions {
   targetId: string;
   deviceId: string;
@@ -193,6 +221,8 @@ export interface SimulationBridge {
   subscribeToUpdates: (handler: (update: SimulationUpdateEntry) => void) => () => void;
   plants: {
     addPlanting: (options: AddPlantingOptions) => Promise<CommandResponse<PlantingResult>>;
+    harvestPlant: (options: HarvestPlantOptions) => Promise<CommandResponse<HarvestPlantResult>>;
+    cullPlant: (options: CullPlantOptions) => Promise<CommandResponse<CullPlantResult>>;
   };
   devices: {
     installDevice: (
@@ -254,6 +284,30 @@ class SocketSystemFacade implements SimulationBridge {
         payload,
       };
       return this.sendIntent<PlantingResult>(intent);
+    },
+    harvestPlant: async (options: HarvestPlantOptions) => {
+      this.requireConnected();
+      const payload = {
+        plantId: options.plantId,
+      } satisfies FacadeIntentCommand['payload'];
+      const intent: FacadeIntentCommand = {
+        domain: 'plants',
+        action: 'harvestPlant',
+        payload,
+      };
+      return this.sendIntent<HarvestPlantResult>(intent);
+    },
+    cullPlant: async (options: CullPlantOptions) => {
+      this.requireConnected();
+      const payload = {
+        plantId: options.plantId,
+      } satisfies FacadeIntentCommand['payload'];
+      const intent: FacadeIntentCommand = {
+        domain: 'plants',
+        action: 'cullPlant',
+        payload,
+      };
+      return this.sendIntent<CullPlantResult>(intent);
     },
   };
 

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -19,7 +19,11 @@ const buildBridge = (overrides: Partial<SimulationBridge> = {}): SimulationBridg
   sendConfigUpdate: async () => ({ ok: true }),
   sendIntent: async () => ({ ok: true }),
   subscribeToUpdates: () => () => undefined,
-  plants: { addPlanting: async () => ({ ok: true }) },
+  plants: {
+    addPlanting: async () => ({ ok: true }),
+    harvestPlant: async () => ({ ok: true }),
+    cullPlant: async () => ({ ok: true }),
+  },
   devices: {
     installDevice: async () => ({ ok: true }),
     adjustLightingCycle: async () => ({ ok: true }),


### PR DESCRIPTION
## Summary
- add a plant lifecycle service that handles single-plant harvest and cull flows with zone safety checks and telemetry updates
- register harvest/cull intents across the backend facade, socket gateway, and documentation while wiring the server to the new service
- extend the frontend simulation bridge plus tests to expose typed harvest/cull helpers and keep fixtures in sync

## Testing
- pnpm run check *(fails: frontend eslint requires @eslint/js in this environment)*
- pnpm --filter @weebbreed/backend test -- --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d9c01ad5cc832586738b273f92e9f1