### PR TITLE
Align substrate and container schema naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed the substrate and container schema modules to `substrateSchema` and
+  `containerSchema`, updating imports to follow the shared schema naming
+  convention and documenting the decision in ADR 0010.
 - Shifted cultivation method media compatibility to `compatibleSubstrateTypes`,
   teaching the loader to index substrates by type, validate referenced media,
   warn when pricing is missing, and refreshing documentation plus blueprints to

--- a/docs/system/adr/0010-blueprint-schema-naming.md
+++ b/docs/system/adr/0010-blueprint-schema-naming.md
@@ -1,0 +1,48 @@
+# ADR 0010 — Blueprint Schema Naming Alignment
+
+- **Status:** Accepted (2025-10-03)
+- **Owner:** Simulation Platform
+- **Context:** Naming consistency for substrate/container blueprint schemas
+
+## Context
+
+The blueprint loader recently introduced dedicated substrate and container
+schemas to replace inline validation. The files were initially published as
+`substrateBlueprintSchema.ts` and `containerBlueprintSchema.ts`, exporting
+`substrateBlueprintSchema` and `containerBlueprintSchema` constants. While this
+mirrored the historic "Blueprint" naming of the JSON data, it broke the
+convention used elsewhere in `@/data/schemas` where schema modules export a
+`<resource>Schema` symbol (for example `strainSchema`, `deviceSchema`, and
+`roomPurposeSchema`). The inconsistency caused import ordering drift in
+`@/data/dataLoader` and increased the risk of duplicate re-exports as future
+contributors add schema helpers.
+
+## Decision
+
+- Rename the modules to `substrateSchema.ts` and `containerSchema.ts` and export
+  `substrateSchema` / `containerSchema` constants to match the folder’s naming
+  conventions.
+- Retain the public type aliases `SubstrateBlueprint` and `ContainerBlueprint`
+  so downstream code continues to consume blueprint-shaped data without churn.
+- Update imports and barrel re-exports in
+  `src/backend/src/data/dataLoader.ts` and
+  `src/backend/src/data/schemas/index.ts` to reference the new module names,
+  keeping downstream type-only consumers (for example
+  `src/backend/src/testing/fixtures.ts`) unchanged.
+
+## Consequences
+
+- Schema imports across the backend now follow a single `<resource>Schema`
+  convention, improving readability and searchability for contributors.
+- Blueprint type names remain unchanged, so no blueprint JSON files or tests
+  require adjustments beyond the schema references.
+- Future schema additions can reuse the established naming pattern without
+  special casing the substrate and container modules.
+
+## References
+
+- `src/backend/src/data/schemas/substrateSchema.ts`
+- `src/backend/src/data/schemas/containerSchema.ts`
+- `src/backend/src/data/dataLoader.ts`
+- `src/backend/src/data/schemas/index.ts`
+- `src/backend/src/testing/fixtures.ts`

--- a/src/backend/src/data/dataLoader.ts
+++ b/src/backend/src/data/dataLoader.ts
@@ -12,8 +12,8 @@ import {
   utilityPricesSchema,
   cultivationMethodPricesSchema,
   consumablePricesSchema,
-  substrateBlueprintSchema,
-  containerBlueprintSchema,
+  substrateSchema,
+  containerSchema,
 } from './schemas/index.js';
 import type {
   StrainBlueprint,
@@ -517,24 +517,12 @@ export const loadBlueprintData = async (
     issues,
   );
   const substrateEntries = filterDuplicateSlugs(
-    await loadDirectoryCollection(
-      substrateDir,
-      substrateBlueprintSchema,
-      absoluteDataDir,
-      summary,
-      issues,
-    ),
+    await loadDirectoryCollection(substrateDir, substrateSchema, absoluteDataDir, summary, issues),
     issues,
     'substrate',
   );
   const containerEntries = filterDuplicateSlugs(
-    await loadDirectoryCollection(
-      containerDir,
-      containerBlueprintSchema,
-      absoluteDataDir,
-      summary,
-      issues,
-    ),
+    await loadDirectoryCollection(containerDir, containerSchema, absoluteDataDir, summary, issues),
     issues,
     'container',
   );

--- a/src/backend/src/data/schemas/containerSchema.ts
+++ b/src/backend/src/data/schemas/containerSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-export const containerBlueprintSchema = z
+export const containerSchema = z
   .object({
     id: z.string().uuid(),
     slug: z.string().min(1).regex(slugPattern, {
@@ -18,4 +18,4 @@ export const containerBlueprintSchema = z
   })
   .passthrough();
 
-export type ContainerBlueprint = z.infer<typeof containerBlueprintSchema>;
+export type ContainerBlueprint = z.infer<typeof containerSchema>;

--- a/src/backend/src/data/schemas/index.ts
+++ b/src/backend/src/data/schemas/index.ts
@@ -3,5 +3,5 @@ export * from './deviceSchema.js';
 export * from './cultivationMethodSchema.js';
 export * from './priceSchemas.js';
 export * from './roomPurposeSchema.js';
-export * from './substrateBlueprintSchema.js';
-export * from './containerBlueprintSchema.js';
+export * from './substrateSchema.js';
+export * from './containerSchema.js';

--- a/src/backend/src/data/schemas/substrateSchema.ts
+++ b/src/backend/src/data/schemas/substrateSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-export const substrateBlueprintSchema = z
+export const substrateSchema = z
   .object({
     id: z.string().uuid(),
     slug: z.string().min(1).regex(slugPattern, {
@@ -15,4 +15,4 @@ export const substrateBlueprintSchema = z
   })
   .passthrough();
 
-export type SubstrateBlueprint = z.infer<typeof substrateBlueprintSchema>;
+export type SubstrateBlueprint = z.infer<typeof substrateSchema>;


### PR DESCRIPTION
## Summary
- rename the substrate and container schema modules to `substrateSchema` / `containerSchema` and update the loader plus schema barrel exports to match
- add ADR 0010 documenting the blueprint schema naming convention and its impact
- note the schema rename in the unreleased changelog section

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm run check *(fails: `@weebbreed/frontend` lint exits with status 2 before emitting diagnostics)*
- pnpm --filter @weebreed/backend typecheck *(fails: existing repository TypeScript errors unrelated to this rename)*

------
https://chatgpt.com/codex/tasks/task_e_68da6898cfa48325a2c7a99b7d45a6a0