### PR TITLE
feat(frontend): add weedbreed daisyui theme

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -4,6 +4,42 @@
 @tailwind components;
 @tailwind utilities;
 
+@plugin "daisyui";
+@plugin "daisyui/theme" {
+  name: 'weedbreed';
+  default: true;
+  prefersdark: true;
+  color-scheme: 'dark';
+  --color-base-100: oklch(20.84% 0.008 17.911);
+  --color-base-200: oklch(18.522% 0.007 17.911);
+  --color-base-300: oklch(16.203% 0.007 17.911);
+  --color-base-content: oklch(83.768% 0.001 17.911);
+  --color-primary: oklch(68.628% 0.185 148.958);
+  --color-primary-content: oklch(0% 0 0);
+  --color-secondary: oklch(69.776% 0.135 168.327);
+  --color-secondary-content: oklch(13.955% 0.027 168.327);
+  --color-accent: oklch(70.628% 0.119 185.713);
+  --color-accent-content: oklch(14.125% 0.023 185.713);
+  --color-neutral: oklch(30.698% 0.039 171.364);
+  --color-neutral-content: oklch(86.139% 0.007 171.364);
+  --color-info: oklch(72.06% 0.191 231.6);
+  --color-info-content: oklch(0% 0 0);
+  --color-success: oklch(64.8% 0.15 160);
+  --color-success-content: oklch(0% 0 0);
+  --color-warning: oklch(84.71% 0.199 83.87);
+  --color-warning-content: oklch(0% 0 0);
+  --color-error: oklch(71.76% 0.221 22.18);
+  --color-error-content: oklch(0% 0 0);
+  --radius-selector: 0.25rem;
+  --radius-field: 0.25rem;
+  --radius-box: 0.5rem;
+  --size-selector: 0.21875rem;
+  --size-field: 0.21875rem;
+  --border: 1.5px;
+  --depth: 1;
+  --noise: 0;
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
## Summary
- register DaisyUI in the frontend root stylesheet
- define the Weedbreed theme tokens to mirror the requested palette and radii defaults

## Testing
- pnpm run check *(fails: frontend lint cannot resolve @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f5b7ae4083258128ddaf6dfc1ec7