### PR TITLE
feat: add reusable substrate and container blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a harvest/cull confirmation modal with toast feedback, wiring ZoneView actions,
   facade mocks, and Vitest coverage to require confirmation and surface command
   success or failure states.
+- Added substrate and container blueprint collections with dedicated schemas, loader
+  cross-checks, repository helpers, and documentation updates so cultivation methods
+  reference shared consumables by slug instead of embedding media/container payloads.
 
 ### Changed
 

--- a/data/blueprints/containers/pot_10l.json
+++ b/data/blueprints/containers/pot_10l.json
@@ -1,0 +1,11 @@
+{
+  "id": "0c48f3e3-2c19-4be4-86ea-4de97f5aa51e",
+  "slug": "pot-10l",
+  "kind": "Container",
+  "name": "10 L Pot",
+  "type": "pot",
+  "volumeInLiters": 10,
+  "footprintArea": 0.25,
+  "reusableCycles": 3,
+  "packingDensity": 0.9
+}

--- a/data/blueprints/containers/pot_11l.json
+++ b/data/blueprints/containers/pot_11l.json
@@ -1,0 +1,11 @@
+{
+  "id": "d9267b6f-41f3-4e91-95b8-5bd7be381d3f",
+  "slug": "pot-11l",
+  "kind": "Container",
+  "name": "11 L Pot",
+  "type": "pot",
+  "volumeInLiters": 11,
+  "footprintArea": 0.2,
+  "reusableCycles": 6,
+  "packingDensity": 0.95
+}

--- a/data/blueprints/containers/pot_25l.json
+++ b/data/blueprints/containers/pot_25l.json
@@ -1,0 +1,11 @@
+{
+  "id": "9fb62d74-df4e-4e74-a0fb-77fa1f21d3ef",
+  "slug": "pot-25l",
+  "kind": "Container",
+  "name": "25 L Pot",
+  "type": "pot",
+  "volumeInLiters": 25,
+  "footprintArea": 0.3,
+  "reusableCycles": 6,
+  "packingDensity": 0.9
+}

--- a/data/blueprints/cultivationMethods/basic_soil_pot.json
+++ b/data/blueprints/cultivationMethods/basic_soil_pot.json
@@ -10,19 +10,10 @@
   "areaPerPlant": 0.5,
   "minimumSpacing": 0.5,
   "maxCycles": 1,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 2.5,
-    "maxCycles": 1
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 10,
-    "footprintArea": 0.25,
-    "reusableCycles": 3,
-    "costPerUnit": 1.5,
-    "packingDensity": 0.9
-  },
+  "compatibleSubstrateSlugs": ["soil-single-cycle"],
+  "substrateCostPerSquareMeter": 2.5,
+  "compatibleContainerSlugs": ["pot-10l"],
+  "containerCostPerUnit": 1.5,
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {

--- a/data/blueprints/cultivationMethods/scrog.json
+++ b/data/blueprints/cultivationMethods/scrog.json
@@ -10,19 +10,10 @@
   "areaPerPlant": 1.0,
   "minimumSpacing": 0.8,
   "maxCycles": 4,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 3.5,
-    "maxCycles": 2
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 25,
-    "footprintArea": 0.3,
-    "reusableCycles": 6,
-    "costPerUnit": 4.0,
-    "packingDensity": 0.9
-  },
+  "compatibleSubstrateSlugs": ["soil-multi-cycle"],
+  "substrateCostPerSquareMeter": 3.5,
+  "compatibleContainerSlugs": ["pot-25l"],
+  "containerCostPerUnit": 4.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {

--- a/data/blueprints/cultivationMethods/sog.json
+++ b/data/blueprints/cultivationMethods/sog.json
@@ -10,19 +10,10 @@
   "areaPerPlant": 0.25,
   "minimumSpacing": 0.25,
   "maxCycles": 2,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 3.5,
-    "maxCycles": 2
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 11,
-    "footprintArea": 0.2,
-    "reusableCycles": 6,
-    "costPerUnit": 2.0,
-    "packingDensity": 0.95
-  },
+  "compatibleSubstrateSlugs": ["soil-multi-cycle"],
+  "substrateCostPerSquareMeter": 3.5,
+  "compatibleContainerSlugs": ["pot-11l"],
+  "containerCostPerUnit": 2.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {

--- a/data/blueprints/substrates/soil_multi_cycle.json
+++ b/data/blueprints/substrates/soil_multi_cycle.json
@@ -1,0 +1,8 @@
+{
+  "id": "ebdb6d5e-fb3d-4db2-90a4-8e6c5be137f4",
+  "slug": "soil-multi-cycle",
+  "kind": "Substrate",
+  "name": "Multi-Cycle Soil Mix",
+  "type": "soil",
+  "maxCycles": 2
+}

--- a/data/blueprints/substrates/soil_single_cycle.json
+++ b/data/blueprints/substrates/soil_single_cycle.json
@@ -1,0 +1,8 @@
+{
+  "id": "04c8b1a5-09cc-4d86-8dc6-9007a64de6f2",
+  "slug": "soil-single-cycle",
+  "kind": "Substrate",
+  "name": "Single-Cycle Soil Mix",
+  "type": "soil",
+  "maxCycles": 1
+}

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -158,7 +158,7 @@ Declares physical equipment (lights, HVAC, CO₂, dehumidifiers, fans, furniture
 
 ### Purpose
 
-Defines planting density, substrate/container baseline, setup costs, and phase suitability.
+Defines planting density, compatible substrate/container blueprints, setup costs, and phase suitability.
 
 ### Schema
 
@@ -169,10 +169,51 @@ Defines planting density, substrate/container baseline, setup costs, and phase s
 - `minimumSpacing?: number (m)` — Optional geometric limit.
 - `laborIntensity?: number (0–1)` — Affects labor time multipliers.
 - `setupCost?: number` — Currency-neutral.
-- `substrate?: { type: string, costPerSquareMeter?: number }`
-- `containerSpec?: { volume_L: number, costPerUnit?: number }`
+- `compatibleSubstrateSlugs?: string[]` — Slug references into `/data/blueprints/substrates`.
+- `substrateCostPerSquareMeter?: number` — Baseline media cost for the default substrate option.
+- `compatibleContainerSlugs?: string[]` — Slug references into `/data/blueprints/containers`.
+- `containerCostPerUnit?: number` — Baseline container cost for the default container option.
 - `compatibility?: { strainTags?: string[] }`
 - `recommendedPhases?: string[]`
+- `meta?: object`
+
+---
+
+## 3a) Substrates — `/data/blueprints/substrates/*.json`
+
+### Purpose
+
+Declares reusable substrate/media options that cultivation methods can reference by slug.
+
+### Schema
+
+- `id: string (UUID v4)`
+- `slug: string` — Lowercase `a–z0–9-` slug, stable across releases.
+- `kind?: string` — Defaults to `"Substrate"`.
+- `name: string`
+- `type: string` — Descriptive category (e.g., `"soil"`, `"coco"`, `"rockwool"`).
+- `maxCycles?: number` — Number of reuse cycles before replacement.
+- `meta?: object`
+
+---
+
+## 3b) Containers — `/data/blueprints/containers/*.json`
+
+### Purpose
+
+Captures reusable container geometries and limits referenced by cultivation methods.
+
+### Schema
+
+- `id: string (UUID v4)`
+- `slug: string` — Lowercase `a–z0–9-` slug, stable across releases.
+- `kind?: string` — Defaults to `"Container"`.
+- `name: string`
+- `type: string` — Container form (e.g., `"pot"`, `"tray"`).
+- `volumeInLiters?: number`
+- `footprintArea?: number (m²)`
+- `reusableCycles?: number`
+- `packingDensity?: number`
 - `meta?: object`
 
 ---

--- a/docs/addendum/all-json.md
+++ b/docs/addendum/all-json.md
@@ -12,23 +12,22 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "name": "Basic Soil Pot",
   "setupCost": 2.0,
   "laborIntensity": 0.1,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 0.35
+  },
   "areaPerPlant": 0.5,
   "minimumSpacing": 0.5,
   "maxCycles": 1,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 2.5,
-    "maxCycles": 1
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 10,
-    "footprintArea": 0.25,
-    "reusableCycles": 3,
-    "costPerUnit": 1.5,
-    "packingDensity": 0.9
-  },
+  "compatibleSubstrateSlugs": ["soil-single-cycle"],
+  "substrateCostPerSquareMeter": 2.5,
+  "compatibleContainerSlugs": ["pot-10l"],
+  "containerCostPerUnit": 1.5,
   "strainTraitCompatibility": {},
+  "envBias": {},
+  "capacityHints": {
+    "plantsPer_m2": 4,
+    "canopyHeight_m": 1.2
+  },
   "idealConditions": {
     "idealTemperature": [20, 28],
     "idealHumidity": [0.5, 0.7]
@@ -50,22 +49,16 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "name": "Screen of Green",
   "setupCost": 15.0,
   "laborIntensity": 0.7,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 1.2
+  },
   "areaPerPlant": 1.0,
   "minimumSpacing": 0.8,
   "maxCycles": 4,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 3.5,
-    "maxCycles": 2
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 25,
-    "footprintArea": 0.3,
-    "reusableCycles": 6,
-    "costPerUnit": 4.0,
-    "packingDensity": 0.9
-  },
+  "compatibleSubstrateSlugs": ["soil-multi-cycle"],
+  "substrateCostPerSquareMeter": 3.5,
+  "compatibleContainerSlugs": ["pot-25l"],
+  "containerCostPerUnit": 4.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {
@@ -77,6 +70,14 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
         "min": 0.7
       }
     }
+  },
+  "envBias": {
+    "temp_C": 0.5,
+    "co2_ppm": 50
+  },
+  "capacityHints": {
+    "plantsPer_m2": 2,
+    "canopyHeight_m": 0.8
   },
   "idealConditions": {
     "idealTemperature": [21, 27],
@@ -107,22 +108,16 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "name": "Sea of Green",
   "setupCost": 10.0,
   "laborIntensity": 0.4,
+  "laborProfile": {
+    "hoursPerPlantPerWeek": 0.65
+  },
   "areaPerPlant": 0.25,
   "minimumSpacing": 0.25,
   "maxCycles": 2,
-  "substrate": {
-    "type": "soil",
-    "costPerSquareMeter": 3.5,
-    "maxCycles": 2
-  },
-  "containerSpec": {
-    "type": "pot",
-    "volumeInLiters": 11,
-    "footprintArea": 0.2,
-    "reusableCycles": 6,
-    "costPerUnit": 2.0,
-    "packingDensity": 0.95
-  },
+  "compatibleSubstrateSlugs": ["soil-multi-cycle"],
+  "substrateCostPerSquareMeter": 3.5,
+  "compatibleContainerSlugs": ["pot-11l"],
+  "containerCostPerUnit": 2.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {
@@ -141,6 +136,14 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
       }
     }
   },
+  "envBias": {
+    "vpd_kPa": 0.1,
+    "rh_frac": -0.05
+  },
+  "capacityHints": {
+    "plantsPer_m2": 18,
+    "canopyHeight_m": 0.6
+  },
   "idealConditions": {
     "idealTemperature": [22, 28],
     "idealHumidity": [0.5, 0.65]
@@ -154,6 +157,80 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
       "Not suitable for large or tall plants"
     ]
   }
+}
+```
+
+## /data/blueprints/substrates/soil_single_cycle.json
+
+```json
+{
+  "id": "04c8b1a5-09cc-4d86-8dc6-9007a64de6f2",
+  "slug": "soil-single-cycle",
+  "kind": "Substrate",
+  "name": "Single-Cycle Soil Mix",
+  "type": "soil",
+  "maxCycles": 1
+}
+```
+
+## /data/blueprints/substrates/soil_multi_cycle.json
+
+```json
+{
+  "id": "ebdb6d5e-fb3d-4db2-90a4-8e6c5be137f4",
+  "slug": "soil-multi-cycle",
+  "kind": "Substrate",
+  "name": "Multi-Cycle Soil Mix",
+  "type": "soil",
+  "maxCycles": 2
+}
+```
+
+## /data/blueprints/containers/pot_10l.json
+
+```json
+{
+  "id": "0c48f3e3-2c19-4be4-86ea-4de97f5aa51e",
+  "slug": "pot-10l",
+  "kind": "Container",
+  "name": "10 L Pot",
+  "type": "pot",
+  "volumeInLiters": 10,
+  "footprintArea": 0.25,
+  "reusableCycles": 3,
+  "packingDensity": 0.9
+}
+```
+
+## /data/blueprints/containers/pot_11l.json
+
+```json
+{
+  "id": "d9267b6f-41f3-4e91-95b8-5bd7be381d3f",
+  "slug": "pot-11l",
+  "kind": "Container",
+  "name": "11 L Pot",
+  "type": "pot",
+  "volumeInLiters": 11,
+  "footprintArea": 0.2,
+  "reusableCycles": 6,
+  "packingDensity": 0.95
+}
+```
+
+## /data/blueprints/containers/pot_25l.json
+
+```json
+{
+  "id": "9fb62d74-df4e-4e74-a0fb-77fa1f21d3ef",
+  "slug": "pot-25l",
+  "kind": "Container",
+  "name": "25 L Pot",
+  "type": "pot",
+  "volumeInLiters": 25,
+  "footprintArea": 0.3,
+  "reusableCycles": 6,
+  "packingDensity": 0.9
 }
 ```
 

--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -73,7 +73,15 @@ The engine core owns the tick scheduler, orchestrates subsystem execution, and k
 
 ### 4.2 Cultivation Methods
 
-Cultivation method templates include `id`, `kind`, `name`, `setupCost` (EUR per installation), `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and `maxCycles` (count). Nested blocks describe `substrate` (type, `costPerSquareMeter`, `maxCycles`) and `containerSpec` (type, `volumeInLiters`, `footprintArea`, `reusableCycles`, `costPerUnit`, `packingDensity`). Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
+Cultivation method templates include `id`, `kind`, `name`, `setupCost` (EUR per installation), `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and `maxCycles` (count). Media and container options are declared via `compatibleSubstrateSlugs` and `compatibleContainerSlugs`, referencing the dedicated consumable blueprints, while `substrateCostPerSquareMeter` and `containerCostPerUnit` record the baseline economics for the default pairing. Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
+
+#### Substrate Blueprints
+
+`/data/blueprints/substrates` holds reusable media definitions with stable `id`/`slug` pairs, media `type`, and optional `maxCycles`. Cultivation methods reference these via their slug arrays so designers can share a single substrate definition across multiple methods.【F:data/blueprints/substrates/soil_multi_cycle.json†L1-L7】
+
+#### Container Blueprints
+
+`/data/blueprints/containers` captures reusable vessel geometries (`volumeInLiters`, `footprintArea`, `reusableCycles`, `packingDensity`) with slug identifiers, allowing consistent reuse while keeping per-method pricing separate.【F:data/blueprints/containers/pot_25l.json†L1-L9】
 
 ### 4.3 Strain Blueprints
 

--- a/src/backend/src/data/dataLoader.test.ts
+++ b/src/backend/src/data/dataLoader.test.ts
@@ -14,11 +14,17 @@ describe('loadBlueprintData', () => {
     const result = await loadBlueprintData(fixtureDataDirectory);
 
     const cultivationMethods = result.data.cultivationMethods;
+    const substrates = result.data.substrates;
+    const containers = result.data.containers;
     expect(cultivationMethods.size).toBeGreaterThan(0);
+    expect(substrates.size).toBeGreaterThan(0);
+    expect(containers.size).toBeGreaterThan(0);
 
     const scrog = cultivationMethods.get('41229377-ef2d-4723-931f-72eea87d7a62');
     expect(scrog?.strainTraitCompatibility?.preferred?.['genotype.sativa']?.min).toBe(0.5);
     expect(scrog?.strainTraitCompatibility?.conflicting?.['genotype.indica']?.min).toBe(0.7);
+    expect(scrog?.compatibleContainerSlugs).toContain('pot-25l');
+    expect(scrog?.compatibleSubstrateSlugs).toContain('soil-multi-cycle');
 
     const sog = cultivationMethods.get('659ba4d7-a5fc-482e-98d4-b614341883ac');
     expect(sog?.strainTraitCompatibility?.preferred?.['photoperiod.vegetationTime']?.max).toBe(
@@ -27,5 +33,7 @@ describe('loadBlueprintData', () => {
     expect(sog?.strainTraitCompatibility?.conflicting?.['photoperiod.vegetationTime']?.min).toBe(
       2_419_200,
     );
+    expect(sog?.compatibleContainerSlugs).toContain('pot-11l');
+    expect(sog?.compatibleSubstrateSlugs).toContain('soil-multi-cycle');
   });
 });

--- a/src/backend/src/data/schemas/containerBlueprintSchema.ts
+++ b/src/backend/src/data/schemas/containerBlueprintSchema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const containerBlueprintSchema = z
+  .object({
+    id: z.string().uuid(),
+    slug: z.string().min(1).regex(slugPattern, {
+      message: 'slug must be lowercase and may include numbers or dashes only.',
+    }),
+    kind: z.string().default('Container'),
+    name: z.string().min(1),
+    type: z.string().min(1),
+    volumeInLiters: z.number().positive().optional(),
+    footprintArea: z.number().positive().optional(),
+    reusableCycles: z.number().int().min(0).optional(),
+    packingDensity: z.number().positive().optional(),
+  })
+  .passthrough();
+
+export type ContainerBlueprint = z.infer<typeof containerBlueprintSchema>;

--- a/src/backend/src/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/src/data/schemas/cultivationMethodSchema.ts
@@ -26,25 +26,10 @@ export const cultivationMethodSchema = z
     areaPerPlant: z.number(),
     minimumSpacing: z.number(),
     maxCycles: z.number().int().min(0).optional(),
-    substrate: z
-      .object({
-        type: z.string(),
-        costPerSquareMeter: z.number().optional(),
-        maxCycles: z.number().optional(),
-      })
-      .passthrough()
-      .optional(),
-    containerSpec: z
-      .object({
-        type: z.string(),
-        volumeInLiters: z.number().optional(),
-        footprintArea: z.number().optional(),
-        reusableCycles: z.number().optional(),
-        costPerUnit: z.number().optional(),
-        packingDensity: z.number().optional(),
-      })
-      .passthrough()
-      .optional(),
+    compatibleSubstrateSlugs: z.array(z.string().min(1)).optional(),
+    compatibleContainerSlugs: z.array(z.string().min(1)).optional(),
+    substrateCostPerSquareMeter: z.number().optional(),
+    containerCostPerUnit: z.number().optional(),
     strainTraitCompatibility: strainTraitCompatibilitySchema.optional(),
     envBias: z
       .object({

--- a/src/backend/src/data/schemas/index.ts
+++ b/src/backend/src/data/schemas/index.ts
@@ -3,3 +3,5 @@ export * from './deviceSchema.js';
 export * from './cultivationMethodSchema.js';
 export * from './priceSchemas.js';
 export * from './roomPurposeSchema.js';
+export * from './substrateBlueprintSchema.js';
+export * from './containerBlueprintSchema.js';

--- a/src/backend/src/data/schemas/substrateBlueprintSchema.ts
+++ b/src/backend/src/data/schemas/substrateBlueprintSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const substrateBlueprintSchema = z
+  .object({
+    id: z.string().uuid(),
+    slug: z.string().min(1).regex(slugPattern, {
+      message: 'slug must be lowercase and may include numbers or dashes only.',
+    }),
+    kind: z.string().default('Substrate'),
+    name: z.string().min(1),
+    type: z.string().min(1),
+    maxCycles: z.number().int().min(0).optional(),
+  })
+  .passthrough();
+
+export type SubstrateBlueprint = z.infer<typeof substrateBlueprintSchema>;

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -5,6 +5,8 @@ import type {
   StrainBlueprint,
   StrainPriceEntry,
   UtilityPrices,
+  SubstrateBlueprint,
+  ContainerBlueprint,
 } from '@/data/schemas/index.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type { StructureBlueprint } from '@/state/models.js';
@@ -102,6 +104,33 @@ export const createStrainBlueprint = (
   ...overrides,
 });
 
+export const createSubstrateBlueprint = (
+  overrides: Partial<SubstrateBlueprint> = {},
+): SubstrateBlueprint => ({
+  id: '55555555-5555-4555-8555-555555555555',
+  slug: 'test-substrate',
+  kind: 'Substrate',
+  name: 'Test Substrate',
+  type: 'soil',
+  maxCycles: 2,
+  ...overrides,
+});
+
+export const createContainerBlueprint = (
+  overrides: Partial<ContainerBlueprint> = {},
+): ContainerBlueprint => ({
+  id: '66666666-6666-4666-8666-666666666666',
+  slug: 'test-container',
+  kind: 'Container',
+  name: 'Test Container',
+  type: 'pot',
+  volumeInLiters: 12,
+  footprintArea: 0.3,
+  reusableCycles: 5,
+  packingDensity: 0.9,
+  ...overrides,
+});
+
 export const createCultivationMethodBlueprint = (
   overrides: Partial<CultivationMethodBlueprint> = {},
 ): CultivationMethodBlueprint => ({
@@ -112,7 +141,10 @@ export const createCultivationMethodBlueprint = (
   laborIntensity: 0.6,
   areaPerPlant: 1.6,
   minimumSpacing: 0.4,
-  containerSpec: { type: 'pot', volumeInLiters: 12 },
+  compatibleSubstrateSlugs: ['test-substrate'],
+  compatibleContainerSlugs: ['test-container'],
+  substrateCostPerSquareMeter: 2.5,
+  containerCostPerUnit: 8.5,
   meta: {},
   ...overrides,
 });
@@ -180,6 +212,8 @@ interface RepositoryStubOptions {
   strains?: StrainBlueprint[];
   cultivationMethods?: CultivationMethodBlueprint[];
   devices?: DeviceBlueprint[];
+  substrates?: SubstrateBlueprint[];
+  containers?: ContainerBlueprint[];
   devicePrices?: Map<string, DevicePriceEntry>;
   strainPrices?: Map<string, StrainPriceEntry>;
   utilityPrices?: UtilityPrices;
@@ -197,6 +231,8 @@ export const createBlueprintRepositoryStub = (
 ): BlueprintRepository => {
   const strains = options.strains ?? [createStrainBlueprint()];
   const methods = options.cultivationMethods ?? [createCultivationMethodBlueprint()];
+  const substrates = options.substrates ?? [createSubstrateBlueprint()];
+  const containers = options.containers ?? [createContainerBlueprint()];
   const devices = options.devices ?? [
     createDeviceBlueprint({ kind: 'Lamp' }),
     createDeviceBlueprint({ kind: 'ClimateUnit', settings: { coverageArea: 12 } }),
@@ -244,10 +280,16 @@ export const createBlueprintRepositoryStub = (
     getStrain: (id: string) => strains.find((strain) => strain.id === id),
     getDevice: (id: string) => devices.find((device) => device.id === id),
     getCultivationMethod: (id: string) => methods.find((method) => method.id === id),
+    getSubstrate: (id: string) => substrates.find((substrate) => substrate.id === id),
+    getSubstrateBySlug: (slug: string) => substrates.find((substrate) => substrate.slug === slug),
+    getContainer: (id: string) => containers.find((container) => container.id === id),
+    getContainerBySlug: (slug: string) => containers.find((container) => container.slug === slug),
     getRoomPurpose: (id: string) => roomPurposes.find((purpose) => purpose.id === id),
     listStrains: () => strains.map((strain) => clone(strain)),
     listDevices: () => devices.map((device) => clone(device)),
     listCultivationMethods: () => methods.map((method) => clone(method)),
+    listSubstrates: () => substrates.map((substrate) => clone(substrate)),
+    listContainers: () => containers.map((container) => clone(container)),
     listRoomPurposes: () => roomPurposes.map((purpose) => clone(purpose)),
     getDevicePrice: (id: string) => devicePrices.get(id),
     getStrainPrice: (id: string) => strainPrices.get(id),

--- a/tools/validate-data.ts
+++ b/tools/validate-data.ts
@@ -260,6 +260,8 @@ const run = async () => {
     strains: validationResult.data.strains.size,
     devices: validationResult.data.devices.size,
     cultivationMethods: validationResult.data.cultivationMethods.size,
+    substrates: validationResult.data.substrates.size,
+    containers: validationResult.data.containers.size,
     roomPurposes: validationResult.data.roomPurposes.size,
     devicePrices: validationResult.data.prices.devices.size,
     strainPrices: validationResult.data.prices.strains.size,


### PR DESCRIPTION
## Summary
- add dedicated substrate and container blueprint collections and migrate cultivation methods to slug-based compatibility fields
- extend schema validation, data loading, repository helpers, and fixtures to cover the new consumables with cross-checks
- refresh documentation and changelog to explain the consumable blueprints and updated cultivation method structure

## Testing
- pnpm run check *(fails: frontend eslint currently errors before reporting details)*
- pnpm --filter @weebbreed/backend lint

------
https://chatgpt.com/codex/tasks/task_e_68da52d1403083258648dcece6a23752