### PR TITLE
feat(frontend): activate Weedbreed theme

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en" class="theme-weedbreed">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -22,10 +22,14 @@ const App = () => {
   const theme = useUIStore((state) => state.theme);
 
   useEffect(() => {
+    const { classList } = document.documentElement;
+    classList.remove('theme-light', 'theme-forest', 'theme-weedbreed');
     if (theme === 'light') {
-      document.documentElement.classList.add('theme-light');
+      classList.add('theme-light');
+    } else if (theme === 'forest') {
+      classList.add('theme-forest');
     } else {
-      document.documentElement.classList.remove('theme-light');
+      classList.add('theme-weedbreed');
     }
   }, [theme]);
 

--- a/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
+++ b/src/frontend/src/components/modals/__tests__/ModalHost.test.tsx
@@ -62,7 +62,7 @@ describe('ModalHost pause safety', () => {
       activeModal: null,
       modalQueue: [],
       notificationsUnread: 0,
-      theme: 'dark',
+      theme: 'weedbreed',
     });
     useSimulationStore.getState().reset();
   });
@@ -74,7 +74,7 @@ describe('ModalHost pause safety', () => {
       activeModal: null,
       modalQueue: [],
       notificationsUnread: 0,
-      theme: 'dark',
+      theme: 'weedbreed',
     });
     useSimulationStore.getState().reset();
   });

--- a/src/frontend/src/store/ui.ts
+++ b/src/frontend/src/store/ui.ts
@@ -39,7 +39,7 @@ interface UIState {
   activeModal: ModalDescriptor | null;
   modalQueue: ModalDescriptor[];
   notificationsUnread: number;
-  theme: 'dark' | 'light' | 'forest';
+  theme: 'weedbreed' | 'forest' | 'light';
   toasts: ToastDescriptor[];
 }
 
@@ -67,7 +67,7 @@ export const useUIStore = create<UIState & UIActions>((set) => ({
   activeModal: null,
   modalQueue: [],
   notificationsUnread: 0,
-  theme: 'dark',
+  theme: 'weedbreed',
   toasts: [],
   openModal: (modal) =>
     set((state) => {
@@ -92,11 +92,13 @@ export const useUIStore = create<UIState & UIActions>((set) => ({
   setTheme: (theme) =>
     set(() => {
       const { classList } = document.documentElement;
-      classList.remove('theme-light', 'theme-forest');
+      classList.remove('theme-light', 'theme-forest', 'theme-weedbreed');
       if (theme === 'light') {
         classList.add('theme-light');
       } else if (theme === 'forest') {
         classList.add('theme-forest');
+      } else {
+        classList.add('theme-weedbreed');
       }
       return { theme };
     }),

--- a/src/frontend/src/styles/tokens.css
+++ b/src/frontend/src/styles/tokens.css
@@ -34,6 +34,22 @@
   --color-danger: 255 25 30;
 }
 
+.theme-weedbreed {
+  color-scheme: dark;
+  --color-surface: 7 20 15;
+  --color-surface-muted: 13 33 25;
+  --color-surface-elevated: 20 48 38;
+  --color-border: 39 85 71;
+  --color-primary: 4 122 23;
+  --color-primary-strong: 3 99 18;
+  --color-accent: 3 122 69;
+  --color-text: 233 247 239;
+  --color-text-muted: 156 166 162;
+  --color-success: 15 157 88;
+  --color-warning: 255 131 0;
+  --color-danger: 255 25 30;
+}
+
 .theme-light {
   color-scheme: light;
   --color-surface: 242 251 246;


### PR DESCRIPTION
## Summary
- default the dashboard markup to the Weedbreed DaisyUI theme and provide matching CSS tokens
- update the UI store and runtime theme effect to toggle the Weedbreed class alongside light and forest modes
- align ModalHost tests with the new Weedbreed default theme selection

## Testing
- pnpm lint
- pnpm exec prettier --log-level=error --check 'src/**/*.{ts,tsx,js,jsx,json,md,css,scss}' 'scripts/**/*.{ts,tsx,js,jsx,json,md}' 'tools/**/*.{ts,tsx,js,jsx,json,md}' '*.{json,md,cjs}'
- pnpm --filter @weebreed/backend test -- --reporter=basic
- pnpm vitest run components/modals/__tests__/ModalHost.test.tsx --reporter=basic
- pnpm --filter @weebreed/backend typecheck *(fails: existing repository type errors)*
- pnpm validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d9f93554d08325b95ee84f96fe0b77