### PR TITLE
Externalize cultivation pricing ledgers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added substrate and container blueprint collections with dedicated schemas, loader
   cross-checks, repository helpers, and documentation updates so cultivation methods
   reference shared consumables by slug instead of embedding media/container payloads.
+- Externalized cultivation method setup costs and consumable pricing into dedicated
+  ledgers (`data/prices/cultivationMethodPrices.json`, `data/prices/consumablePrices.json`),
+  extending schemas, repository accessors, loader cross-checks, and docs to surface
+  the new price sources.
 
 ### Changed
 

--- a/data/blueprints/cultivationMethods/basic_soil_pot.json
+++ b/data/blueprints/cultivationMethods/basic_soil_pot.json
@@ -2,7 +2,6 @@
   "id": "85cc0916-0e8a-495e-af8f-50291abe6855",
   "kind": "CultivationMethod",
   "name": "Basic Soil Pot",
-  "setupCost": 2.0,
   "laborIntensity": 0.1,
   "laborProfile": {
     "hoursPerPlantPerWeek": 0.35
@@ -11,9 +10,7 @@
   "minimumSpacing": 0.5,
   "maxCycles": 1,
   "compatibleSubstrateSlugs": ["soil-single-cycle"],
-  "substrateCostPerSquareMeter": 2.5,
   "compatibleContainerSlugs": ["pot-10l"],
-  "containerCostPerUnit": 1.5,
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {

--- a/data/blueprints/cultivationMethods/scrog.json
+++ b/data/blueprints/cultivationMethods/scrog.json
@@ -2,7 +2,6 @@
   "id": "41229377-ef2d-4723-931f-72eea87d7a62",
   "kind": "CultivationMethod",
   "name": "Screen of Green",
-  "setupCost": 15.0,
   "laborIntensity": 0.7,
   "laborProfile": {
     "hoursPerPlantPerWeek": 1.2
@@ -11,9 +10,7 @@
   "minimumSpacing": 0.8,
   "maxCycles": 4,
   "compatibleSubstrateSlugs": ["soil-multi-cycle"],
-  "substrateCostPerSquareMeter": 3.5,
   "compatibleContainerSlugs": ["pot-25l"],
-  "containerCostPerUnit": 4.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {

--- a/data/blueprints/cultivationMethods/sog.json
+++ b/data/blueprints/cultivationMethods/sog.json
@@ -2,7 +2,6 @@
   "id": "659ba4d7-a5fc-482e-98d4-b614341883ac",
   "kind": "CultivationMethod",
   "name": "Sea of Green",
-  "setupCost": 10.0,
   "laborIntensity": 0.4,
   "laborProfile": {
     "hoursPerPlantPerWeek": 0.65
@@ -11,9 +10,7 @@
   "minimumSpacing": 0.25,
   "maxCycles": 2,
   "compatibleSubstrateSlugs": ["soil-multi-cycle"],
-  "substrateCostPerSquareMeter": 3.5,
   "compatibleContainerSlugs": ["pot-11l"],
-  "containerCostPerUnit": 2.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {

--- a/data/prices/consumablePrices.json
+++ b/data/prices/consumablePrices.json
@@ -1,0 +1,22 @@
+{
+  "version": "2024-09-01",
+  "substrates": {
+    "soil-single-cycle": {
+      "costPerSquareMeter": 2.5
+    },
+    "soil-multi-cycle": {
+      "costPerSquareMeter": 3.5
+    }
+  },
+  "containers": {
+    "pot-10l": {
+      "costPerUnit": 1.5
+    },
+    "pot-11l": {
+      "costPerUnit": 2
+    },
+    "pot-25l": {
+      "costPerUnit": 4
+    }
+  }
+}

--- a/data/prices/cultivationMethodPrices.json
+++ b/data/prices/cultivationMethodPrices.json
@@ -1,0 +1,14 @@
+{
+  "version": "2024-09-01",
+  "cultivationMethodPrices": {
+    "85cc0916-0e8a-495e-af8f-50291abe6855": {
+      "setupCost": 2
+    },
+    "41229377-ef2d-4723-931f-72eea87d7a62": {
+      "setupCost": 15
+    },
+    "659ba4d7-a5fc-482e-98d4-b614341883ac": {
+      "setupCost": 10
+    }
+  }
+}

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -168,14 +168,13 @@ Defines planting density, compatible substrate/container blueprints, setup costs
 - `areaPerPlant: number (m²)` — Max plant count = `floor(zoneArea / areaPerPlant)`.
 - `minimumSpacing?: number (m)` — Optional geometric limit.
 - `laborIntensity?: number (0–1)` — Affects labor time multipliers.
-- `setupCost?: number` — Currency-neutral.
 - `compatibleSubstrateSlugs?: string[]` — Slug references into `/data/blueprints/substrates`.
-- `substrateCostPerSquareMeter?: number` — Baseline media cost for the default substrate option.
 - `compatibleContainerSlugs?: string[]` — Slug references into `/data/blueprints/containers`.
-- `containerCostPerUnit?: number` — Baseline container cost for the default container option.
 - `compatibility?: { strainTags?: string[] }`
 - `recommendedPhases?: string[]`
 - `meta?: object`
+
+> Pricing lives in `/data/prices/cultivationMethodPrices.json` (method `setupCost`) and `/data/prices/consumablePrices.json` (slug-keyed `substrates.costPerSquareMeter` and `containers.costPerUnit`).【F:data/prices/cultivationMethodPrices.json†L1-L13】【F:data/prices/consumablePrices.json†L1-L17】
 
 ---
 

--- a/docs/addendum/all-json.md
+++ b/docs/addendum/all-json.md
@@ -10,7 +10,6 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "id": "85cc0916-0e8a-495e-af8f-50291abe6855",
   "kind": "CultivationMethod",
   "name": "Basic Soil Pot",
-  "setupCost": 2.0,
   "laborIntensity": 0.1,
   "laborProfile": {
     "hoursPerPlantPerWeek": 0.35
@@ -19,9 +18,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.5,
   "maxCycles": 1,
   "compatibleSubstrateSlugs": ["soil-single-cycle"],
-  "substrateCostPerSquareMeter": 2.5,
   "compatibleContainerSlugs": ["pot-10l"],
-  "containerCostPerUnit": 1.5,
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {
@@ -47,7 +44,6 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "id": "41229377-ef2d-4723-931f-72eea87d7a62",
   "kind": "CultivationMethod",
   "name": "Screen of Green",
-  "setupCost": 15.0,
   "laborIntensity": 0.7,
   "laborProfile": {
     "hoursPerPlantPerWeek": 1.2
@@ -56,9 +52,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.8,
   "maxCycles": 4,
   "compatibleSubstrateSlugs": ["soil-multi-cycle"],
-  "substrateCostPerSquareMeter": 3.5,
   "compatibleContainerSlugs": ["pot-25l"],
-  "containerCostPerUnit": 4.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {
@@ -106,7 +100,6 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "id": "659ba4d7-a5fc-482e-98d4-b614341883ac",
   "kind": "CultivationMethod",
   "name": "Sea of Green",
-  "setupCost": 10.0,
   "laborIntensity": 0.4,
   "laborProfile": {
     "hoursPerPlantPerWeek": 0.65
@@ -115,9 +108,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.25,
   "maxCycles": 2,
   "compatibleSubstrateSlugs": ["soil-multi-cycle"],
-  "substrateCostPerSquareMeter": 3.5,
   "compatibleContainerSlugs": ["pot-11l"],
-  "containerCostPerUnit": 2.0,
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {
@@ -156,6 +147,52 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
       "Legal limitations in plant count (IRL)",
       "Not suitable for large or tall plants"
     ]
+  }
+}
+```
+
+## /data/prices/cultivationMethodPrices.json
+
+```json
+{
+  "version": "2024-09-01",
+  "cultivationMethodPrices": {
+    "85cc0916-0e8a-495e-af8f-50291abe6855": {
+      "setupCost": 2
+    },
+    "41229377-ef2d-4723-931f-72eea87d7a62": {
+      "setupCost": 15
+    },
+    "659ba4d7-a5fc-482e-98d4-b614341883ac": {
+      "setupCost": 10
+    }
+  }
+}
+```
+
+## /data/prices/consumablePrices.json
+
+```json
+{
+  "version": "2024-09-01",
+  "substrates": {
+    "soil-single-cycle": {
+      "costPerSquareMeter": 2.5
+    },
+    "soil-multi-cycle": {
+      "costPerSquareMeter": 3.5
+    }
+  },
+  "containers": {
+    "pot-10l": {
+      "costPerUnit": 1.5
+    },
+    "pot-11l": {
+      "costPerUnit": 2
+    },
+    "pot-25l": {
+      "costPerUnit": 4
+    }
   }
 }
 ```

--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -73,7 +73,9 @@ The engine core owns the tick scheduler, orchestrates subsystem execution, and k
 
 ### 4.2 Cultivation Methods
 
-Cultivation method templates include `id`, `kind`, `name`, `setupCost` (EUR per installation), `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and `maxCycles` (count). Media and container options are declared via `compatibleSubstrateSlugs` and `compatibleContainerSlugs`, referencing the dedicated consumable blueprints, while `substrateCostPerSquareMeter` and `containerCostPerUnit` record the baseline economics for the default pairing. Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
+Cultivation method templates include `id`, `kind`, `name`, `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and optional `maxCycles`. Media and container options are declared via `compatibleSubstrateSlugs` and `compatibleContainerSlugs`, referencing the dedicated consumable blueprints. Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
+
+Upfront economics are externalized: `data/prices/cultivationMethodPrices.json` maps method ids to `{ "setupCost" }`, while `data/prices/consumablePrices.json` exposes nested `substrates` and `containers` price tables keyed by slug with `costPerSquareMeter` and `costPerUnit` respectively.【F:data/prices/cultivationMethodPrices.json†L1-L13】【F:data/prices/consumablePrices.json†L1-L17】 Designers select compatible consumables in the blueprint and tune the actual ledger entries centrally, keeping balancing data separate from structural definitions.
 
 #### Substrate Blueprints
 

--- a/docs/ui-building_guide.backup.md
+++ b/docs/ui-building_guide.backup.md
@@ -255,7 +255,7 @@ The application follows a structure → room → zone drill-down supported by pe
 - **InstallDeviceModal/UpdateDeviceModal/MoveDeviceModal**: manage device lifecycle (install JSON validation, patch existing settings, relocate hardware) through zone-store helpers and `SimulationFacade` intents.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **Device removal confirmation**: reuses confirmation modal to call `devices.removeDevice` via zone store helper.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **RentStructureModal**: rents new structure with affordability gating; uses forms primitives.【F:docs/ui/ui-components-desciption.md†L533-L540】
-- **Duplicate flows** described above require inline cost previews and compliance with `allowedRoomPurposes` for devices.【F:docs/ui/ui-components-desciption.md†L360-L533】【F:docs/ui/ui_interactions_spec.md†L27-L54】 Cost tooltips break totals into Rooms, Zones, Devices (count × individual CapEx via `devicePrices.json`), Setup (method/container/substrate), and Other, summing capital and setup costs while reminding players that maintenance remains separate.
+- **Duplicate flows** described above require inline cost previews and compliance with `allowedRoomPurposes` for devices.【F:docs/ui/ui-components-desciption.md†L360-L533】【F:docs/ui/ui_interactions_spec.md†L27-L54】 Cost tooltips break totals into Rooms, Zones, Devices (count × individual CapEx via `devicePrices.json`), Setup (method/container/substrate sourced from `cultivationMethodPrices.json` + `consumablePrices.json`), and Other, summing capital and setup costs while reminding players that maintenance remains separate.
 
 ### Simulation Components
 

--- a/docs/ui-building_guide.md
+++ b/docs/ui-building_guide.md
@@ -263,7 +263,7 @@ The application follows a structure → room → zone drill-down supported by pe
 - **InstallDeviceModal/UpdateDeviceModal/MoveDeviceModal**: manage device lifecycle (install JSON validation, patch existing settings, relocate hardware) through zone-store helpers and `SimulationFacade` intents.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **Device removal confirmation**: reuses confirmation modal to call `devices.removeDevice` via zone store helper.【F:docs/ui/ui-components-desciption.md†L440-L533】
 - **RentStructureModal**: rents new structure with affordability gating; uses forms primitives.【F:docs/ui/ui-components-desciption.md†L533-L540】
-- **Duplicate flows** described above require inline cost previews and compliance with `allowedRoomPurposes` for devices.【F:docs/ui/ui-components-desciption.md†L360-L533】【F:docs/ui/ui_interactions_spec.md†L27-L54】 Cost tooltips break totals into Rooms, Zones, Devices (count × individual CapEx via `devicePrices.json`), Setup (method/container/substrate), and Other, summing capital and setup costs while reminding players that maintenance remains separate.
+- **Duplicate flows** described above require inline cost previews and compliance with `allowedRoomPurposes` for devices.【F:docs/ui/ui-components-desciption.md†L360-L533】【F:docs/ui/ui_interactions_spec.md†L27-L54】 Cost tooltips break totals into Rooms, Zones, Devices (count × individual CapEx via `devicePrices.json`), Setup (method/container/substrate sourced from `cultivationMethodPrices.json` + `consumablePrices.json`), and Other, summing capital and setup costs while reminding players that maintenance remains separate.
 
 ### Simulation Components
 

--- a/src/backend/src/data/blueprintRepository.ts
+++ b/src/backend/src/data/blueprintRepository.ts
@@ -7,6 +7,9 @@ import type {
   StrainPriceEntry,
   SubstrateBlueprint,
   ContainerBlueprint,
+  CultivationMethodPriceEntry,
+  SubstratePriceEntry,
+  ContainerPriceEntry,
 } from './schemas/index.js';
 
 export type HotReloadDisposition = 'commit' | 'defer';
@@ -116,6 +119,18 @@ export class BlueprintRepository {
     return this.data.prices.strains.get(id);
   }
 
+  getCultivationMethodPrice(id: string) {
+    return this.data.prices.cultivationMethods.get(id);
+  }
+
+  getSubstratePrice(slug: string) {
+    return this.data.prices.consumables.substrates.get(slug);
+  }
+
+  getContainerPrice(slug: string) {
+    return this.data.prices.consumables.containers.get(slug);
+  }
+
   getUtilityPrices() {
     return this.data.prices.utility;
   }
@@ -126,6 +141,18 @@ export class BlueprintRepository {
 
   listStrainPrices(): Array<[string, StrainPriceEntry]> {
     return Array.from(this.data.prices.strains.entries());
+  }
+
+  listCultivationMethodPrices(): Array<[string, CultivationMethodPriceEntry]> {
+    return Array.from(this.data.prices.cultivationMethods.entries());
+  }
+
+  listSubstratePrices(): Array<[string, SubstratePriceEntry]> {
+    return Array.from(this.data.prices.consumables.substrates.entries());
+  }
+
+  listContainerPrices(): Array<[string, ContainerPriceEntry]> {
+    return Array.from(this.data.prices.consumables.containers.entries());
   }
 
   getSummary(): DataLoadSummary {

--- a/src/backend/src/data/dataLoader.test.ts
+++ b/src/backend/src/data/dataLoader.test.ts
@@ -26,6 +26,14 @@ describe('loadBlueprintData', () => {
     expect(scrog?.compatibleContainerSlugs).toContain('pot-25l');
     expect(scrog?.compatibleSubstrateSlugs).toContain('soil-multi-cycle');
 
+    const methodPrices = result.data.prices.cultivationMethods;
+    expect(methodPrices.get('41229377-ef2d-4723-931f-72eea87d7a62')?.setupCost).toBe(15);
+
+    const substratePrice = result.data.prices.consumables.substrates.get('soil-multi-cycle');
+    expect(substratePrice?.costPerSquareMeter).toBe(3.5);
+    const containerPrice = result.data.prices.consumables.containers.get('pot-25l');
+    expect(containerPrice?.costPerUnit).toBe(4);
+
     const sog = cultivationMethods.get('659ba4d7-a5fc-482e-98d4-b614341883ac');
     expect(sog?.strainTraitCompatibility?.preferred?.['photoperiod.vegetationTime']?.max).toBe(
       1_814_400,

--- a/src/backend/src/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/src/data/schemas/cultivationMethodSchema.ts
@@ -21,15 +21,12 @@ export const cultivationMethodSchema = z
     id: z.string().uuid(),
     kind: z.string().default('CultivationMethod'),
     name: z.string().min(1),
-    setupCost: z.number(),
     laborIntensity: z.number(),
     areaPerPlant: z.number(),
     minimumSpacing: z.number(),
     maxCycles: z.number().int().min(0).optional(),
     compatibleSubstrateSlugs: z.array(z.string().min(1)).optional(),
     compatibleContainerSlugs: z.array(z.string().min(1)).optional(),
-    substrateCostPerSquareMeter: z.number().optional(),
-    containerCostPerUnit: z.number().optional(),
     strainTraitCompatibility: strainTraitCompatibilitySchema.optional(),
     envBias: z
       .object({

--- a/src/backend/src/data/schemas/priceSchemas.ts
+++ b/src/backend/src/data/schemas/priceSchemas.ts
@@ -31,6 +31,42 @@ export const strainPricesSchema = z
 export type StrainPriceEntry = z.infer<typeof strainPriceSchema>;
 export type StrainPriceMap = z.infer<typeof strainPricesSchema>['strainPrices'];
 
+export const cultivationMethodPriceSchema = z.object({
+  setupCost: z.number(),
+});
+
+export const cultivationMethodPricesSchema = z
+  .object({
+    version: z.string().optional(),
+    cultivationMethodPrices: z.record(z.string().uuid(), cultivationMethodPriceSchema),
+  })
+  .passthrough();
+
+export type CultivationMethodPriceEntry = z.infer<typeof cultivationMethodPriceSchema>;
+export type CultivationMethodPriceMap = z.infer<
+  typeof cultivationMethodPricesSchema
+>['cultivationMethodPrices'];
+
+export const substratePriceSchema = z.object({
+  costPerSquareMeter: z.number(),
+});
+
+export const containerPriceSchema = z.object({
+  costPerUnit: z.number(),
+});
+
+export const consumablePricesSchema = z
+  .object({
+    version: z.string().optional(),
+    substrates: z.record(z.string().min(1), substratePriceSchema),
+    containers: z.record(z.string().min(1), containerPriceSchema),
+  })
+  .passthrough();
+
+export type SubstratePriceEntry = z.infer<typeof substratePriceSchema>;
+export type ContainerPriceEntry = z.infer<typeof containerPriceSchema>;
+export type ConsumablePriceLedger = z.infer<typeof consumablePricesSchema>;
+
 export const utilityPricesSchema = z
   .object({
     version: z.string().optional(),

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -7,6 +7,9 @@ import type {
   UtilityPrices,
   SubstrateBlueprint,
   ContainerBlueprint,
+  CultivationMethodPriceEntry,
+  SubstratePriceEntry,
+  ContainerPriceEntry,
 } from '@/data/schemas/index.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type { StructureBlueprint } from '@/state/models.js';
@@ -137,14 +140,11 @@ export const createCultivationMethodBlueprint = (
   id: '22222222-2222-4222-8222-222222222222',
   kind: 'CultivationMethod',
   name: 'Method Alpha',
-  setupCost: 1200,
   laborIntensity: 0.6,
   areaPerPlant: 1.6,
   minimumSpacing: 0.4,
   compatibleSubstrateSlugs: ['test-substrate'],
   compatibleContainerSlugs: ['test-container'],
-  substrateCostPerSquareMeter: 2.5,
-  containerCostPerUnit: 8.5,
   meta: {},
   ...overrides,
 });
@@ -216,6 +216,9 @@ interface RepositoryStubOptions {
   containers?: ContainerBlueprint[];
   devicePrices?: Map<string, DevicePriceEntry>;
   strainPrices?: Map<string, StrainPriceEntry>;
+  cultivationMethodPrices?: Map<string, CultivationMethodPriceEntry>;
+  substratePrices?: Map<string, SubstratePriceEntry>;
+  containerPrices?: Map<string, ContainerPriceEntry>;
   utilityPrices?: UtilityPrices;
   roomPurposes?: RoomPurpose[];
 }
@@ -274,6 +277,27 @@ export const createBlueprintRepositoryStub = (
       [strains[0].id, { seedPrice: 0.6, harvestPricePerGram: 4.2 }],
     ]);
 
+  const cultivationMethodPrices =
+    options.cultivationMethodPrices ??
+    new Map<string, CultivationMethodPriceEntry>(
+      methods.map((method, index) => [method.id, { setupCost: 500 + index * 125 }]),
+    );
+
+  const substratePrices =
+    options.substratePrices ??
+    new Map<string, SubstratePriceEntry>(
+      substrates.map((substrate, index) => [
+        substrate.slug,
+        { costPerSquareMeter: 2 + index * 0.5 },
+      ]),
+    );
+
+  const containerPrices =
+    options.containerPrices ??
+    new Map<string, ContainerPriceEntry>(
+      containers.map((container, index) => [container.slug, { costPerUnit: 7 + index * 1.5 }]),
+    );
+
   const utilityPrices = options.utilityPrices ?? DEFAULT_UTILITY_PRICES;
 
   const repo = {
@@ -293,9 +317,15 @@ export const createBlueprintRepositoryStub = (
     listRoomPurposes: () => roomPurposes.map((purpose) => clone(purpose)),
     getDevicePrice: (id: string) => devicePrices.get(id),
     getStrainPrice: (id: string) => strainPrices.get(id),
+    getCultivationMethodPrice: (id: string) => cultivationMethodPrices.get(id),
+    getSubstratePrice: (slug: string) => substratePrices.get(slug),
+    getContainerPrice: (slug: string) => containerPrices.get(slug),
     getUtilityPrices: () => ({ ...utilityPrices }),
     listDevicePrices: () => Array.from(devicePrices.entries()),
     listStrainPrices: () => Array.from(strainPrices.entries()),
+    listCultivationMethodPrices: () => Array.from(cultivationMethodPrices.entries()),
+    listSubstratePrices: () => Array.from(substratePrices.entries()),
+    listContainerPrices: () => Array.from(containerPrices.entries()),
   } satisfies Partial<BlueprintRepository>;
 
   return repo as unknown as BlueprintRepository;
@@ -328,3 +358,18 @@ export const createDevicePriceMap = (
 export const createStrainPriceMap = (
   entries: Array<[string, StrainPriceEntry]>,
 ): Map<string, StrainPriceEntry> => new Map(entries.map(([id, entry]) => [id, clone(entry)]));
+
+export const createCultivationMethodPriceMap = (
+  entries: Array<[string, CultivationMethodPriceEntry]>,
+): Map<string, CultivationMethodPriceEntry> =>
+  new Map(entries.map(([id, entry]) => [id, clone(entry)]));
+
+export const createSubstratePriceMap = (
+  entries: Array<[string, SubstratePriceEntry]>,
+): Map<string, SubstratePriceEntry> =>
+  new Map(entries.map(([slug, entry]) => [slug, clone(entry)]));
+
+export const createContainerPriceMap = (
+  entries: Array<[string, ContainerPriceEntry]>,
+): Map<string, ContainerPriceEntry> =>
+  new Map(entries.map(([slug, entry]) => [slug, clone(entry)]));


### PR DESCRIPTION
## Summary
- externalize cultivation method setup and consumable pricing into dedicated ledgers and remove the legacy cost fields from the cultivation method blueprints
- extend backend schemas, loader cross-checks, repository accessors, and fixtures/tests to load and expose the new cultivation method and consumable price maps
- refresh backend and UI documentation to point at the new price sources for setup/tooling breakdowns

## Testing
- `pnpm run check` *(fails: @weebbreed/frontend lint exits with code 2 in the existing tree)*

------
https://chatgpt.com/codex/tasks/task_e_68da56f59488832597df09fe55b18616