### PR TITLE
docs: log Tailwind baseline ahead of forest theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented the current Tailwind baseline (plugins, dark mode, CSS tokens) in
+  `docs/ui/themes/tailwind-baseline.md` to support upcoming theme work.
 - Dokumentiert den Umsetzungsplan für die Irrigation-&-Nutrient-Überarbeitung unter
   `docs/tasks/20250928-irrgitation-nutrient-overhaul.md`.
 - Implemented a device removal engine service that clears unsupported zone setpoints, emits

--- a/docs/ui/themes/tailwind-baseline.md
+++ b/docs/ui/themes/tailwind-baseline.md
@@ -1,0 +1,6 @@
+# Tailwind Baseline Theme Notes
+
+- **Tailwind config** – `src/frontend/tailwind.config.ts` keeps `darkMode: 'class'` and ships an empty `plugins` array, so utilities come from core Tailwind only (no DaisyUI).
+- **PostCSS** – `src/frontend/postcss.config.cjs` loads `tailwindcss` and `autoprefixer` without any DaisyUI preset wiring.
+- **Theme toggling** – `src/frontend/src/styles/tokens.css` defines the default dark palette on `:root` and a `.theme-light` override. Switching the class on the root element flips palettes while Tailwind reads the CSS variables through configured color tokens.
+- **Custom tokens** – The shared color tokens (`--color-surface`, `--color-text`, etc.) and layout token (`--sidebar-width`) feed both Tailwind (`theme.extend.colors`) and global styles (`src/frontend/src/index.css`).


### PR DESCRIPTION
## Summary
- capture the current Tailwind dark-mode/class setup and empty plugin list in `docs/ui/themes/tailwind-baseline.md`
- note how theme tokens are sourced from CSS variables so the upcoming forest-theme work can reference the baseline
- record the documentation addition in the changelog for future traceability

## Testing
- pnpm run check *(fails: existing @weebbreed/frontend lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d7e3825c8325babfc9cc9a0b2498