### PR TITLE
Add metadata support for container and substrate blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added substrate and container blueprint collections with dedicated schemas, loader
   cross-checks, repository helpers, and documentation updates so cultivation methods
   reference shared consumables by slug instead of embedding media/container payloads.
+- Added optional `meta` payloads to substrate and container blueprints, extending schemas,
+  fixtures, loader expectations, and docs so designers can surface descriptions plus
+  advantage/disadvantage call-outs alongside quantitative specs.
 - Externalized cultivation method setup costs and consumable pricing into dedicated
   ledgers (`data/prices/cultivationMethodPrices.json`, `data/prices/consumablePrices.json`),
   extending schemas, repository accessors, loader cross-checks, and docs to surface

--- a/data/blueprints/containers/pot_10l.json
+++ b/data/blueprints/containers/pot_10l.json
@@ -7,5 +7,17 @@
   "volumeInLiters": 10,
   "footprintArea": 0.25,
   "reusableCycles": 3,
-  "packingDensity": 0.9
+  "packingDensity": 0.9,
+  "meta": {
+    "description": "Compact 10 L pot tuned for short-cycle soil or coco runs where designers want dense spacing without root binding surprises.",
+    "advantages": [
+      "Small footprint keeps canopy layouts tight",
+      "Lightweight shell is easy to reposition",
+      "Medium warms quickly under indoor lighting"
+    ],
+    "disadvantages": [
+      "Limited root volume for extended vegetative phases",
+      "Requires tighter irrigation cadence to avoid drybacks"
+    ]
+  }
 }

--- a/data/blueprints/containers/pot_11l.json
+++ b/data/blueprints/containers/pot_11l.json
@@ -7,5 +7,17 @@
   "volumeInLiters": 11,
   "footprintArea": 0.2,
   "reusableCycles": 6,
-  "packingDensity": 0.95
+  "packingDensity": 0.95,
+  "meta": {
+    "description": "Balanced 11 L container sized for standard indoor runs; pairs with ebb-and-flow trays or benches without sacrificing root stability.",
+    "advantages": [
+      "Supports moderate root mass for full-cycle plants",
+      "Fits common flood tables and rolling benches",
+      "Durable enough for multiple sanitization cycles"
+    ],
+    "disadvantages": [
+      "Heavier to maneuver when saturated",
+      "Still undersized for very long veg or mother plants"
+    ]
+  }
 }

--- a/data/blueprints/containers/pot_25l.json
+++ b/data/blueprints/containers/pot_25l.json
@@ -7,5 +7,17 @@
   "volumeInLiters": 25,
   "footprintArea": 0.3,
   "reusableCycles": 6,
-  "packingDensity": 0.9
+  "packingDensity": 0.9,
+  "meta": {
+    "description": "Large 25 L pot for flagship plants or extended veg; gives roots the headroom needed for heavy-feeding cultivars.",
+    "advantages": [
+      "High volume supports vigorous, tall plants",
+      "Moisture buffer stretches irrigation intervals",
+      "Wide base resists tipping in high-canopy rooms"
+    ],
+    "disadvantages": [
+      "Consumes more floor area per plant",
+      "Longer dry-down can slow reset between cycles"
+    ]
+  }
 }

--- a/data/blueprints/substrates/coco_coir.json
+++ b/data/blueprints/substrates/coco_coir.json
@@ -4,5 +4,17 @@
   "kind": "Substrate",
   "name": "Coco Coir",
   "type": "coco",
-  "maxCycles": 4
+  "maxCycles": 4,
+  "meta": {
+    "description": "Buffered coco coir blend optimized for drain-to-waste or recirculating fertigation systems with multiple reuse cycles.",
+    "advantages": [
+      "Excellent aeration drives rapid root development",
+      "Handles high-frequency fertigation without compaction",
+      "Reusable across four cycles with proper flushing"
+    ],
+    "disadvantages": [
+      "Demands precise nutrient and EC management",
+      "Dries quickly without automated irrigation"
+    ]
+  }
 }

--- a/data/blueprints/substrates/soil_multi_cycle.json
+++ b/data/blueprints/substrates/soil_multi_cycle.json
@@ -4,5 +4,17 @@
   "kind": "Substrate",
   "name": "Multi-Cycle Soil Mix",
   "type": "soil",
-  "maxCycles": 2
+  "maxCycles": 2,
+  "meta": {
+    "description": "Reconditionable soil blend that survives two full runs with proper amendment and sterilization between crops.",
+    "advantages": [
+      "Supports two reuse cycles with consistent structure",
+      "Balanced water retention keeps irrigation predictable",
+      "Cation exchange capacity stabilizes nutrient delivery"
+    ],
+    "disadvantages": [
+      "Needs re-amendment between harvests",
+      "Heavier medium increases handling effort"
+    ]
+  }
 }

--- a/data/blueprints/substrates/soil_single_cycle.json
+++ b/data/blueprints/substrates/soil_single_cycle.json
@@ -4,5 +4,17 @@
   "kind": "Substrate",
   "name": "Single-Cycle Soil Mix",
   "type": "soil",
-  "maxCycles": 1
+  "maxCycles": 1,
+  "meta": {
+    "description": "Pre-charged soil mix formulated for one-and-done harvests; ideal when designers prefer a fresh medium each run.",
+    "advantages": [
+      "Arrives with a balanced nutrient charge",
+      "High buffering capacity smooths pH swings",
+      "Familiar handling for soil-focused operators"
+    ],
+    "disadvantages": [
+      "Needs full replacement after a single cycle",
+      "Spent media can harbor pests if disposal is delayed"
+    ]
+  }
 }

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -195,7 +195,7 @@ Current library entries cover single-cycle soil, multi-cycle soil, and a reusabl
 - `name: string`
 - `type: string` — Descriptive category (e.g., `"soil"`, `"coco"`, `"rockwool"`).
 - `maxCycles?: number` — Number of reuse cycles before replacement.
-- `meta?: object`
+- `meta?: { description?: string, advantages?: string[], disadvantages?: string[] }` — Optional designer notes. Advantages/disadvantages capture quick decision aids for the UI; additional keys allowed for future enrichment.
 
 ---
 
@@ -216,7 +216,7 @@ Captures reusable container geometries and limits referenced by cultivation meth
 - `footprintArea?: number (m²)`
 - `reusableCycles?: number`
 - `packingDensity?: number`
-- `meta?: object`
+- `meta?: { description?: string, advantages?: string[], disadvantages?: string[] }` — Optional designer notes describing positioning guidance and trade-offs. Passthrough to allow future extensions.
 
 ---
 

--- a/docs/addendum/all-json.md
+++ b/docs/addendum/all-json.md
@@ -209,7 +209,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "kind": "Substrate",
   "name": "Single-Cycle Soil Mix",
   "type": "soil",
-  "maxCycles": 1
+  "maxCycles": 1,
+  "meta": {
+    "description": "Pre-charged soil mix formulated for one-and-done harvests; ideal when designers prefer a fresh medium each run.",
+    "advantages": [
+      "Arrives with a balanced nutrient charge",
+      "High buffering capacity smooths pH swings",
+      "Familiar handling for soil-focused operators"
+    ],
+    "disadvantages": [
+      "Needs full replacement after a single cycle",
+      "Spent media can harbor pests if disposal is delayed"
+    ]
+  }
 }
 ```
 
@@ -222,7 +234,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "kind": "Substrate",
   "name": "Multi-Cycle Soil Mix",
   "type": "soil",
-  "maxCycles": 2
+  "maxCycles": 2,
+  "meta": {
+    "description": "Reconditionable soil blend that survives two full runs with proper amendment and sterilization between crops.",
+    "advantages": [
+      "Supports two reuse cycles with consistent structure",
+      "Balanced water retention keeps irrigation predictable",
+      "Cation exchange capacity stabilizes nutrient delivery"
+    ],
+    "disadvantages": [
+      "Needs re-amendment between harvests",
+      "Heavier medium increases handling effort"
+    ]
+  }
 }
 ```
 
@@ -235,7 +259,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "kind": "Substrate",
   "name": "Coco Coir",
   "type": "coco",
-  "maxCycles": 4
+  "maxCycles": 4,
+  "meta": {
+    "description": "Buffered coco coir blend optimized for drain-to-waste or recirculating fertigation systems with multiple reuse cycles.",
+    "advantages": [
+      "Excellent aeration drives rapid root development",
+      "Handles high-frequency fertigation without compaction",
+      "Reusable across four cycles with proper flushing"
+    ],
+    "disadvantages": [
+      "Demands precise nutrient and EC management",
+      "Dries quickly without automated irrigation"
+    ]
+  }
 }
 ```
 
@@ -251,7 +287,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "volumeInLiters": 10,
   "footprintArea": 0.25,
   "reusableCycles": 3,
-  "packingDensity": 0.9
+  "packingDensity": 0.9,
+  "meta": {
+    "description": "Compact 10 L pot tuned for short-cycle soil or coco runs where designers want dense spacing without root binding surprises.",
+    "advantages": [
+      "Small footprint keeps canopy layouts tight",
+      "Lightweight shell is easy to reposition",
+      "Medium warms quickly under indoor lighting"
+    ],
+    "disadvantages": [
+      "Limited root volume for extended vegetative phases",
+      "Requires tighter irrigation cadence to avoid drybacks"
+    ]
+  }
 }
 ```
 
@@ -267,7 +315,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "volumeInLiters": 11,
   "footprintArea": 0.2,
   "reusableCycles": 6,
-  "packingDensity": 0.95
+  "packingDensity": 0.95,
+  "meta": {
+    "description": "Balanced 11 L container sized for standard indoor runs; pairs with ebb-and-flow trays or benches without sacrificing root stability.",
+    "advantages": [
+      "Supports moderate root mass for full-cycle plants",
+      "Fits common flood tables and rolling benches",
+      "Durable enough for multiple sanitization cycles"
+    ],
+    "disadvantages": [
+      "Heavier to maneuver when saturated",
+      "Still undersized for very long veg or mother plants"
+    ]
+  }
 }
 ```
 
@@ -283,7 +343,19 @@ These files are crucial! The blueprinted Objects will be rehidrated from these c
   "volumeInLiters": 25,
   "footprintArea": 0.3,
   "reusableCycles": 6,
-  "packingDensity": 0.9
+  "packingDensity": 0.9,
+  "meta": {
+    "description": "Large 25 L pot for flagship plants or extended veg; gives roots the headroom needed for heavy-feeding cultivars.",
+    "advantages": [
+      "High volume supports vigorous, tall plants",
+      "Moisture buffer stretches irrigation intervals",
+      "Wide base resists tipping in high-canopy rooms"
+    ],
+    "disadvantages": [
+      "Consumes more floor area per plant",
+      "Longer dry-down can slow reset between cycles"
+    ]
+  }
 }
 ```
 

--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -80,11 +80,11 @@ Upfront economics are externalized: `data/prices/cultivationMethodPrices.json` m
 
 #### Substrate Blueprints
 
-`/data/blueprints/substrates` holds reusable media definitions with stable `id`/`slug` pairs, media `type`, and optional `maxCycles`. Cultivation methods now reference these by type, while the loader builds a type index to validate compatibility lists and flag missing priced options. The catalog currently offers single-cycle soil, multi-cycle soil, and coco coir blueprints for reuse-friendly grow plans.【F:data/blueprints/substrates/soil_single_cycle.json†L1-L7】【F:data/blueprints/substrates/soil_multi_cycle.json†L1-L7】【F:data/blueprints/substrates/coco_coir.json†L1-L7】
+`/data/blueprints/substrates` holds reusable media definitions with stable `id`/`slug` pairs, media `type`, and optional `maxCycles`. Cultivation methods now reference these by type, while the loader builds a type index to validate compatibility lists and flag missing priced options. Each substrate blueprint also exposes a `meta` block with `description`, `advantages`, and `disadvantages` so UI tooling can surface qualitative trade-offs alongside numeric specs. The catalog currently offers single-cycle soil, multi-cycle soil, and coco coir blueprints for reuse-friendly grow plans.【F:data/blueprints/substrates/soil_single_cycle.json†L1-L19】【F:data/blueprints/substrates/soil_multi_cycle.json†L1-L19】【F:data/blueprints/substrates/coco_coir.json†L1-L19】
 
 #### Container Blueprints
 
-`/data/blueprints/containers` captures reusable vessel geometries (`volumeInLiters`, `footprintArea`, `reusableCycles`, `packingDensity`) with slug identifiers and a `type` category so cultivation methods can reference compatible families via `compatibleContainerTypes`. The loader builds a `containersByType` index and warns when a referenced type lacks priced slugs.【F:data/blueprints/containers/pot_25l.json†L1-L9】
+`/data/blueprints/containers` captures reusable vessel geometries (`volumeInLiters`, `footprintArea`, `reusableCycles`, `packingDensity`) with slug identifiers and a `type` category so cultivation methods can reference compatible families via `compatibleContainerTypes`. Each container blueprint mirrors cultivation-method metadata with a `meta` block for descriptive copy and advantage/disadvantage lists, and the loader builds a `containersByType` index while warning when a referenced type lacks priced slugs.【F:data/blueprints/containers/pot_25l.json†L1-L19】
 
 ### 4.3 Strain Blueprints
 

--- a/src/backend/src/data/dataLoader.test.ts
+++ b/src/backend/src/data/dataLoader.test.ts
@@ -33,11 +33,20 @@ describe('loadBlueprintData', () => {
     expect(cocoSubstrates?.map((entry) => entry.slug)).toContain('coco-coir');
     const cocoCoir = Array.from(substrates.values()).find((entry) => entry.slug === 'coco-coir');
     expect(cocoCoir?.type).toBe('coco');
+    expect(cocoCoir?.meta?.description).toContain('coco coir blend');
+    expect(cocoCoir?.meta?.advantages).toContain(
+      'Excellent aeration drives rapid root development',
+    );
 
     const potContainers = containersByType.get('pot');
     expect(potContainers).toBeDefined();
     expect(potContainers?.map((entry) => entry.slug)).toEqual(
       expect.arrayContaining(['pot-10l', 'pot-11l', 'pot-25l']),
+    );
+    const pot10l = Array.from(containers.values()).find((entry) => entry.slug === 'pot-10l');
+    expect(pot10l?.meta?.advantages).toContain('Small footprint keeps canopy layouts tight');
+    expect(pot10l?.meta?.disadvantages).toContain(
+      'Limited root volume for extended vegetative phases',
     );
 
     const scrog = cultivationMethods.get('41229377-ef2d-4723-931f-72eea87d7a62');

--- a/src/backend/src/data/schemas/containerSchema.ts
+++ b/src/backend/src/data/schemas/containerSchema.ts
@@ -15,6 +15,14 @@ export const containerSchema = z
     footprintArea: z.number().positive().optional(),
     reusableCycles: z.number().int().min(0).optional(),
     packingDensity: z.number().positive().optional(),
+    meta: z
+      .object({
+        description: z.string().optional(),
+        advantages: z.array(z.string()).optional(),
+        disadvantages: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough();
 

--- a/src/backend/src/data/schemas/substrateSchema.ts
+++ b/src/backend/src/data/schemas/substrateSchema.ts
@@ -12,6 +12,14 @@ export const substrateSchema = z
     name: z.string().min(1),
     type: z.string().min(1),
     maxCycles: z.number().int().min(0).optional(),
+    meta: z
+      .object({
+        description: z.string().optional(),
+        advantages: z.array(z.string()).optional(),
+        disadvantages: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough();
 

--- a/src/backend/src/testing/fixtures.ts
+++ b/src/backend/src/testing/fixtures.ts
@@ -116,6 +116,11 @@ export const createSubstrateBlueprint = (
   name: 'Test Substrate',
   type: 'soil',
   maxCycles: 2,
+  meta: {
+    description: 'Test substrate description',
+    advantages: ['Test substrate advantage'],
+    disadvantages: ['Test substrate disadvantage'],
+  },
   ...overrides,
 });
 
@@ -131,6 +136,11 @@ export const createContainerBlueprint = (
   footprintArea: 0.3,
   reusableCycles: 5,
   packingDensity: 0.9,
+  meta: {
+    description: 'Test container description',
+    advantages: ['Test container advantage'],
+    disadvantages: ['Test container disadvantage'],
+  },
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary
- allow container and substrate schemas, fixtures, and loader tests to handle optional `meta` objects with description and advantage/disadvantage arrays
- populate `meta` blocks across all container and substrate blueprints and document the new fields in the data dictionary and JSON addendum

## Testing
- pnpm --filter @weebreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68da70b935a48325ab70e1add6b70a69