### PR TITLE
Switch cultivation methods to container type compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   teaching the loader to index substrates by type, validate referenced media,
   warn when pricing is missing, and refreshing documentation plus blueprints to
   list both soil and coco support.
+- Switched cultivation method container compatibility to `compatibleContainerTypes`,
+  normalizing existing methods to the shared `pot` category, indexing containers
+  by type in the loader, and extending cross-checks, fixtures, and docs to flag
+  missing container pricing per category.
 - Normalized substrate consumable pricing to `costPerLiter`, updating schemas,
   fixtures, loader expectations, and docs so per-liter figures are enforced in
   validation and surfaced consistently across the toolchain.

--- a/data/blueprints/cultivationMethods/basic_soil_pot.json
+++ b/data/blueprints/cultivationMethods/basic_soil_pot.json
@@ -10,7 +10,7 @@
   "minimumSpacing": 0.5,
   "maxCycles": 1,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-10l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {

--- a/data/blueprints/cultivationMethods/scrog.json
+++ b/data/blueprints/cultivationMethods/scrog.json
@@ -10,7 +10,7 @@
   "minimumSpacing": 0.8,
   "maxCycles": 4,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-25l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {

--- a/data/blueprints/cultivationMethods/sog.json
+++ b/data/blueprints/cultivationMethods/sog.json
@@ -10,7 +10,7 @@
   "minimumSpacing": 0.25,
   "maxCycles": 2,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-11l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -170,7 +170,7 @@ Defines planting density, compatible substrate/container blueprints, setup costs
 - `laborIntensity?: number (0–1)` — Affects labor time multipliers.
 - `compatibleSubstrateTypes?: string[]` — Media categories (e.g., `"soil"`, `"coco"`) resolved against `/data/blueprints/substrates`.
 - Loader cross-checks ensure each referenced type is defined and warns when no priced substrate slug exists for that type.
-- `compatibleContainerSlugs?: string[]` — Slug references into `/data/blueprints/containers`.
+- `compatibleContainerTypes?: string[]` — Container categories (e.g., `"pot"`) resolved against `/data/blueprints/containers`. Loader cross-checks ensure each referenced type exists and warns when none of its slugs carry pricing.
 - `compatibility?: { strainTags?: string[] }`
 - `recommendedPhases?: string[]`
 - `meta?: object`

--- a/docs/addendum/all-json.md
+++ b/docs/addendum/all-json.md
@@ -18,7 +18,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.5,
   "maxCycles": 1,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-10l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {
@@ -52,7 +52,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.8,
   "maxCycles": 4,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-25l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {
@@ -108,7 +108,7 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "minimumSpacing": 0.25,
   "maxCycles": 2,
   "compatibleSubstrateTypes": ["soil", "coco"],
-  "compatibleContainerSlugs": ["pot-11l"],
+  "compatibleContainerTypes": ["pot"],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {

--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -73,8 +73,8 @@ The engine core owns the tick scheduler, orchestrates subsystem execution, and k
 
 ### 4.2 Cultivation Methods
 
-Cultivation method templates include `id`, `kind`, `name`, `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and optional `maxCycles`. Media options are declared via `compatibleSubstrateTypes` (category names such as `"soil"` and `"coco"`, resolved against the substrate library) and container options continue to use `compatibleContainerSlugs`. Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
-The baseline cultivation methods (`basic_soil_pot`, `scrog`, `sog`) each enumerate both substrate types so either soil mixes or coco coir consumables can be paired with their unchanged container lists.【F:data/blueprints/cultivationMethods/basic_soil_pot.json†L1-L29】【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】【F:data/blueprints/cultivationMethods/sog.json†L1-L46】
+Cultivation method templates include `id`, `kind`, `name`, `laborIntensity` (0..1), `areaPerPlant` (m²·plant⁻¹), `minimumSpacing` (m), and optional `maxCycles`. Media options are declared via `compatibleSubstrateTypes` (category names such as `"soil"` and `"coco"`, resolved against the substrate library) and container options point to category names via `compatibleContainerTypes`. Compatibility rules appear under `strainTraitCompatibility`, and `idealConditions` specify `idealTemperature` (°C) and `idealHumidity` (0..1) ranges. Optional `meta` text documents trade-offs.【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】
+The baseline cultivation methods (`basic_soil_pot`, `scrog`, `sog`) each enumerate both substrate types so either soil mixes or coco coir consumables can be paired with their shared `pot` container category.【F:data/blueprints/cultivationMethods/basic_soil_pot.json†L1-L29】【F:data/blueprints/cultivationMethods/scrog.json†L1-L47】【F:data/blueprints/cultivationMethods/sog.json†L1-L46】
 
 Upfront economics are externalized: `data/prices/cultivationMethodPrices.json` maps method ids to `{ "setupCost" }`, while `data/prices/consumablePrices.json` exposes nested `substrates` and `containers` price tables keyed by slug. Substrate entries now declare `costPerLiter`, and containers track `costPerUnit`.【F:data/prices/cultivationMethodPrices.json†L1-L13】【F:data/prices/consumablePrices.json†L1-L21】 Designers select compatible consumables in the blueprint and tune the actual ledger entries centrally, keeping balancing data separate from structural definitions.
 
@@ -84,7 +84,7 @@ Upfront economics are externalized: `data/prices/cultivationMethodPrices.json` m
 
 #### Container Blueprints
 
-`/data/blueprints/containers` captures reusable vessel geometries (`volumeInLiters`, `footprintArea`, `reusableCycles`, `packingDensity`) with slug identifiers, allowing consistent reuse while keeping per-method pricing separate.【F:data/blueprints/containers/pot_25l.json†L1-L9】
+`/data/blueprints/containers` captures reusable vessel geometries (`volumeInLiters`, `footprintArea`, `reusableCycles`, `packingDensity`) with slug identifiers and a `type` category so cultivation methods can reference compatible families via `compatibleContainerTypes`. The loader builds a `containersByType` index and warns when a referenced type lacks priced slugs.【F:data/blueprints/containers/pot_25l.json†L1-L9】
 
 ### 4.3 Strain Blueprints
 

--- a/src/backend/src/data/dataLoader.test.ts
+++ b/src/backend/src/data/dataLoader.test.ts
@@ -17,9 +17,11 @@ describe('loadBlueprintData', () => {
     const substrates = result.data.substrates;
     const substratesByType = result.data.substratesByType;
     const containers = result.data.containers;
+    const containersByType = result.data.containersByType;
     expect(cultivationMethods.size).toBeGreaterThan(0);
     expect(substrates.size).toBeGreaterThan(0);
     expect(containers.size).toBeGreaterThan(0);
+    expect(containersByType.size).toBeGreaterThan(0);
 
     const substrateSlugs = Array.from(substrates.values()).map((entry) => entry.slug);
     expect(substrateSlugs).toContain('coco-coir');
@@ -32,10 +34,16 @@ describe('loadBlueprintData', () => {
     const cocoCoir = Array.from(substrates.values()).find((entry) => entry.slug === 'coco-coir');
     expect(cocoCoir?.type).toBe('coco');
 
+    const potContainers = containersByType.get('pot');
+    expect(potContainers).toBeDefined();
+    expect(potContainers?.map((entry) => entry.slug)).toEqual(
+      expect.arrayContaining(['pot-10l', 'pot-11l', 'pot-25l']),
+    );
+
     const scrog = cultivationMethods.get('41229377-ef2d-4723-931f-72eea87d7a62');
     expect(scrog?.strainTraitCompatibility?.preferred?.['genotype.sativa']?.min).toBe(0.5);
     expect(scrog?.strainTraitCompatibility?.conflicting?.['genotype.indica']?.min).toBe(0.7);
-    expect(scrog?.compatibleContainerSlugs).toContain('pot-25l');
+    expect(scrog?.compatibleContainerTypes).toContain('pot');
     expect(scrog?.compatibleSubstrateTypes).toContain('soil');
     expect(scrog?.compatibleSubstrateTypes).toContain('coco');
 
@@ -56,7 +64,7 @@ describe('loadBlueprintData', () => {
     expect(sog?.strainTraitCompatibility?.conflicting?.['photoperiod.vegetationTime']?.min).toBe(
       2_419_200,
     );
-    expect(sog?.compatibleContainerSlugs).toContain('pot-11l');
+    expect(sog?.compatibleContainerTypes).toContain('pot');
     expect(sog?.compatibleSubstrateTypes).toContain('soil');
     expect(sog?.compatibleSubstrateTypes).toContain('coco');
   });

--- a/src/backend/src/data/schemas/cultivationMethodSchema.ts
+++ b/src/backend/src/data/schemas/cultivationMethodSchema.ts
@@ -26,7 +26,7 @@ export const cultivationMethodSchema = z
     minimumSpacing: z.number(),
     maxCycles: z.number().int().min(0).optional(),
     compatibleSubstrateTypes: z.array(z.string().min(1)).optional(),
-    compatibleContainerSlugs: z.array(z.string().min(1)).optional(),
+    compatibleContainerTypes: z.array(z.string().min(1)).optional(),
     strainTraitCompatibility: strainTraitCompatibilitySchema.optional(),
     envBias: z
       .object({

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -144,7 +144,7 @@ export const createCultivationMethodBlueprint = (
   areaPerPlant: 1.6,
   minimumSpacing: 0.4,
   compatibleSubstrateTypes: ['soil'],
-  compatibleContainerSlugs: ['test-container'],
+  compatibleContainerTypes: ['pot'],
   meta: {},
   ...overrides,
 });


### PR DESCRIPTION
## Summary
- rename cultivation method container compatibility to reference container types and normalize the baseline blueprints to the shared pot category
- extend the blueprint loader schema, data shapes, and cross-checks to index containers by type and warn when pricing coverage is missing
- update fixtures, documentation, and tests to exercise the new container type compatibility map

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm --filter @weebbreed/backend lint

------
https://chatgpt.com/codex/tasks/task_e_68da6db38ed88325b8847b563f6143d9