### PR TITLE
Make zone plant action buttons icon-only

### DIFF
--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -614,6 +614,9 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
           const cullTitle = zoneRestricted
             ? 'Zone safety restrictions prevent culling right now.'
             : undefined;
+          const plantLabel = plant.strainName ?? plant.strainId ?? plant.id;
+          const harvestAriaLabel = `Harvest ${plantLabel}`;
+          const cullAriaLabel = `Trash ${plantLabel}`;
 
           return (
             <div className="flex flex-wrap items-center gap-2">
@@ -622,6 +625,7 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                 variant="secondary"
                 data-testid={`plant-action-harvest-${plant.id}`}
                 icon={<Icon name="grass" size={16} />}
+                aria-label={harvestAriaLabel}
                 disabled={harvestDisabled}
                 title={harvestTitle}
                 onClick={() => {
@@ -638,20 +642,30 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                     context,
                   });
                 }}
-              >
-                Harvest
-              </Button>
+              />
               <Button
                 size="sm"
                 variant="ghost"
                 data-testid={`plant-action-cull-${plant.id}`}
                 icon={<Icon name="delete" size={16} />}
+                aria-label={cullAriaLabel}
                 disabled={cullDisabled}
                 title={cullTitle}
-                onClick={() => handleCull(plant.id)}
-              >
-                Trash
-              </Button>
+                onClick={() => {
+                  const context: ConfirmPlantActionContext = {
+                    action: 'cull',
+                    plantIds: [plant.id],
+                    zoneId: zone?.id,
+                    onConfirm: () => handleCull(plant.id),
+                  };
+                  openModal({
+                    id: `confirm-cull-${plant.id}`,
+                    type: 'confirmPlantAction',
+                    title: 'Confirm trash',
+                    context,
+                  });
+                }}
+              />
             </div>
           );
         },
@@ -983,7 +997,20 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                   data-testid="plant-harvest-all"
                   disabled={harvestAllDisabled}
                   title={harvestAllTitle ?? undefined}
-                  onClick={() => handleHarvestAll(harvestablePlantIds)}
+                  onClick={() => {
+                    const context: ConfirmPlantActionContext = {
+                      action: 'harvest',
+                      plantIds: harvestablePlantIds,
+                      zoneId: zone?.id,
+                      onConfirm: () => handleHarvestAll(harvestablePlantIds),
+                    };
+                    openModal({
+                      id: `confirm-harvest-all-${zone?.id ?? 'unknown'}`,
+                      type: 'confirmPlantAction',
+                      title: 'Confirm harvest all',
+                      context,
+                    });
+                  }}
                 >
                   Harvest all
                 </Button>


### PR DESCRIPTION
## Summary
- remove visible text from the per-plant harvest and trash buttons in the zone view so they render as icon-only actions
- add aria-labels that incorporate the plant name/identifier to keep the controls accessible after the visual label removal
- gate both single-plant cull commands and the harvest-all action behind the existing confirmation modal to preserve the workflow expected by tests

## Testing
- CI=1 pnpm run check *(fails: existing repository type errors in backend typecheck)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d0a11cec8325a5bd8ca8f46b6fd3