### PR TITLE
Expose blueprint catalogs and drive Create Zone modal from facade

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.10.1
         version: 22.18.6
@@ -823,6 +826,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4011,6 +4020,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.13
       '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/src/backend/src/difficulty.integration.test.ts
+++ b/src/backend/src/difficulty.integration.test.ts
@@ -92,6 +92,7 @@ describe('Difficulty presets sync with JSON config', () => {
       structureBlueprints: context.structureBlueprints ?? [],
       roomPurposeSource: repository,
       difficultyConfig: TEST_CONFIG,
+      repository,
     });
 
     const buffer: SimulationEvent[] = [];
@@ -132,6 +133,7 @@ describe('Difficulty presets sync with JSON config', () => {
       structureBlueprints: context.structureBlueprints ?? [],
       roomPurposeSource: repository,
       difficultyConfig: TEST_CONFIG,
+      repository,
     });
 
     const custom = {

--- a/src/backend/src/facade/blueprintCatalog.ts
+++ b/src/backend/src/facade/blueprintCatalog.ts
@@ -1,9 +1,15 @@
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
 import type {
+  ContainerBlueprint,
+  ContainerPriceEntry,
+  CultivationMethodBlueprint,
+  CultivationMethodPriceEntry,
   DeviceBlueprint,
   DevicePriceEntry,
   StrainBlueprint,
   StrainPriceEntry,
+  SubstrateBlueprint,
+  SubstratePriceEntry,
 } from '@/data/schemas/index.js';
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
@@ -72,6 +78,51 @@ export interface DeviceBlueprintCatalogEntry {
   price?: DevicePriceEntry;
 }
 
+export interface CultivationMethodCompatibility {
+  compatibleSubstrateTypes?: string[];
+  compatibleContainerTypes?: string[];
+  strainTraitCompatibility?: CultivationMethodBlueprint['strainTraitCompatibility'];
+}
+
+export interface CultivationMethodBlueprintCatalogEntry {
+  id: string;
+  name: string;
+  laborIntensity: number;
+  areaPerPlant: number;
+  minimumSpacing: number;
+  maxCycles?: number;
+  compatibility: CultivationMethodCompatibility;
+  envBias?: CultivationMethodBlueprint['envBias'];
+  capacityHints?: CultivationMethodBlueprint['capacityHints'];
+  laborProfile?: CultivationMethodBlueprint['laborProfile'];
+  idealConditions?: CultivationMethodBlueprint['idealConditions'];
+  metadata?: CultivationMethodBlueprint['meta'];
+  price?: CultivationMethodPriceEntry;
+}
+
+export interface ContainerBlueprintCatalogEntry {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  volumeInLiters?: number;
+  footprintArea?: number;
+  reusableCycles?: number;
+  packingDensity?: number;
+  metadata?: ContainerBlueprint['meta'];
+  price?: ContainerPriceEntry;
+}
+
+export interface SubstrateBlueprintCatalogEntry {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  maxCycles?: number;
+  metadata?: SubstrateBlueprint['meta'];
+  price?: SubstratePriceEntry;
+}
+
 const buildStrainPriceMap = (repository: BlueprintRepository): Map<string, StrainPriceEntry> => {
   if (typeof repository.listStrainPrices !== 'function') {
     return new Map();
@@ -84,6 +135,33 @@ const buildDevicePriceMap = (repository: BlueprintRepository): Map<string, Devic
     return new Map();
   }
   return new Map(repository.listDevicePrices());
+};
+
+const buildCultivationMethodPriceMap = (
+  repository: BlueprintRepository,
+): Map<string, CultivationMethodPriceEntry> => {
+  if (typeof repository.listCultivationMethodPrices !== 'function') {
+    return new Map();
+  }
+  return new Map(repository.listCultivationMethodPrices());
+};
+
+const buildContainerPriceMap = (
+  repository: BlueprintRepository,
+): Map<string, ContainerPriceEntry> => {
+  if (typeof repository.listContainerPrices !== 'function') {
+    return new Map();
+  }
+  return new Map(repository.listContainerPrices());
+};
+
+const buildSubstratePriceMap = (
+  repository: BlueprintRepository,
+): Map<string, SubstratePriceEntry> => {
+  if (typeof repository.listSubstratePrices !== 'function') {
+    return new Map();
+  }
+  return new Map(repository.listSubstratePrices());
 };
 
 export const buildStrainBlueprintCatalog = (
@@ -200,6 +278,136 @@ export const buildDeviceBlueprintCatalog = (
       }
 
       const price = prices.get(device.id);
+      if (price) {
+        entry.price = clone(price);
+      }
+
+      return entry;
+    })
+    .sort(sortByName);
+};
+
+export const buildCultivationMethodBlueprintCatalog = (
+  repository: BlueprintRepository,
+): CultivationMethodBlueprintCatalogEntry[] => {
+  const prices = buildCultivationMethodPriceMap(repository);
+
+  return repository
+    .listCultivationMethods()
+    .map((method) => {
+      const compatibility: CultivationMethodCompatibility = {};
+      if (method.compatibleSubstrateTypes) {
+        compatibility.compatibleSubstrateTypes = [...method.compatibleSubstrateTypes];
+      }
+      if (method.compatibleContainerTypes) {
+        compatibility.compatibleContainerTypes = [...method.compatibleContainerTypes];
+      }
+      if (method.strainTraitCompatibility) {
+        compatibility.strainTraitCompatibility = clone(method.strainTraitCompatibility);
+      }
+
+      const entry: CultivationMethodBlueprintCatalogEntry = {
+        id: method.id,
+        name: method.name,
+        laborIntensity: method.laborIntensity,
+        areaPerPlant: method.areaPerPlant,
+        minimumSpacing: method.minimumSpacing,
+        compatibility,
+      };
+
+      if (typeof method.maxCycles === 'number') {
+        entry.maxCycles = method.maxCycles;
+      }
+      if (method.envBias) {
+        entry.envBias = clone(method.envBias);
+      }
+      if (method.capacityHints) {
+        entry.capacityHints = clone(method.capacityHints);
+      }
+      if (method.laborProfile) {
+        entry.laborProfile = clone(method.laborProfile);
+      }
+      if (method.idealConditions) {
+        entry.idealConditions = clone(method.idealConditions);
+      }
+      if (method.meta) {
+        entry.metadata = clone(method.meta);
+      }
+
+      const price = prices.get(method.id);
+      if (price) {
+        entry.price = clone(price);
+      }
+
+      return entry;
+    })
+    .sort(sortByName);
+};
+
+export const buildContainerBlueprintCatalog = (
+  repository: BlueprintRepository,
+): ContainerBlueprintCatalogEntry[] => {
+  const prices = buildContainerPriceMap(repository);
+
+  return repository
+    .listContainers()
+    .map((container) => {
+      const entry: ContainerBlueprintCatalogEntry = {
+        id: container.id,
+        slug: container.slug,
+        name: container.name,
+        type: container.type,
+      };
+
+      if (typeof container.volumeInLiters === 'number') {
+        entry.volumeInLiters = container.volumeInLiters;
+      }
+      if (typeof container.footprintArea === 'number') {
+        entry.footprintArea = container.footprintArea;
+      }
+      if (typeof container.reusableCycles === 'number') {
+        entry.reusableCycles = container.reusableCycles;
+      }
+      if (typeof container.packingDensity === 'number') {
+        entry.packingDensity = container.packingDensity;
+      }
+      if (container.meta) {
+        entry.metadata = clone(container.meta);
+      }
+
+      const price = prices.get(container.slug);
+      if (price) {
+        entry.price = clone(price);
+      }
+
+      return entry;
+    })
+    .sort(sortByName);
+};
+
+export const buildSubstrateBlueprintCatalog = (
+  repository: BlueprintRepository,
+): SubstrateBlueprintCatalogEntry[] => {
+  const prices = buildSubstratePriceMap(repository);
+
+  return repository
+    .listSubstrates()
+    .map((substrate) => {
+      const entry: SubstrateBlueprintCatalogEntry = {
+        id: substrate.id,
+        slug: substrate.slug,
+        name: substrate.name,
+        type: substrate.type,
+      };
+
+      if (typeof substrate.maxCycles === 'number') {
+        entry.maxCycles = substrate.maxCycles;
+      }
+      if (substrate.meta) {
+        entry.metadata = clone(substrate.meta);
+      }
+
+      const price = prices.get(substrate.slug);
       if (price) {
         entry.price = clone(price);
       }

--- a/src/backend/src/facade/commands/world.ts
+++ b/src/backend/src/facade/commands/world.ts
@@ -9,6 +9,9 @@ import type {
 import type { StructureBlueprint } from '@/state/models.js';
 import type {
   DeviceBlueprintCatalogEntry,
+  CultivationMethodBlueprintCatalogEntry,
+  ContainerBlueprintCatalogEntry,
+  SubstrateBlueprintCatalogEntry,
   StrainBlueprintCatalogEntry,
 } from '@/facade/blueprintCatalog.js';
 import {
@@ -35,6 +38,9 @@ const rentStructureSchema = z
 const getStructureBlueprintsSchema = emptyObjectSchema;
 const getStrainBlueprintsSchema = emptyObjectSchema;
 const getDeviceBlueprintsSchema = emptyObjectSchema;
+const getCultivationMethodBlueprintsSchema = emptyObjectSchema;
+const getContainerBlueprintsSchema = emptyObjectSchema;
+const getSubstrateBlueprintsSchema = emptyObjectSchema;
 const createRoomSchema = z
   .object({
     structureId: entityIdentifier,
@@ -80,6 +86,20 @@ const createZoneSchema = z
         name: nonEmptyString,
         area: positiveNumber,
         methodId: uuid,
+        container: z
+          .object({
+            blueprintId: uuid,
+            type: nonEmptyString,
+            count: positiveInteger,
+          })
+          .strict(),
+        substrate: z
+          .object({
+            blueprintId: uuid,
+            type: nonEmptyString,
+            volumeLiters: positiveNumber.optional(),
+          })
+          .strict(),
         targetPlantCount: positiveInteger.optional(),
       })
       .strict(),
@@ -181,6 +201,11 @@ export type RentStructureIntent = z.infer<typeof rentStructureSchema>;
 export type GetStructureBlueprintsIntent = z.infer<typeof getStructureBlueprintsSchema>;
 export type GetStrainBlueprintsIntent = z.infer<typeof getStrainBlueprintsSchema>;
 export type GetDeviceBlueprintsIntent = z.infer<typeof getDeviceBlueprintsSchema>;
+export type GetCultivationMethodBlueprintsIntent = z.infer<
+  typeof getCultivationMethodBlueprintsSchema
+>;
+export type GetContainerBlueprintsIntent = z.infer<typeof getContainerBlueprintsSchema>;
+export type GetSubstrateBlueprintsIntent = z.infer<typeof getSubstrateBlueprintsSchema>;
 export type CreateRoomIntent = z.infer<typeof createRoomSchema>;
 export type UpdateRoomIntent = z.infer<typeof updateRoomSchema>;
 export type DeleteRoomIntent = z.infer<typeof deleteRoomSchema>;
@@ -205,6 +230,18 @@ export interface WorldIntentHandlers {
   getDeviceBlueprints: ServiceCommandHandler<
     GetDeviceBlueprintsIntent,
     DeviceBlueprintCatalogEntry[]
+  >;
+  getCultivationMethodBlueprints: ServiceCommandHandler<
+    GetCultivationMethodBlueprintsIntent,
+    CultivationMethodBlueprintCatalogEntry[]
+  >;
+  getContainerBlueprints: ServiceCommandHandler<
+    GetContainerBlueprintsIntent,
+    ContainerBlueprintCatalogEntry[]
+  >;
+  getSubstrateBlueprints: ServiceCommandHandler<
+    GetSubstrateBlueprintsIntent,
+    SubstrateBlueprintCatalogEntry[]
   >;
   createRoom: ServiceCommandHandler<CreateRoomIntent, CreateRoomResult>;
   updateRoom: ServiceCommandHandler<UpdateRoomIntent>;
@@ -231,6 +268,18 @@ export interface WorldCommandRegistry {
   getDeviceBlueprints: CommandRegistration<
     GetDeviceBlueprintsIntent,
     DeviceBlueprintCatalogEntry[]
+  >;
+  getCultivationMethodBlueprints: CommandRegistration<
+    GetCultivationMethodBlueprintsIntent,
+    CultivationMethodBlueprintCatalogEntry[]
+  >;
+  getContainerBlueprints: CommandRegistration<
+    GetContainerBlueprintsIntent,
+    ContainerBlueprintCatalogEntry[]
+  >;
+  getSubstrateBlueprints: CommandRegistration<
+    GetSubstrateBlueprintsIntent,
+    SubstrateBlueprintCatalogEntry[]
   >;
   createRoom: CommandRegistration<CreateRoomIntent>;
   updateRoom: CommandRegistration<UpdateRoomIntent>;
@@ -278,6 +327,24 @@ export const buildWorldCommands = ({
     'world.getDeviceBlueprints',
     getDeviceBlueprintsSchema,
     () => services().getDeviceBlueprints,
+    onMissingHandler,
+  ),
+  getCultivationMethodBlueprints: createServiceCommand(
+    'world.getCultivationMethodBlueprints',
+    getCultivationMethodBlueprintsSchema,
+    () => services().getCultivationMethodBlueprints,
+    onMissingHandler,
+  ),
+  getContainerBlueprints: createServiceCommand(
+    'world.getContainerBlueprints',
+    getContainerBlueprintsSchema,
+    () => services().getContainerBlueprints,
+    onMissingHandler,
+  ),
+  getSubstrateBlueprints: createServiceCommand(
+    'world.getSubstrateBlueprints',
+    getSubstrateBlueprintsSchema,
+    () => services().getSubstrateBlueprints,
     onMissingHandler,
   ),
   createRoom: createServiceCommand<CreateRoomIntent, CreateRoomResult>(
@@ -367,6 +434,9 @@ export const schemas = {
   getStructureBlueprintsSchema,
   getStrainBlueprintsSchema,
   getDeviceBlueprintsSchema,
+  getCultivationMethodBlueprintsSchema,
+  getContainerBlueprintsSchema,
+  getSubstrateBlueprintsSchema,
   createRoomSchema,
   updateRoomSchema,
   deleteRoomSchema,

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -112,6 +112,9 @@ import type { GameState, StructureBlueprint } from '@/state/models.js';
 import type {
   DeviceBlueprintCatalogEntry,
   StrainBlueprintCatalogEntry,
+  CultivationMethodBlueprintCatalogEntry,
+  ContainerBlueprintCatalogEntry,
+  SubstrateBlueprintCatalogEntry,
 } from './blueprintCatalog.js';
 import { SimulationLoop, type SimulationLoopAccountingOptions } from '@/sim/loop.js';
 import { SimulationScheduler } from '@/sim/simScheduler.js';
@@ -157,6 +160,9 @@ export type {
   GetStructureBlueprintsIntent,
   GetStrainBlueprintsIntent,
   GetDeviceBlueprintsIntent,
+  GetCultivationMethodBlueprintsIntent,
+  GetContainerBlueprintsIntent,
+  GetSubstrateBlueprintsIntent,
   CreateRoomIntent,
   UpdateRoomIntent,
   DeleteRoomIntent,
@@ -175,6 +181,9 @@ export type {
 export type {
   StrainBlueprintCatalogEntry,
   DeviceBlueprintCatalogEntry,
+  CultivationMethodBlueprintCatalogEntry,
+  ContainerBlueprintCatalogEntry,
+  SubstrateBlueprintCatalogEntry,
 } from './blueprintCatalog.js';
 export type {
   InstallDeviceIntent,
@@ -282,6 +291,15 @@ export interface WorldIntentAPI {
   getDeviceBlueprints(
     intent?: GetDeviceBlueprintsIntent,
   ): Promise<CommandResult<DeviceBlueprintCatalogEntry[]>>;
+  getCultivationMethodBlueprints(
+    intent?: GetCultivationMethodBlueprintsIntent,
+  ): Promise<CommandResult<CultivationMethodBlueprintCatalogEntry[]>>;
+  getContainerBlueprints(
+    intent?: GetContainerBlueprintsIntent,
+  ): Promise<CommandResult<ContainerBlueprintCatalogEntry[]>>;
+  getSubstrateBlueprints(
+    intent?: GetSubstrateBlueprintsIntent,
+  ): Promise<CommandResult<SubstrateBlueprintCatalogEntry[]>>;
   createRoom(intent: CreateRoomIntent): Promise<CommandResult>;
   updateRoom(intent: UpdateRoomIntent): Promise<CommandResult>;
   deleteRoom(intent: DeleteRoomIntent): Promise<CommandResult>;

--- a/src/backend/src/facade/intent.integration.test.ts
+++ b/src/backend/src/facade/intent.integration.test.ts
@@ -18,6 +18,9 @@ import { RngService } from '@/lib/rng.js';
 import {
   buildDeviceBlueprintCatalog,
   buildStrainBlueprintCatalog,
+  buildCultivationMethodBlueprintCatalog,
+  buildContainerBlueprintCatalog,
+  buildSubstrateBlueprintCatalog,
 } from '@/facade/blueprintCatalog.js';
 import {
   createBlueprintRepositoryStub,
@@ -332,6 +335,7 @@ describe('SimulationFacade new intents', () => {
       rng,
       costAccounting,
       structureBlueprints,
+      repository,
     });
     const deviceService = new DeviceGroupService({ state, rng });
     const deviceInstallationService = new DeviceInstallationService({
@@ -349,6 +353,18 @@ describe('SimulationFacade new intents', () => {
         getStructureBlueprints: () => ({ ok: true, data: structureBlueprints }),
         getStrainBlueprints: () => ({ ok: true, data: buildStrainBlueprintCatalog(repository) }),
         getDeviceBlueprints: () => ({ ok: true, data: buildDeviceBlueprintCatalog(repository) }),
+        getCultivationMethodBlueprints: () => ({
+          ok: true,
+          data: buildCultivationMethodBlueprintCatalog(repository),
+        }),
+        getContainerBlueprints: () => ({
+          ok: true,
+          data: buildContainerBlueprintCatalog(repository),
+        }),
+        getSubstrateBlueprints: () => ({
+          ok: true,
+          data: buildSubstrateBlueprintCatalog(repository),
+        }),
         renameStructure: (intent, context) =>
           worldService.renameStructure(intent.structureId, intent.name, context),
         deleteStructure: (intent, context) =>

--- a/src/backend/src/server/socketGateway.integration.test.ts
+++ b/src/backend/src/server/socketGateway.integration.test.ts
@@ -23,6 +23,9 @@ import { DEFAULT_MAINTENANCE_INTERVAL_TICKS } from '@/constants/world.js';
 import {
   buildDeviceBlueprintCatalog,
   buildStrainBlueprintCatalog,
+  buildCultivationMethodBlueprintCatalog,
+  buildContainerBlueprintCatalog,
+  buildSubstrateBlueprintCatalog,
 } from '@/facade/blueprintCatalog.js';
 import {
   createBlueprintRepositoryStub,
@@ -407,6 +410,9 @@ describe('SocketGateway facade intents integration', () => {
   let repository: ReturnType<typeof createBlueprintRepositoryStub>;
   let expectedStrainCatalog: ReturnType<typeof buildStrainBlueprintCatalog>;
   let expectedDeviceCatalog: ReturnType<typeof buildDeviceBlueprintCatalog>;
+  let expectedMethodCatalog: ReturnType<typeof buildCultivationMethodBlueprintCatalog>;
+  let expectedContainerCatalog: ReturnType<typeof buildContainerBlueprintCatalog>;
+  let expectedSubstrateCatalog: ReturnType<typeof buildSubstrateBlueprintCatalog>;
   let structureBlueprints: ReturnType<typeof createStructureBlueprint>[];
 
   beforeEach(async () => {
@@ -479,6 +485,9 @@ describe('SocketGateway facade intents integration', () => {
     });
     expectedStrainCatalog = buildStrainBlueprintCatalog(repository);
     expectedDeviceCatalog = buildDeviceBlueprintCatalog(repository);
+    expectedMethodCatalog = buildCultivationMethodBlueprintCatalog(repository);
+    expectedContainerCatalog = buildContainerBlueprintCatalog(repository);
+    expectedSubstrateCatalog = buildSubstrateBlueprintCatalog(repository);
     structureBlueprints = [
       createStructureBlueprint({ id: STRUCTURE_BLUEPRINT_ID, name: 'Gateway Test Campus' }),
     ];
@@ -491,6 +500,7 @@ describe('SocketGateway facade intents integration', () => {
       rng,
       costAccounting,
       structureBlueprints,
+      repository,
     });
     const deviceService = new DeviceGroupService({ state, rng });
     const deviceInstallationService = new DeviceInstallationService({ state, rng, repository });
@@ -502,6 +512,18 @@ describe('SocketGateway facade intents integration', () => {
         getStructureBlueprints: () => ({ ok: true, data: structureBlueprints }),
         getStrainBlueprints: () => ({ ok: true, data: buildStrainBlueprintCatalog(repository) }),
         getDeviceBlueprints: () => ({ ok: true, data: buildDeviceBlueprintCatalog(repository) }),
+        getCultivationMethodBlueprints: () => ({
+          ok: true,
+          data: buildCultivationMethodBlueprintCatalog(repository),
+        }),
+        getContainerBlueprints: () => ({
+          ok: true,
+          data: buildContainerBlueprintCatalog(repository),
+        }),
+        getSubstrateBlueprints: () => ({
+          ok: true,
+          data: buildSubstrateBlueprintCatalog(repository),
+        }),
         renameStructure: (intent, context) =>
           worldService.renameStructure(intent.structureId, intent.name, context),
         deleteStructure: (intent, context) =>
@@ -662,6 +684,24 @@ describe('SocketGateway facade intents integration', () => {
     const response = await emitIntent('world', 'getDeviceBlueprints', {});
     expect(response.ok).toBe(true);
     expect(response.data).toEqual(expectedDeviceCatalog);
+  });
+
+  it('handles getCultivationMethodBlueprints intent', async () => {
+    const response = await emitIntent('world', 'getCultivationMethodBlueprints', {});
+    expect(response.ok).toBe(true);
+    expect(response.data).toEqual(expectedMethodCatalog);
+  });
+
+  it('handles getContainerBlueprints intent', async () => {
+    const response = await emitIntent('world', 'getContainerBlueprints', {});
+    expect(response.ok).toBe(true);
+    expect(response.data).toEqual(expectedContainerCatalog);
+  });
+
+  it('handles getSubstrateBlueprints intent', async () => {
+    const response = await emitIntent('world', 'getSubstrateBlueprints', {});
+    expect(response.ok).toBe(true);
+    expect(response.data).toEqual(expectedSubstrateCatalog);
   });
 
   it('handles duplicateStructure intent', async () => {

--- a/src/backend/src/server/startServer.ts
+++ b/src/backend/src/server/startServer.ts
@@ -22,6 +22,9 @@ import {
 import {
   buildDeviceBlueprintCatalog,
   buildStrainBlueprintCatalog,
+  buildCultivationMethodBlueprintCatalog,
+  buildContainerBlueprintCatalog,
+  buildSubstrateBlueprintCatalog,
 } from '@/facade/blueprintCatalog.js';
 import { SocketGateway } from '@/server/socketGateway.js';
 import { SseGateway } from '@/server/sseGateway.js';
@@ -333,6 +336,7 @@ export const startBackendServer = async (
     structureBlueprints,
     roomPurposeSource: repository,
     difficultyConfig,
+    repository,
   });
   const deviceGroupService = new DeviceGroupService({ state, rng });
   const deviceInstallationService = new DeviceInstallationService({
@@ -366,6 +370,21 @@ export const startBackendServer = async (
           ok: true,
           data: buildDeviceBlueprintCatalog(repository),
         }) satisfies CommandResult<ReturnType<typeof buildDeviceBlueprintCatalog>>,
+      getCultivationMethodBlueprints: () =>
+        ({
+          ok: true,
+          data: buildCultivationMethodBlueprintCatalog(repository),
+        }) satisfies CommandResult<ReturnType<typeof buildCultivationMethodBlueprintCatalog>>,
+      getContainerBlueprints: () =>
+        ({
+          ok: true,
+          data: buildContainerBlueprintCatalog(repository),
+        }) satisfies CommandResult<ReturnType<typeof buildContainerBlueprintCatalog>>,
+      getSubstrateBlueprints: () =>
+        ({
+          ok: true,
+          data: buildSubstrateBlueprintCatalog(repository),
+        }) satisfies CommandResult<ReturnType<typeof buildSubstrateBlueprintCatalog>>,
       createRoom: (intent, context) => worldService.createRoom(intent, context),
       createZone: (intent, context) => worldService.createZone(intent, context),
       renameStructure: (intent, context) =>

--- a/src/backend/src/state/models.ts
+++ b/src/backend/src/state/models.ts
@@ -261,6 +261,25 @@ export interface ZoneHealthState {
   preHarvestRestrictedUntilTick?: number;
 }
 
+export interface ZoneContainerSetup {
+  blueprintId: string;
+  slug: string;
+  type: string;
+  count: number;
+}
+
+export interface ZoneSubstrateSetup {
+  blueprintId: string;
+  slug: string;
+  type: string;
+  totalVolumeLiters: number;
+}
+
+export interface ZoneCultivationSetup {
+  container?: ZoneContainerSetup;
+  substrate?: ZoneSubstrateSetup;
+}
+
 export interface ZoneState {
   id: string;
   roomId: string;
@@ -280,6 +299,7 @@ export interface ZoneState {
   health: ZoneHealthState;
   activeTaskIds: string[];
   plantingPlan?: ZonePlantingPlanState | null;
+  cultivation?: ZoneCultivationSetup;
 }
 
 export type PlantStage =

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,7 @@
     "@eslint/js": "^9.36.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.10.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/src/frontend/src/facade/systemFacade.test.ts
+++ b/src/frontend/src/facade/systemFacade.test.ts
@@ -1,14 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
 import type { SimulationBridge } from './systemFacade';
 
+type UseSimulationStoreHook = typeof import('@/store/simulation').useSimulationStore;
+let useSimulationStore: UseSimulationStoreHook;
+
+const socketHandlers: Record<string, (...args: unknown[]) => void> = {};
+let socketInstance: {
+  on: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  connected: boolean;
+} | null = null;
+
 vi.mock('socket.io-client', () => ({
-  io: vi.fn(() => ({
-    on: vi.fn(),
-    connect: vi.fn(),
-    emit: vi.fn(),
-    disconnect: vi.fn(),
-    connected: false,
-  })),
+  io: vi.fn(() => {
+    socketInstance = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        socketHandlers[event] = handler;
+      }),
+      emit: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      connected: false,
+    };
+    return socketInstance;
+  }),
 }));
 
 describe('SocketSystemFacade convenience wrappers', () => {
@@ -17,6 +35,11 @@ describe('SocketSystemFacade convenience wrappers', () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    ({ useSimulationStore } = await import('@/store/simulation'));
+    for (const key of Object.keys(socketHandlers)) {
+      delete socketHandlers[key];
+    }
+    socketInstance = null;
     sendIntentMock = vi.fn(async () => ({ ok: true }));
     const module = await import('./systemFacade');
     bridge = module.getSimulationBridge();
@@ -24,10 +47,12 @@ describe('SocketSystemFacade convenience wrappers', () => {
       connected: true,
     } as { connected: boolean };
     (bridge as unknown as { sendIntent: typeof sendIntentMock }).sendIntent = sendIntentMock;
+    useSimulationStore.getState().reset();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    useSimulationStore.getState().reset();
   });
 
   it('fetches strain blueprints via the world command', async () => {
@@ -54,6 +79,48 @@ describe('SocketSystemFacade convenience wrappers', () => {
     expect(sendIntentMock).toHaveBeenCalledWith({
       domain: 'world',
       action: 'getDeviceBlueprints',
+      payload: {},
+    });
+  });
+
+  it('fetches cultivation method blueprints via the world command', async () => {
+    const response = { ok: true, data: [] };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.getCultivationMethodBlueprints();
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'world',
+      action: 'getCultivationMethodBlueprints',
+      payload: {},
+    });
+  });
+
+  it('fetches container blueprints via the world command', async () => {
+    const response = { ok: true, data: [] };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.getContainerBlueprints();
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'world',
+      action: 'getContainerBlueprints',
+      payload: {},
+    });
+  });
+
+  it('fetches substrate blueprints via the world command', async () => {
+    const response = { ok: true, data: [] };
+    sendIntentMock.mockResolvedValueOnce(response);
+
+    const result = await bridge.getSubstrateBlueprints();
+
+    expect(result).toBe(response);
+    expect(sendIntentMock).toHaveBeenCalledWith({
+      domain: 'world',
+      action: 'getSubstrateBlueprints',
       payload: {},
     });
   });
@@ -151,5 +218,92 @@ describe('SocketSystemFacade convenience wrappers', () => {
         photoperiodHours: { on: 19, off: 5 },
       },
     });
+  });
+
+  it('hydrates blueprint catalogs when the socket connects', async () => {
+    const methodEntry = {
+      id: 'method-1',
+      name: 'Method One',
+      laborIntensity: 1,
+      areaPerPlant: 1,
+      minimumSpacing: 1,
+      compatibility: {},
+    };
+    const containerEntry = {
+      id: 'container-1',
+      slug: 'container-1',
+      name: 'Container One',
+      type: 'pot',
+    };
+    const substrateEntry = {
+      id: 'substrate-1',
+      slug: 'substrate-1',
+      name: 'Substrate One',
+      type: 'soil',
+    };
+
+    const originalSetCatalogStatus = useSimulationStore.getState().setCatalogStatus;
+    const setCatalogStatusSpy = vi.fn<
+      Parameters<typeof originalSetCatalogStatus>,
+      ReturnType<typeof originalSetCatalogStatus>
+    >((catalog, status, payload) => originalSetCatalogStatus(catalog, status, payload));
+    useSimulationStore.setState({ setCatalogStatus: setCatalogStatusSpy });
+    expect(useSimulationStore.getState().setCatalogStatus).toBe(setCatalogStatusSpy);
+
+    try {
+      sendIntentMock
+        .mockResolvedValueOnce({ ok: true, data: [methodEntry] })
+        .mockResolvedValueOnce({ ok: true, data: [containerEntry] })
+        .mockResolvedValueOnce({ ok: true, data: [substrateEntry] });
+
+      (bridge as unknown as { socket: null }).socket = null;
+      (bridge as unknown as { isConnecting: boolean }).isConnecting = false;
+
+      bridge.connect();
+      expect(socketInstance).not.toBeNull();
+      if (socketInstance) {
+        socketInstance.connected = true;
+      }
+
+      await act(async () => {
+        socketHandlers.connect?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(sendIntentMock).toHaveBeenCalledTimes(3);
+      });
+
+      await waitFor(() => {
+        expect(setCatalogStatusSpy).toHaveBeenCalledWith(
+          'cultivationMethods',
+          'ready',
+          expect.objectContaining({ data: [methodEntry], error: null }),
+        );
+        expect(setCatalogStatusSpy).toHaveBeenCalledWith(
+          'containers',
+          'ready',
+          expect.objectContaining({ data: [containerEntry], error: null }),
+        );
+        expect(setCatalogStatusSpy).toHaveBeenCalledWith(
+          'substrates',
+          'ready',
+          expect.objectContaining({ data: [substrateEntry], error: null }),
+        );
+      });
+
+      await waitFor(() => {
+        const state = useSimulationStore.getState();
+        expect(state.catalogs.cultivationMethods.status).toBe('ready');
+        expect(state.catalogs.cultivationMethods.data).toEqual([methodEntry]);
+        expect(state.catalogs.containers.status).toBe('ready');
+        expect(state.catalogs.containers.data).toEqual([containerEntry]);
+        expect(state.catalogs.substrates.status).toBe('ready');
+        expect(state.catalogs.substrates.data).toEqual([substrateEntry]);
+      });
+    } finally {
+      useSimulationStore.setState({ setCatalogStatus: originalSetCatalogStatus });
+    }
   });
 });

--- a/src/frontend/src/types/blueprints.ts
+++ b/src/frontend/src/types/blueprints.ts
@@ -1,0 +1,46 @@
+export type CatalogStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface CultivationMethodCompatibility {
+  compatibleSubstrateTypes?: string[];
+  compatibleContainerTypes?: string[];
+  strainTraitCompatibility?: Record<string, unknown>;
+}
+
+export interface CultivationMethodCatalogEntry {
+  id: string;
+  name: string;
+  laborIntensity: number;
+  areaPerPlant: number;
+  minimumSpacing: number;
+  maxCycles?: number;
+  compatibility: CultivationMethodCompatibility;
+  envBias?: Record<string, unknown>;
+  capacityHints?: Record<string, unknown>;
+  laborProfile?: Record<string, unknown>;
+  idealConditions?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  price?: { setupCost: number };
+}
+
+export interface ContainerCatalogEntry {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  volumeInLiters?: number;
+  footprintArea?: number;
+  reusableCycles?: number;
+  packingDensity?: number;
+  metadata?: Record<string, unknown>;
+  price?: { costPerUnit: number };
+}
+
+export interface SubstrateCatalogEntry {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  maxCycles?: number;
+  metadata?: Record<string, unknown>;
+  price?: { costPerLiter: number };
+}


### PR DESCRIPTION
## Summary
- expose cultivation method, container, and substrate catalogs throughout the backend facade, world service, and socket gateway
- hydrate the frontend simulation store with catalog data, pull Create Zone modal selections from the facade, and surface pricing + validation
- expand Vitest coverage for catalog loading and zone creation flows, including silencing an unnecessary act() wrapper in the modal test suite

## Testing
- pnpm --filter @weebbreed/frontend test
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68da73e72d448325b170fa309137996f