### PR TITLE
feat: add harvest management controls to zone plant table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Quellensichtung und Deprecation-Empfehlungen für Reservoir-Aufgaben (`docs/tasks/irrigation/phase0-alignment-report.md`).
 - Added an `isHarvestable` flag to plant snapshots, plumbing the backend UI snapshot,
   frontend types, fixtures, and store hydration so harvest readiness survives updates.
+- Introduced zone plant-table harvest management: a harvestable-only filter, per-plant
+  harvest/cull controls, and a batch "Harvest all" action that respects zone safety
+  restrictions, invokes the bridge intents, and keeps the list in sync.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- add a harvestable-only filter, per-plant Harvest/Trash actions, and a batch Harvest all control to the zone plant table
- respect zone safety restrictions, remove harvested plants locally, and keep the list width/virtualization balanced after adding the action column
- extend the ZoneView test suite and changelog coverage for the new controls

## Testing
- pnpm --dir src/frontend test -- --filter ZoneView

------
https://chatgpt.com/codex/tasks/task_e_68d9c40dc904832589c0d93a66644939