### PR TITLE
Remove zone health card from Zone Detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the zone "Health" summary card from the Zone Detail view to declutter the
+  plants panel.
 - Collapsed zone device groups by default behind accessible toggle buttons in
   `ZoneView`, surfacing icons and coverage for the expanded state while
   extending Vitest coverage for the new behaviour.

--- a/src/frontend/src/views/ZoneView.tsx
+++ b/src/frontend/src/views/ZoneView.tsx
@@ -1248,43 +1248,6 @@ export const ZoneView = ({ bridge }: { bridge: SimulationBridge }) => {
                 No plants assigned to this zone yet. Use "Plant zone" to schedule a new batch.
               </p>
             ) : null}
-            <div
-              className="mt-4 grid gap-3 rounded-2xl border border-border/30 bg-surface-muted/40 p-4"
-              data-testid="zone-health-summary"
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                  <span className="text-xs uppercase tracking-wide text-text-muted">Health</span>
-                  <span className="text-sm font-semibold text-text">
-                    Disease &amp; treatment overview
-                  </span>
-                </div>
-              </div>
-              <div className="grid gap-2 text-sm text-text-muted">
-                <div className="flex items-center justify-between">
-                  <span>Diseases</span>
-                  <Badge tone={zone.health.diseases ? 'warning' : 'success'}>
-                    {zone.health.diseases}
-                  </Badge>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span>Pests</span>
-                  <Badge tone={zone.health.pests ? 'warning' : 'success'}>
-                    {zone.health.pests}
-                  </Badge>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span>Pending treatments</span>
-                  <Badge tone={zone.health.pendingTreatments ? 'warning' : 'default'}>
-                    {zone.health.pendingTreatments}
-                  </Badge>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span>Applied treatments</span>
-                  <Badge tone="default">{zone.health.appliedTreatments}</Badge>
-                </div>
-              </div>
-            </div>
           </Card>
           <Card
             title="Devices"

--- a/src/frontend/src/views/__tests__/ZoneView.test.tsx
+++ b/src/frontend/src/views/__tests__/ZoneView.test.tsx
@@ -846,7 +846,7 @@ describe('ZoneView', () => {
     expect(trashButton).toBeDisabled();
   });
 
-  it('renders health summary within the plants card and removes the standalone health card', async () => {
+  it('does not render the health summary card', async () => {
     const bridge = buildBridge();
 
     act(() => {
@@ -862,35 +862,10 @@ describe('ZoneView', () => {
 
     render(<ZoneView bridge={bridge} />);
 
-    const summaryHeadings = await screen.findAllByText('Disease & treatment overview');
-    const summaryHeading = summaryHeadings[0]!;
-    const healthSummary = summaryHeading.closest('div[data-testid="zone-health-summary"]');
-    expect(healthSummary).not.toBeNull();
+    await screen.findByTestId('zone-plants-card');
 
-    const plantsCard = summaryHeading.closest('[data-testid="zone-plants-card"]');
-    expect(plantsCard).not.toBeNull();
-    expect(
-      within(plantsCard as HTMLElement).getByRole('heading', { name: 'Plants' }),
-    ).toBeInTheDocument();
-
-    const labels = ['Diseases', 'Pests', 'Pending treatments', 'Applied treatments'];
-    for (const label of labels) {
-      expect(within(healthSummary as HTMLElement).getByText(label)).toBeInTheDocument();
-    }
-
-    const expectRowValue = (label: string, value: string) => {
-      const row = within(healthSummary as HTMLElement)
-        .getByText(label)
-        .closest('div');
-      expect(row).not.toBeNull();
-      expect(row).toHaveTextContent(value);
-    };
-
-    expectRowValue('Diseases', String(zone.health.diseases));
-    expectRowValue('Pests', String(zone.health.pests));
-    expectRowValue('Pending treatments', String(zone.health.pendingTreatments));
-    expectRowValue('Applied treatments', String(zone.health.appliedTreatments));
-
+    expect(screen.queryByTestId('zone-health-summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disease & treatment overview')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Health' })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- remove the zone Health summary card from the Zone Detail plants panel
- update the ZoneView test to assert the health card is no longer rendered
- document the UI simplification in the changelog

## Testing
- pnpm --filter @weebbreed/frontend test -- --runTestsByPath src/frontend/src/views/__tests__/ZoneView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da0147e0bc8325b56af58c1455a877