### PR TITLE
Call cull handler directly from zone plant action

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -648,20 +648,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                 icon={<Icon name="delete" size={16} />}
                 disabled={cullDisabled}
                 title={cullTitle}
-                onClick={() => {
-                  const context: ConfirmPlantActionContext = {
-                    action: 'cull',
-                    plantIds: [plant.id],
-                    zoneId: zone?.id,
-                    onConfirm: () => handleCull(plant.id),
-                  };
-                  openModal({
-                    id: `confirm-cull-${plant.id}`,
-                    type: 'confirmPlantAction',
-                    title: 'Confirm trash',
-                    context,
-                  });
-                }}
+                onClick={() => handleCull(plant.id)}
               >
                 Trash
               </Button>


### PR DESCRIPTION
## Summary
- call the zone plant cull handler directly when the Trash action is clicked

## Testing
- pnpm run check *(fails: frontend lint cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68d9cf68caa08325934ac4e3b6e59be6