### PR TITLE
feat(frontend): integrate daisyui forest theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enabled the DaisyUI plugin with the forest theme as the default and dark
+  palette for the dashboard Tailwind pipeline.
 - Documented the current Tailwind baseline (plugins, dark mode, CSS tokens) in
   `docs/ui/themes/tailwind-baseline.md` to support upcoming theme work.
 - Dokumentiert den Umsetzungsplan für die Irrigation-&-Nutrient-Überarbeitung unter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      daisyui:
+        specifier: ^5.1.25
+        version: 5.1.25
       eslint:
         specifier: ^9.36.0
         version: 9.36.0(jiti@1.21.7)
@@ -1497,6 +1500,9 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  daisyui@5.1.25:
+    resolution: {integrity: sha512-LYOGVIzTCCucEFkKmdj0fxbHHPZ83fpkYD7jXYF3/7UwrUu68TtXkIdGtEXadzeqUT361hCe6cj5tBB/7mvszw==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -4751,6 +4757,8 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  daisyui@5.1.25: {}
 
   data-urls@5.0.0:
     dependencies:

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/parser": "^8.15.0",
     "@vitejs/plugin-react": "^5.0.3",
     "autoprefixer": "^10.4.21",
+    "daisyui": "^5.1.25",
     "eslint": "^9.36.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.31.0",

--- a/src/frontend/tailwind.config.ts
+++ b/src/frontend/tailwind.config.ts
@@ -1,7 +1,18 @@
 import type { Config } from 'tailwindcss';
 import defaultTheme from 'tailwindcss/defaultTheme';
+import daisyui from 'daisyui';
 
-const config: Config = {
+type DaisyUIConfig = {
+  themes?: Array<string | Record<string, unknown>> | false;
+  darkTheme?: string | false;
+  base?: boolean;
+  styled?: boolean;
+  utils?: boolean;
+  logs?: boolean;
+  themeRoot?: string;
+};
+
+const config = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   darkMode: 'class',
   theme: {
@@ -29,7 +40,16 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
-};
+  plugins: [daisyui],
+  daisyui: {
+    themes: ['forest --default --prefersdark'],
+    darkTheme: 'forest',
+    base: true,
+    styled: true,
+    utils: true,
+    logs: false,
+    themeRoot: ':root',
+  },
+} satisfies Config & { daisyui: DaisyUIConfig };
 
 export default config;


### PR DESCRIPTION
## Summary
- add DaisyUI as a frontend dev dependency and enable the plugin in the Tailwind configuration
- register the built-in forest theme as both the default and dark palette while keeping class-based dark mode
- document the Tailwind theming change in the changelog

## Testing
- pnpm run check *(fails: existing backend type errors in personnel/tasks fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68d9dcb527c88325a98c6bf075977f2b