### PR TITLE
feat(frontend): confirm plant actions with toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced zone plant-table harvest management: a harvestable-only filter, per-plant
   harvest/cull controls, and a batch "Harvest all" action that respects zone safety
   restrictions, invokes the bridge intents, and keeps the list in sync.
+- Added a harvest/cull confirmation modal with toast feedback, wiring ZoneView actions,
+  facade mocks, and Vitest coverage to require confirmation and surface command
+  success or failure states.
 
 ### Changed
 

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ZoneView } from '@/views/ZoneView';
 import { PersonnelView } from '@/views/PersonnelView';
 import { FinanceView } from '@/views/FinanceView';
 import { ModalHost } from '@/components/modals/ModalHost';
+import { ToastViewport } from '@/components/feedback/ToastViewport';
 import { useSimulationBridge } from '@/hooks/useSimulationBridge';
 import { useNavigationStore } from '@/store/navigation';
 import { useSimulationStore } from '@/store/simulation';
@@ -51,6 +52,7 @@ const App = () => {
       <>
         <StartScreen bridge={bridge} />
         <ModalHost bridge={bridge} />
+        <ToastViewport />
       </>
     );
   }
@@ -60,6 +62,7 @@ const App = () => {
       <>
         <NewGameView bridge={bridge} />
         <ModalHost bridge={bridge} />
+        <ToastViewport />
       </>
     );
   }
@@ -68,6 +71,7 @@ const App = () => {
     <>
       <DashboardShell bridge={bridge}>{content}</DashboardShell>
       <ModalHost bridge={bridge} />
+      <ToastViewport />
     </>
   );
 };

--- a/src/frontend/src/components/feedback/ToastViewport.tsx
+++ b/src/frontend/src/components/feedback/ToastViewport.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+import cx from 'clsx';
+import { Icon } from '@/components/common/Icon';
+import { Button } from '@/components/primitives/Button';
+import { useUIStore, type ToastDescriptor } from '@/store/ui';
+
+const TONE_ICON: Record<ToastDescriptor['tone'], string> = {
+  success: 'check_circle',
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+};
+
+const TONE_CLASSES: Record<ToastDescriptor['tone'], string> = {
+  success: 'border-success/50 bg-success/10 text-success',
+  info: 'border-primary/40 bg-primary/10 text-primary',
+  warning: 'border-warning/50 bg-warning/10 text-warning',
+  error: 'border-danger/50 bg-danger/10 text-danger',
+};
+
+const DEFAULT_DURATION_MS = 6000;
+
+const ToastEntry = ({ toast }: { toast: ToastDescriptor }) => {
+  const dismissToast = useUIStore((state) => state.dismissToast);
+
+  useEffect(() => {
+    if (toast.durationMs === 0) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      dismissToast(toast.id);
+    }, toast.durationMs ?? DEFAULT_DURATION_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [dismissToast, toast.durationMs, toast.id]);
+
+  return (
+    <div
+      role="status"
+      className={cx(
+        'pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-2xl border bg-surface-elevated/95 p-4 shadow-lg backdrop-blur',
+        TONE_CLASSES[toast.tone],
+      )}
+      data-testid={`toast-${toast.tone}`}
+    >
+      <Icon name={TONE_ICON[toast.tone]} size={24} className="mt-0.5 flex-shrink-0" />
+      <div className="flex-1">
+        <p className="text-sm font-semibold text-text">{toast.title}</p>
+        {toast.description ? (
+          <p className="mt-1 text-sm text-text-muted">{toast.description}</p>
+        ) : null}
+      </div>
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label="Dismiss notification"
+        onClick={() => {
+          dismissToast(toast.id);
+        }}
+      >
+        <Icon name="close" size={18} />
+      </Button>
+    </div>
+  );
+};
+
+export const ToastViewport = () => {
+  const toasts = useUIStore((state) => state.toasts);
+
+  if (!toasts.length) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-6 z-[70] flex flex-col items-center gap-3 px-4 sm:items-end sm:px-6">
+      {toasts.map((toast) => (
+        <ToastEntry key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+};

--- a/src/frontend/src/components/modals/ConfirmPlantActionModal.tsx
+++ b/src/frontend/src/components/modals/ConfirmPlantActionModal.tsx
@@ -1,0 +1,209 @@
+import { useMemo, useState } from 'react';
+import { ModalFrame } from './ModalFrame';
+import { Button } from '@/components/primitives/Button';
+import { Icon } from '@/components/common/Icon';
+import { useSimulationStore } from '@/store/simulation';
+import { type SimulationBridge } from '@/facade/systemFacade';
+import type { PlantSnapshot } from '@/types/simulation';
+
+export interface ConfirmPlantActionContext {
+  action?: 'harvest' | 'cull';
+  plantIds?: string[];
+  zoneId?: string;
+  onConfirm?: () => Promise<boolean> | boolean;
+}
+
+interface ConfirmPlantActionModalProps {
+  bridge: SimulationBridge;
+  closeModal: () => void;
+  context?: Record<string, unknown>;
+}
+
+const resolveContext = (context?: Record<string, unknown>): ConfirmPlantActionContext => {
+  if (!context) {
+    return {};
+  }
+  const entries = context as ConfirmPlantActionContext & { plantId?: unknown };
+  const plantIds: string[] = [];
+  if (Array.isArray(entries.plantIds)) {
+    for (const value of entries.plantIds) {
+      if (typeof value === 'string') {
+        plantIds.push(value);
+      }
+    }
+  } else if (typeof entries.plantIds === 'string') {
+    plantIds.push(entries.plantIds);
+  }
+  if (!plantIds.length && typeof entries.plantId === 'string') {
+    plantIds.push(entries.plantId);
+  }
+  return {
+    action: entries.action,
+    plantIds,
+    zoneId: entries.zoneId,
+    onConfirm: entries.onConfirm,
+  };
+};
+
+const findPlants = (snapshotPlants: PlantSnapshot[], ids: string[]): PlantSnapshot[] => {
+  const idSet = new Set(ids);
+  return snapshotPlants.filter((plant) => idSet.has(plant.id));
+};
+
+const usePlantsForContext = (plantIds: string[], zoneId?: string) => {
+  return useSimulationStore(
+    (state) => {
+      const snapshot = state.snapshot;
+      if (!snapshot || !plantIds.length) {
+        return [] as PlantSnapshot[];
+      }
+      if (zoneId) {
+        const zone = snapshot.zones.find((entry) => entry.id === zoneId);
+        if (zone) {
+          return findPlants(zone.plants, plantIds);
+        }
+      }
+      for (const zone of snapshot.zones) {
+        const matches = findPlants(zone.plants, plantIds);
+        if (matches.length) {
+          return matches;
+        }
+      }
+      return [] as PlantSnapshot[];
+    },
+    (a, b) => {
+      if (a === b) {
+        return true;
+      }
+      if (a.length !== b.length) {
+        return false;
+      }
+      return a.every((plant, index) => plant.id === b[index]?.id);
+    },
+  );
+};
+
+export const ConfirmPlantActionModal = ({ closeModal, context }: ConfirmPlantActionModalProps) => {
+  const parsed = resolveContext(context);
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const plantIds = parsed.plantIds ?? [];
+  const plants = usePlantsForContext(plantIds, parsed.zoneId);
+  const action = parsed.action ?? 'harvest';
+  const actionVerb = action === 'cull' ? 'cull' : 'harvest';
+  const actionLabel = action === 'cull' ? 'Cull' : 'Harvest';
+  const plural = plantIds.length !== 1;
+
+  const details = useMemo(() => {
+    if (!plants.length) {
+      return null;
+    }
+    return plants.map((plant) => ({
+      id: plant.id,
+      label: plant.strainName || plant.id,
+      stage: plant.stage,
+      harvestable: plant.isHarvestable,
+    }));
+  }, [plants]);
+
+  const handleConfirm = async () => {
+    if (typeof parsed.onConfirm !== 'function') {
+      setFeedback('Command handler missing. Close the modal and try again.');
+      return;
+    }
+    if (!plantIds.length) {
+      setFeedback('Select at least one plant to continue.');
+      return;
+    }
+    setBusy(true);
+    setFeedback(null);
+    try {
+      const result = await parsed.onConfirm();
+      if (result === false) {
+        setFeedback('Action was not accepted. Review the toast notification for details.');
+        setBusy(false);
+        return;
+      }
+      closeModal();
+    } catch (error) {
+      console.error('Failed to confirm plant action', error);
+      setFeedback('Unexpected error while dispatching the command. Please retry in a moment.');
+      setBusy(false);
+    }
+  };
+
+  const disabled = busy || !plantIds.length;
+
+  return (
+    <ModalFrame
+      title={`${actionLabel} plant${plural ? 's' : ''}`}
+      subtitle={`Confirm ${actionVerb} command${plural ? 's' : ''}`}
+      onClose={() => {
+        if (!busy) {
+          closeModal();
+        }
+      }}
+    >
+      <div className="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning">
+        <div className="flex items-start gap-3">
+          <Icon name="report" className="mt-0.5" />
+          <div>
+            <p className="text-sm font-semibold text-warning">This action cannot be undone.</p>
+            <p className="text-sm text-warning/80">
+              {plural
+                ? `You are about to ${actionVerb} ${plantIds.length} plants. Their biomass and telemetry will be removed.`
+                : `You are about to ${actionVerb} this plant. Its biomass and telemetry will be removed.`}
+            </p>
+          </div>
+        </div>
+      </div>
+      {details && details.length ? (
+        <ul className="grid gap-2" data-testid="confirm-plant-action-list">
+          {details.map((plant) => (
+            <li
+              key={plant.id}
+              className="flex items-center justify-between rounded-xl border border-border/40 bg-surface-muted/30 px-4 py-3"
+            >
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-text">{plant.label}</span>
+                <span className="text-xs text-text-muted">{plant.stage || 'Stage unknown'}</span>
+              </div>
+              <span className="text-xs text-text-muted">{plant.id}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-warning" data-testid="confirm-plant-action-missing">
+          Plants could not be found in the current snapshot. Continue only if you are sure the
+          selection is correct.
+        </p>
+      )}
+      {feedback ? <p className="text-sm text-danger">{feedback}</p> : null}
+      <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            if (!busy) {
+              closeModal();
+            }
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          variant={action === 'cull' ? 'danger' : 'primary'}
+          onClick={() => {
+            void handleConfirm();
+          }}
+          disabled={disabled}
+          data-testid="confirm-plant-action-confirm"
+        >
+          {busy ? `${actionLabel}ing…` : actionLabel}
+        </Button>
+      </div>
+    </ModalFrame>
+  );
+};

--- a/src/frontend/src/components/modals/ModalHost.tsx
+++ b/src/frontend/src/components/modals/ModalHost.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { Button } from '@/components/primitives/Button';
 import { Icon } from '@/components/common/Icon';
 import { ModalFrame } from '@/components/modals/ModalFrame';
+import { ConfirmPlantActionModal } from './ConfirmPlantActionModal';
 import type {
   DeviceBlueprint,
   InstallDeviceOptions,
@@ -2430,6 +2431,9 @@ const modalRenderers: Record<
   ),
   tuneDevice: ({ bridge, closeModal, context }) => (
     <TuneDeviceModal bridge={bridge} closeModal={closeModal} context={context} />
+  ),
+  confirmPlantAction: ({ bridge, closeModal, context }) => (
+    <ConfirmPlantActionModal bridge={bridge} closeModal={closeModal} context={context} />
   ),
 };
 


### PR DESCRIPTION
## Summary
- add a toast viewport and confirmation modal to drive harvest/cull actions
- route ZoneView plant actions through the modal, surface toast feedback, and remove local plant pruning
- expand the UI store API plus modal/ZoneView tests to cover the new UX and bridge wiring

## Testing
- pnpm --filter @weebbreed/frontend test -- ZoneView PlantAndDeviceModals

------
https://chatgpt.com/codex/tasks/task_e_68d9c71980408325b69c60dde1e236d2