### PR TITLE
refactor: align profit chart colors with theme tokens

### DIFF
--- a/docs/tasks/forest-theme-qa-checklist.md
+++ b/docs/tasks/forest-theme-qa-checklist.md
@@ -1,0 +1,11 @@
+# Forest Theme QA Checklist
+
+Use this checklist to verify the finance dashboard after the forest theme rolls out. Focus on visual regressions and token usage for the chart module that now relies on CSS variables instead of hard-coded hex values.
+
+- [ ] **Finance → ProfitChart**
+  - [ ] Revenue line renders with the success token color and keeps its 80% opacity overlay.
+  - [ ] Expenses line renders with the danger token color and keeps its 80% opacity overlay.
+  - [ ] Profit line and fill use the primary token color and remain legible against the muted surface background.
+  - [ ] Grid, labels, and growth metric badges remain readable in both default and light theme variants.
+
+Document any visual discrepancies in the QA report so the design system tokens can be updated if required.

--- a/src/frontend/src/components/finance/ProfitChart.tsx
+++ b/src/frontend/src/components/finance/ProfitChart.tsx
@@ -220,18 +220,30 @@ export const ProfitChart = ({
           )}
 
           {/* Revenue line */}
-          <path d={revenuePath} fill="none" stroke="#10b981" strokeWidth="0.5" opacity="0.8" />
+          <path
+            d={revenuePath}
+            fill="none"
+            stroke="rgb(var(--color-success))"
+            strokeWidth="0.5"
+            opacity="0.8"
+          />
 
           {/* Expenses line */}
-          <path d={expensePath} fill="none" stroke="#ef4444" strokeWidth="0.5" opacity="0.8" />
+          <path
+            d={expensePath}
+            fill="none"
+            stroke="rgb(var(--color-danger))"
+            strokeWidth="0.5"
+            opacity="0.8"
+          />
 
           {/* Profit line */}
-          <path d={profitPath} fill="none" stroke="#3b82f6" strokeWidth="0.8" />
+          <path d={profitPath} fill="none" stroke="rgb(var(--color-primary))" strokeWidth="0.8" />
 
           {/* Profit area fill */}
           <path
             d={`${profitPath} L 100 ${chartHeight} L 0 ${chartHeight} Z`}
-            fill="#3b82f6"
+            fill="rgb(var(--color-primary))"
             opacity="0.1"
           />
         </svg>


### PR DESCRIPTION
## Summary
- replace hardcoded stroke and fill colors in the profit chart with CSS token references
- add a QA checklist covering the profit chart visuals for the upcoming forest theme rollout

## Testing
- pnpm run check *(fails: @weebbreed/frontend lint cannot resolve @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e49402608325aa2c8a982e0958e3