### PR TITLE
docs: outline forest theme integration

### DIFF
--- a/docs/ui/themes/forest-plan.md
+++ b/docs/ui/themes/forest-plan.md
@@ -1,0 +1,30 @@
+# Forest Theme Integration Plan
+
+## Decision Summary
+
+- **Chosen approach:** Factor the DaisyUI "forest" theme into a dedicated module at `src/frontend/src/themes/forest.ts` instead of embedding it directly in `tailwind.config.ts`.
+- **Rationale:**
+  - Keeps the Tailwind configuration lean and focused on build tooling while the theme data lives alongside other runtime UI assets, allowing React components and feature toggles to consume the same source of truth as the build step.【F:src/frontend/src/themes/forest.ts†L1-L86】
+  - The strongly typed export shields both Tailwind and runtime consumers from accidental drift in CSS custom property names, which is harder to enforce when the theme is copied into the config file as an inline literal.【F:src/frontend/src/themes/forest.ts†L1-L86】
+  - Consolidating the theme into an importable module mirrors how we already centralize color tokens for the default and `theme-light` schemes inside CSS, keeping future dark/light/forest switches symmetrical and easier to test.【F:src/frontend/src/styles/tokens.css†L1-L33】
+
+## Type & Module Sketch
+
+- `ThemeDefinition`: shared interface that captures the canonical name, color-scheme metadata, activating class name, and DaisyUI-compatible CSS custom properties. Tailwind and any runtime registries can rely on the interface to validate new themes at compile time.【F:src/frontend/src/themes/forest.ts†L33-L56】
+- `ForestThemeDefinition`/`forestTheme`: concrete export for the DaisyUI forest palette, including the exact custom properties DaisyUI exposes. The module ships both a named and default export for ergonomic imports (`import { forestTheme } ...` or `import forestTheme ...`).【F:src/frontend/src/themes/forest.ts†L58-L86】
+- Tailwind usage: `tailwind.config.ts` can import `{ forestTheme }` and hand its `cssVariables` bag to DaisyUI (or a custom plugin) without suppressing TypeScript warnings. Runtime toggles can reuse `forestTheme.className` to attach the right class to `document.documentElement`.
+
+## Coexistence with Existing Toggles
+
+- The current theme system defaults to the dark palette in `:root` and enables the light palette by toggling the `theme-light` class on `<html>`.【F:src/frontend/src/styles/tokens.css†L1-L33】【F:src/frontend/src/store/ui.ts†L89-L103】
+- We will extend the toggle logic to support `theme-forest` by:
+  1. Adding a new branch that removes both `theme-light` and `theme-forest` before applying the selected theme, keeping mutual exclusivity explicit.【F:src/frontend/src/store/ui.ts†L89-L103】
+  2. Mirroring the CSS variable overrides from `forestTheme.cssVariables` into a `.theme-forest { ... }` block (either generated at build-time or authored once), matching how `.theme-light` is layered today.【F:src/frontend/src/styles/tokens.css†L1-L33】
+  3. Ensuring the default (`:root`) remains a dark-first palette so toggling back from forest/light does not require a dedicated class.
+- Because `forestTheme` carries both `className` and `colorScheme`, runtime logic can set `document.documentElement.dataset.colorScheme` or adjust `color-scheme` values to align with accessibility requirements when the forest theme is active.
+
+## Next Steps
+
+1. Update `tailwind.config.ts` to import `{ forestTheme }` and hand its `cssVariables` to DaisyUI (or a future Tailwind plugin wrapper).
+2. Author the `.theme-forest` CSS overrides using the values in `forestTheme.cssVariables` so that toggling via DOM class mirrors the Tailwind preview.
+3. Extend the UI store to register `forestTheme.className` as an available option and persist the user choice alongside existing light/dark state.

--- a/src/frontend/src/themes/forest.ts
+++ b/src/frontend/src/themes/forest.ts
@@ -1,0 +1,96 @@
+export type ThemeColorScheme = 'light' | 'dark';
+
+export type ForestCssVariable =
+  | '--color-base-100'
+  | '--color-base-200'
+  | '--color-base-300'
+  | '--color-base-content'
+  | '--color-primary'
+  | '--color-primary-content'
+  | '--color-secondary'
+  | '--color-secondary-content'
+  | '--color-accent'
+  | '--color-accent-content'
+  | '--color-neutral'
+  | '--color-neutral-content'
+  | '--color-info'
+  | '--color-info-content'
+  | '--color-success'
+  | '--color-success-content'
+  | '--color-warning'
+  | '--color-warning-content'
+  | '--color-error'
+  | '--color-error-content'
+  | '--radius-selector'
+  | '--radius-field'
+  | '--radius-box'
+  | '--size-selector'
+  | '--size-field'
+  | '--border'
+  | '--depth'
+  | '--noise';
+
+export interface ThemeDefinition<VariableName extends string = string> {
+  /**
+   * Human-friendly identifier for runtime toggles and Tailwind plugins.
+   */
+  readonly name: string;
+  /**
+   * Indicates whether the theme should opt into prefers-color-scheme dark or light primitives.
+   */
+  readonly colorScheme: ThemeColorScheme;
+  /**
+   * CSS class appended to the document root to activate the theme tokens.
+   */
+  readonly className: string;
+  /**
+   * DaisyUI compatible variable bag. Keys should align with the exported CSS custom properties.
+   */
+  readonly cssVariables: Readonly<Record<VariableName, string>>;
+}
+
+export type ForestThemeDefinition = ThemeDefinition<ForestCssVariable> & {
+  readonly name: 'forest';
+  readonly colorScheme: 'dark';
+  readonly className: 'theme-forest';
+};
+
+export const forestTheme: ForestThemeDefinition = {
+  name: 'forest',
+  colorScheme: 'dark',
+  className: 'theme-forest',
+  cssVariables: {
+    '--color-base-100': '#030202',
+    '--color-base-200': '#020101',
+    '--color-base-300': '#010101',
+    '--color-base-content': '#979695',
+    '--color-primary': '#047a17',
+    '--color-primary-content': '#000000',
+    '--color-secondary': '#037a45',
+    '--color-secondary-content': '#000101',
+    '--color-accent': '#037a68',
+    '--color-accent-content': '#000101',
+    '--color-neutral': '#020907',
+    '--color-neutral-content': '#9ca6a2',
+    '--color-info': '#0077ff',
+    '--color-info-content': '#000000',
+    '--color-success': '#006628',
+    '--color-success-content': '#000000',
+    '--color-warning': '#ff8300',
+    '--color-warning-content': '#000000',
+    '--color-error': '#ff191e',
+    '--color-error-content': '#000000',
+    '--radius-selector': '1rem',
+    '--radius-field': '2rem',
+    '--radius-box': '1rem',
+    '--size-selector': '0.25rem',
+    '--size-field': '0.25rem',
+    '--border': '1px',
+    '--depth': '0',
+    '--noise': '0',
+  },
+} as const;
+
+export type ForestTheme = typeof forestTheme;
+
+export default forestTheme;


### PR DESCRIPTION
## Summary
- add a typed `forestTheme` module so Tailwind and runtime code can import the DaisyUI palette from one place
- document the forest theme rollout plan, including how it complements the existing `theme-light` toggle

## Testing
- pnpm -r lint
- pnpm exec prettier --check 'src/**/*.{ts,tsx,js,jsx,json,md,css,scss}' 'scripts/**/*.{ts,tsx,js,jsx,json,md}' 'tools/**/*.{ts,tsx,js,jsx,json,md}' '*.{json,md,cjs}'
- pnpm --filter @weebbreed/backend test -- --run --reporter=basic
- pnpm --filter @weebbreed/frontend test -- --run --reporter=basic
- pnpm --filter @weebbreed/backend typecheck *(fails: existing type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d9aae57c832588db7ccb161aaf9b