### PR TITLE
Simplify harvest all action in zone view

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -983,20 +983,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                   data-testid="plant-harvest-all"
                   disabled={harvestAllDisabled}
                   title={harvestAllTitle ?? undefined}
-                  onClick={() => {
-                    const context: ConfirmPlantActionContext = {
-                      action: 'harvest',
-                      plantIds: harvestablePlantIds,
-                      zoneId: zone.id,
-                      onConfirm: () => handleHarvestAll(harvestablePlantIds),
-                    };
-                    openModal({
-                      id: `confirm-harvest-all-${zone.id}`,
-                      type: 'confirmPlantAction',
-                      title: 'Confirm harvest all',
-                      context,
-                    });
-                  }}
+                  onClick={() => handleHarvestAll(harvestablePlantIds)}
                 >
                   Harvest all
                 </Button>


### PR DESCRIPTION
## Summary
- trigger the harvest-all handler directly from the plants card action toolbar
- remove the unused confirmation modal wiring for the bulk harvest action

## Testing
- `pnpm run check` *(fails: missing @eslint/js dependency for frontend lint)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d004790c832588e34e5569d6d103