### PR TITLE
Refine world service collaborators and zone updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extending schemas, repository accessors, loader cross-checks, and docs to surface
   the new price sources.
 
+### Changed
+
+- Replaced the monolithic world service with dedicated structure/room/zone collaborators,
+  extracted cloning helpers, and completed the `ZoneService.updateZone` migration so
+  cultivation defaults, validations, and telemetry align with the refactored delegates.
+
 - Extended the `world.updateZone` intent to accept container and substrate patches, revalidating
   method compatibility, clamping container capacity, recomputing substrate volume, and persisting
   consumable metadata with regression coverage and facade bridge support.【F:src/backend/src/facade/commands/world.ts†L109-L133】【F:src/backend/src/engine/world/worldService.ts†L828-L1106】【F:src/backend/src/engine/world/worldService.updateZone.test.ts†L128-L210】【F:src/frontend/src/facade/systemFacade.ts†L440-L456】

--- a/src/backend/src/engine/world/roomService.ts
+++ b/src/backend/src/engine/world/roomService.ts
@@ -1,0 +1,225 @@
+import type { CostAccountingService } from '@/engine/economy/costAccounting.js';
+import type {
+  CommandExecutionContext,
+  CommandResult,
+  CreateRoomIntent,
+  ErrorCode,
+} from '@/facade/index.js';
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import { findRoom, findStructure } from './stateSelectors.js';
+import { validateStructureGeometry } from '@/state/geometry.js';
+import type { GameState, RoomState } from '@/state/models.js';
+import { deriveDuplicateName } from './worldDefaults.js';
+import type { RoomPurposeSource } from '@/engine/roomPurposes/index.js';
+import { resolveRoomPurposeId } from '@/engine/roomPurposes/index.js';
+import type { ZoneService, DevicePurchaseMap } from './zoneService.js';
+
+export interface CreateRoomResult {
+  roomId: string;
+}
+
+export interface DuplicateRoomResult {
+  roomId: string;
+}
+
+export type FailureFactory = <T>(
+  code: ErrorCode,
+  message: string,
+  path: string[],
+) => CommandResult<T>;
+
+export interface RoomServiceDependencies {
+  state: GameState;
+  costAccounting: CostAccountingService;
+  repository: BlueprintRepository;
+  createId: (prefix: string) => string;
+  roomPurposeSource?: RoomPurposeSource;
+  zoneService: Pick<ZoneService, 'cloneZone'>;
+  failure: FailureFactory;
+}
+
+export interface RoomService {
+  createRoom(
+    intent: CreateRoomIntent,
+    context: CommandExecutionContext,
+  ): CommandResult<CreateRoomResult>;
+  duplicateRoom(
+    roomId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateRoomResult>;
+  cloneRoom(
+    room: RoomState,
+    structureId: string,
+    context: CommandExecutionContext,
+    options?: { forcedName?: string; recordPurchases?: boolean },
+  ): { room: RoomState; purchases: DevicePurchaseMap };
+}
+
+const mergePurchaseMaps = (target: DevicePurchaseMap, source: DevicePurchaseMap): void => {
+  for (const [blueprintId, quantity] of source.entries()) {
+    const previous = target.get(blueprintId) ?? 0;
+    target.set(blueprintId, previous + quantity);
+  }
+};
+
+export const createRoomService = (deps: RoomServiceDependencies): RoomService => {
+  const createRoom = (
+    intent: CreateRoomIntent,
+    context: CommandExecutionContext,
+  ): CommandResult<CreateRoomResult> => {
+    const { structureId, room } = intent;
+    const lookup = findStructure(deps.state, structureId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
+        'world.createRoom',
+        'structureId',
+      ]);
+    }
+
+    const structure = lookup.structure;
+
+    if (!deps.roomPurposeSource) {
+      return deps.failure('ERR_INVALID_STATE', 'Room purpose registry is not configured.', [
+        'world.createRoom',
+        'room.purpose',
+      ]);
+    }
+
+    let purposeId: string;
+    try {
+      purposeId = resolveRoomPurposeId(deps.roomPurposeSource, room.purpose);
+    } catch (error) {
+      return deps.failure('ERR_NOT_FOUND', `Unknown room purpose: ${room.purpose}`, [
+        'world.createRoom',
+        'room.purpose',
+      ]);
+    }
+
+    const totalExistingArea = structure.rooms.reduce((sum, current) => sum + current.area, 0);
+    if (totalExistingArea + room.area > structure.footprint.area) {
+      return deps.failure(
+        'ERR_CONFLICT',
+        'Adding the room would exceed the structure footprint area.',
+        ['world.createRoom', 'room.area'],
+      );
+    }
+
+    const height = room.height ?? 2.5;
+    const newRoom: RoomState = {
+      id: deps.createId('room'),
+      structureId,
+      name: room.name.trim(),
+      purposeId,
+      area: room.area,
+      height,
+      volume: room.area * height,
+      cleanliness: 1,
+      maintenanceLevel: 1,
+      zones: [],
+    } satisfies RoomState;
+
+    structure.rooms.push(newRoom);
+    validateStructureGeometry(structure);
+
+    context.events.queue(
+      'world.roomCreated',
+      { roomId: newRoom.id, structureId, name: newRoom.name },
+      context.tick,
+      'info',
+    );
+
+    return { ok: true, data: { roomId: newRoom.id } } satisfies CommandResult<CreateRoomResult>;
+  };
+
+  const cloneRoom = (
+    room: RoomState,
+    structureId: string,
+    context: CommandExecutionContext,
+    options?: { forcedName?: string; recordPurchases?: boolean },
+  ): { room: RoomState; purchases: DevicePurchaseMap } => {
+    const forcedName = options?.forcedName;
+    const shouldRecord = options?.recordPurchases ?? false;
+    const newRoomId = deps.createId('room');
+    const zones: RoomState['zones'] = [];
+    const purchases: DevicePurchaseMap = new Map();
+
+    for (const zone of room.zones) {
+      const { zone: clonedZone, purchases: zonePurchases } = deps.zoneService.cloneZone(
+        zone,
+        structureId,
+        newRoomId,
+        context,
+        {
+          forcedName: forcedName ? zone.name : undefined,
+          recordPurchases: shouldRecord,
+        },
+      );
+      zones.push(clonedZone);
+      mergePurchaseMaps(purchases, zonePurchases);
+    }
+
+    const clonedRoom: RoomState = {
+      id: newRoomId,
+      structureId,
+      name: forcedName ?? deriveDuplicateName(room.name, 'Room Copy'),
+      purposeId: room.purposeId,
+      area: room.area,
+      height: room.height,
+      volume: room.volume,
+      cleanliness: room.cleanliness,
+      maintenanceLevel: room.maintenanceLevel,
+      zones,
+    } satisfies RoomState;
+
+    return { room: clonedRoom, purchases };
+  };
+
+  const duplicateRoom = (
+    roomId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateRoomResult> => {
+    const lookup = findRoom(deps.state, roomId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Room ${roomId} was not found.`, [
+        'world.duplicateRoom',
+        'roomId',
+      ]);
+    }
+
+    const { structure, room } = lookup;
+    const totalArea = structure.rooms.reduce((sum, current) => sum + current.area, 0);
+    if (totalArea + room.area - structure.footprint.area > 1e-6) {
+      return deps.failure(
+        'ERR_CONFLICT',
+        'Duplicating the room would exceed the structure footprint.',
+        ['world.duplicateRoom', 'roomId'],
+      );
+    }
+
+    const forcedName = desiredName?.trim().length ? desiredName.trim() : undefined;
+    const { room: newRoom } = cloneRoom(room, structure.id, context, {
+      forcedName,
+      recordPurchases: true,
+    });
+
+    structure.rooms.push(newRoom);
+    validateStructureGeometry(structure);
+
+    context.events.queue(
+      'world.roomDuplicated',
+      { roomId: newRoom.id, sourceRoomId: roomId, structureId: structure.id },
+      context.tick,
+      'info',
+    );
+
+    return { ok: true, data: { roomId: newRoom.id } } satisfies CommandResult<DuplicateRoomResult>;
+  };
+
+  return {
+    createRoom,
+    duplicateRoom,
+    cloneRoom,
+  };
+};

--- a/src/backend/src/engine/world/structureService.ts
+++ b/src/backend/src/engine/world/structureService.ts
@@ -1,0 +1,328 @@
+import type { CostAccountingService, TickAccumulator } from '@/engine/economy/costAccounting.js';
+import type { CommandExecutionContext, CommandResult, ErrorCode } from '@/facade/index.js';
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import { findStructure } from './stateSelectors.js';
+import { validateStructureGeometry } from '@/state/geometry.js';
+import type { GameState, StructureBlueprint, StructureState } from '@/state/models.js';
+import { deriveDuplicateName } from './worldDefaults.js';
+import type { RoomService } from './roomService.js';
+import type { DevicePurchaseMap } from './zoneService.js';
+
+export interface DuplicateStructureResult {
+  structureId: string;
+}
+
+export type FailureFactory = <T>(
+  code: ErrorCode,
+  message: string,
+  path: string[],
+) => CommandResult<T>;
+
+export interface StructureServiceDependencies {
+  state: GameState;
+  costAccounting: CostAccountingService;
+  repository: BlueprintRepository;
+  createId: (prefix: string) => string;
+  structureBlueprints?: StructureBlueprint[];
+  roomService: Pick<RoomService, 'cloneRoom'>;
+  failure: FailureFactory;
+}
+
+export interface StructureService {
+  renameStructure(
+    structureId: string,
+    name: string,
+    context: CommandExecutionContext,
+  ): CommandResult;
+  rentStructure(
+    structureId: string,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateStructureResult>;
+  deleteStructure(structureId: string, context: CommandExecutionContext): CommandResult;
+  duplicateStructure(
+    structureId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateStructureResult>;
+  recordDevicePurchases(
+    purchases: DevicePurchaseMap,
+    context: CommandExecutionContext,
+    description: string,
+  ): void;
+}
+
+const mergePurchaseMaps = (target: DevicePurchaseMap, source: DevicePurchaseMap): void => {
+  for (const [blueprintId, quantity] of source.entries()) {
+    const previous = target.get(blueprintId) ?? 0;
+    target.set(blueprintId, previous + quantity);
+  }
+};
+
+export const createStructureService = (deps: StructureServiceDependencies): StructureService => {
+  const applyAccumulator = (accumulator: TickAccumulator): void => {
+    const summary = deps.state.finances.summary;
+    summary.totalRevenue += accumulator.revenue;
+    summary.totalExpenses += accumulator.expenses;
+    summary.totalMaintenance += accumulator.maintenance;
+    summary.totalPayroll += accumulator.payroll;
+    summary.lastTickRevenue = accumulator.revenue;
+    summary.lastTickExpenses = accumulator.expenses;
+    summary.netIncome = summary.totalRevenue - summary.totalExpenses;
+  };
+
+  const recordDevicePurchases = (
+    purchases: DevicePurchaseMap,
+    context: CommandExecutionContext,
+    description: string,
+  ): void => {
+    if (purchases.size === 0) {
+      return;
+    }
+
+    const accumulator = deps.costAccounting.createAccumulator();
+    const timestamp = new Date().toISOString();
+    for (const [blueprintId, quantity] of purchases.entries()) {
+      deps.costAccounting.recordDevicePurchase(
+        deps.state,
+        blueprintId,
+        quantity,
+        context.tick,
+        timestamp,
+        accumulator,
+        context.events,
+        description,
+      );
+    }
+    applyAccumulator(accumulator);
+  };
+
+  const renameStructure = (
+    structureId: string,
+    name: string,
+    context: CommandExecutionContext,
+  ): CommandResult => {
+    const lookup = findStructure(deps.state, structureId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
+        'world.renameStructure',
+        'structureId',
+      ]);
+    }
+
+    const trimmedName = name.trim();
+    lookup.structure.name = trimmedName;
+
+    context.events.queue(
+      'world.structureRenamed',
+      { structureId, name: trimmedName },
+      context.tick,
+      'info',
+    );
+    return { ok: true } satisfies CommandResult;
+  };
+
+  const rentStructure = (
+    structureId: string,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateStructureResult> => {
+    if (!deps.structureBlueprints) {
+      return deps.failure('ERR_INVALID_STATE', 'Structure blueprints are not available.', [
+        'world.rentStructure',
+      ]);
+    }
+    const blueprint = deps.structureBlueprints.find((s) => s.id === structureId);
+    if (!blueprint) {
+      return deps.failure('ERR_NOT_FOUND', `Structure blueprint ${structureId} not found.`, [
+        'world.rentStructure',
+        'structureId',
+      ]);
+    }
+
+    if (deps.state.finances.cashOnHand < blueprint.upfrontFee) {
+      return deps.failure(
+        'ERR_INSUFFICIENT_FUNDS',
+        `Insufficient funds for upfront fee. Required: ${blueprint.upfrontFee}, Available: ${deps.state.finances.cashOnHand}`,
+        ['world.rentStructure', 'upfrontFee'],
+      );
+    }
+
+    const tickLengthHours = deps.state.metadata.tickLengthMinutes / 60;
+    const hoursPerMonth = 30 * 24;
+    const area = blueprint.footprint.length * blueprint.footprint.width;
+    const monthlyRentTotal = blueprint.rentalCostPerSqmPerMonth * area;
+    const hourlyRent = monthlyRentTotal / hoursPerMonth;
+    const rentPerTick = hourlyRent * tickLengthHours;
+
+    const newStructure: StructureState = {
+      id: deps.createId('structure'),
+      blueprintId: blueprint.id,
+      name: blueprint.name,
+      status: 'active',
+      footprint: {
+        ...blueprint.footprint,
+        area,
+        volume: area * (blueprint.footprint.height || 2.5),
+        height: blueprint.footprint.height || 2.5,
+      },
+      rooms: [],
+      rentPerTick,
+      upfrontCostPaid: blueprint.upfrontFee,
+      notes: undefined,
+    } satisfies StructureState;
+
+    deps.state.structures.push(newStructure);
+    deps.state.finances.cashOnHand -= blueprint.upfrontFee;
+
+    if (blueprint.upfrontFee > 0) {
+      const timestamp = new Date().toISOString();
+      const ledgerEntry = {
+        id: `ledger_${deps.state.finances.ledger.length + 1}`,
+        tick: context.tick,
+        timestamp,
+        amount: -blueprint.upfrontFee,
+        type: 'expense' as const,
+        category: 'rent' as const,
+        description: `Structure rental upfront fee: ${newStructure.name}`,
+      };
+
+      deps.state.finances.ledger.push(ledgerEntry);
+      const summary = deps.state.finances.summary;
+      summary.totalExpenses += blueprint.upfrontFee;
+      summary.lastTickExpenses = blueprint.upfrontFee;
+      summary.netIncome = summary.totalRevenue - summary.totalExpenses;
+
+      context.events.queue(
+        'finance.capex',
+        {
+          tick: context.tick,
+          amount: blueprint.upfrontFee,
+          category: 'rent',
+          description: `Structure rental upfront fee: ${newStructure.name}`,
+          structureId: newStructure.id,
+        },
+        context.tick,
+        'info',
+      );
+    }
+
+    context.events.queue(
+      'world.structureRented',
+      { structureId: newStructure.id, name: newStructure.name },
+      context.tick,
+      'info',
+    );
+
+    return {
+      ok: true,
+      data: { structureId: newStructure.id },
+    } satisfies CommandResult<DuplicateStructureResult>;
+  };
+
+  const removeTasksForStructure = (structureId: string): void => {
+    const filterTasks = (collection: typeof deps.state.tasks.backlog) =>
+      collection.filter((task) => task.location?.structureId !== structureId);
+
+    deps.state.tasks.backlog = filterTasks(deps.state.tasks.backlog);
+    deps.state.tasks.active = filterTasks(deps.state.tasks.active);
+    deps.state.tasks.completed = filterTasks(deps.state.tasks.completed);
+    deps.state.tasks.cancelled = filterTasks(deps.state.tasks.cancelled);
+  };
+
+  const deleteStructure = (
+    structureId: string,
+    context: CommandExecutionContext,
+  ): CommandResult => {
+    const lookup = findStructure(deps.state, structureId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
+        'world.deleteStructure',
+        'structureId',
+      ]);
+    }
+
+    const [removed] = deps.state.structures.splice(lookup.index, 1);
+    if (removed) {
+      for (const room of removed.rooms) {
+        for (const zone of room.zones) {
+          zone.activeTaskIds = [];
+        }
+      }
+      removeTasksForStructure(structureId);
+    }
+
+    context.events.queue('world.structureDeleted', { structureId }, context.tick, 'info');
+    return { ok: true } satisfies CommandResult;
+  };
+
+  const duplicateStructure = (
+    structureId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateStructureResult> => {
+    const lookup = findStructure(deps.state, structureId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
+        'world.duplicateStructure',
+        'structureId',
+      ]);
+    }
+
+    const source = lookup.structure;
+    const newStructureId = deps.createId('structure');
+    const duplicateName = desiredName?.trim().length
+      ? desiredName.trim()
+      : deriveDuplicateName(source.name, 'Structure Copy');
+    const rooms: StructureState['rooms'] = [];
+    const purchaseMap: DevicePurchaseMap = new Map();
+
+    for (const room of source.rooms) {
+      const { room: clonedRoom, purchases } = deps.roomService.cloneRoom(
+        room,
+        newStructureId,
+        context,
+        {
+          recordPurchases: false,
+        },
+      );
+      rooms.push(clonedRoom);
+      mergePurchaseMaps(purchaseMap, purchases);
+    }
+
+    const duplicated: StructureState = {
+      id: newStructureId,
+      blueprintId: source.blueprintId,
+      name: duplicateName,
+      status: 'active',
+      footprint: { ...source.footprint },
+      rooms,
+      rentPerTick: source.rentPerTick,
+      upfrontCostPaid: 0,
+      notes: undefined,
+    } satisfies StructureState;
+
+    validateStructureGeometry(duplicated);
+    deps.state.structures.push(duplicated);
+
+    recordDevicePurchases(purchaseMap, context, `Structure duplication from ${structureId}`);
+
+    context.events.queue(
+      'world.structureDuplicated',
+      { structureId: newStructureId, sourceStructureId: structureId, name: duplicateName },
+      context.tick,
+      'info',
+    );
+
+    return {
+      ok: true,
+      data: { structureId: newStructureId },
+    } satisfies CommandResult<DuplicateStructureResult>;
+  };
+
+  return {
+    renameStructure,
+    rentStructure,
+    deleteStructure,
+    duplicateStructure,
+    recordDevicePurchases,
+  };
+};

--- a/src/backend/src/engine/world/worldDefaults.ts
+++ b/src/backend/src/engine/world/worldDefaults.ts
@@ -1,0 +1,109 @@
+import {
+  DEFAULT_MAINTENANCE_INTERVAL_TICKS,
+  DEFAULT_ZONE_NUTRIENT_LITERS,
+  DEFAULT_ZONE_RESERVOIR_LEVEL,
+  DEFAULT_ZONE_WATER_LITERS,
+} from '@/constants/world.js';
+import type {
+  DeviceFailureModifiers,
+  PlantStressModifiers,
+  ZoneHealthState,
+  ZoneMetricState,
+  ZoneResourceState,
+  ZoneState,
+} from '@/state/models.js';
+
+export const deriveDuplicateName = (original: string, fallbackSuffix: string): string => {
+  const trimmed = original.trim();
+  if (trimmed.length === 0) {
+    return fallbackSuffix;
+  }
+  if (trimmed.toLowerCase().includes('copy')) {
+    return trimmed;
+  }
+  return `${trimmed} Copy`;
+};
+
+export const cloneMetrics = (source: ZoneMetricState, tick: number): ZoneMetricState => ({
+  averageTemperature: source.averageTemperature,
+  averageHumidity: source.averageHumidity,
+  averageCo2: source.averageCo2,
+  averagePpfd: source.averagePpfd,
+  stressLevel: source.stressLevel,
+  lastUpdatedTick: tick,
+});
+
+export const cloneCultivation = (
+  cultivation: ZoneState['cultivation'] | undefined,
+): ZoneState['cultivation'] | undefined => {
+  if (!cultivation) {
+    return undefined;
+  }
+
+  const cloned: ZoneState['cultivation'] = {};
+  if (cultivation.container) {
+    cloned.container = { ...cultivation.container };
+  }
+  if (cultivation.substrate) {
+    cloned.substrate = { ...cultivation.substrate };
+  }
+  return cloned;
+};
+
+export const createDefaultResources = (): ZoneResourceState => ({
+  waterLiters: DEFAULT_ZONE_WATER_LITERS,
+  nutrientSolutionLiters: DEFAULT_ZONE_NUTRIENT_LITERS,
+  nutrientStrength: 1,
+  substrateHealth: 1,
+  reservoirLevel: DEFAULT_ZONE_RESERVOIR_LEVEL,
+  lastTranspirationLiters: 0,
+});
+
+export const createEmptyHealth = (): ZoneHealthState => ({
+  plantHealth: {},
+  pendingTreatments: [],
+  appliedTreatments: [],
+});
+
+export const cloneEnvironment = (
+  environment: ZoneState['environment'],
+): ZoneState['environment'] => ({
+  temperature: environment.temperature,
+  relativeHumidity: environment.relativeHumidity,
+  co2: environment.co2,
+  ppfd: environment.ppfd,
+  vpd: environment.vpd,
+});
+
+export const cloneControl = (control: ZoneState['control'] | undefined): ZoneState['control'] => {
+  if (!control) {
+    return { setpoints: {} } satisfies ZoneState['control'];
+  }
+  const setpoints = control.setpoints ?? {};
+  return {
+    setpoints: {
+      temperature: setpoints.temperature,
+      humidity: setpoints.humidity,
+      co2: setpoints.co2,
+      ppfd: setpoints.ppfd,
+      vpd: setpoints.vpd,
+    },
+  } satisfies ZoneState['control'];
+};
+
+export const clonePlantStressModifiers = (source: PlantStressModifiers): PlantStressModifiers => ({
+  optimalRangeMultiplier: source.optimalRangeMultiplier,
+  stressAccumulationMultiplier: source.stressAccumulationMultiplier,
+});
+
+export const cloneDeviceFailureModifiers = (
+  source: DeviceFailureModifiers,
+): DeviceFailureModifiers => ({
+  mtbfMultiplier: source.mtbfMultiplier,
+});
+
+export const deepCloneSettings = (settings: Record<string, unknown>): Record<string, unknown> => {
+  return JSON.parse(JSON.stringify(settings));
+};
+
+export const defaultMaintenanceIntervalTicks = DEFAULT_MAINTENANCE_INTERVAL_TICKS;

--- a/src/backend/src/engine/world/worldService.ts
+++ b/src/backend/src/engine/world/worldService.ts
@@ -2,12 +2,6 @@ import { generateId } from '@/state/initialization/common.js';
 import type { RngService, RngStream } from '@/lib/rng.js';
 import { CostAccountingService, type TickAccumulator } from '@/engine/economy/costAccounting.js';
 import {
-  DEFAULT_MAINTENANCE_INTERVAL_TICKS,
-  DEFAULT_ZONE_NUTRIENT_LITERS,
-  DEFAULT_ZONE_RESERVOIR_LEVEL,
-  DEFAULT_ZONE_WATER_LITERS,
-} from '@/constants/world.js';
-import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
@@ -20,99 +14,35 @@ import {
   type GameState,
   type PlantStressModifiers,
   type StructureBlueprint,
-  type StructureState,
-  type RoomState,
-  type ZoneState,
-  type ZoneResourceState,
-  type ZoneMetricState,
-  type ZoneHealthState,
   type DifficultyLevel,
   type EconomicsSettings,
 } from '@/state/models.js';
-import { validateStructureGeometry } from '@/state/geometry.js';
-import { findStructure, findRoom, findZone, type ZoneLookupResult } from './stateSelectors.js';
-import { type RoomPurposeSource, resolveRoomPurposeId } from '@/engine/roomPurposes/index.js';
+import type { RoomPurposeSource } from '@/engine/roomPurposes/index.js';
 import type { DifficultyConfig } from '@/data/configs/difficulty.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
-import type { CultivationMethodBlueprint } from '@/data/schemas/index.js';
+import {
+  createStructureService,
+  type StructureService,
+  type DuplicateStructureResult,
+} from './structureService.js';
+import {
+  createRoomService,
+  type RoomService,
+  type CreateRoomResult,
+  type DuplicateRoomResult,
+} from './roomService.js';
+import {
+  createZoneService,
+  type ZoneService,
+  type CreateZoneResult,
+  type DuplicateZoneResult,
+} from './zoneService.js';
+import { cloneDeviceFailureModifiers, clonePlantStressModifiers } from './worldDefaults.js';
+import { type ZoneLookupResult } from './stateSelectors.js';
 
-const deriveDuplicateName = (original: string, fallbackSuffix: string): string => {
-  const trimmed = original.trim();
-  if (trimmed.length === 0) {
-    return fallbackSuffix;
-  }
-  if (trimmed.toLowerCase().includes('copy')) {
-    return trimmed;
-  }
-  return `${trimmed} Copy`;
-};
-
-const cloneMetrics = (source: ZoneMetricState, tick: number): ZoneMetricState => ({
-  averageTemperature: source.averageTemperature,
-  averageHumidity: source.averageHumidity,
-  averageCo2: source.averageCo2,
-  averagePpfd: source.averagePpfd,
-  stressLevel: source.stressLevel,
-  lastUpdatedTick: tick,
-});
-
-const cloneCultivation = (
-  cultivation: ZoneState['cultivation'] | undefined,
-): ZoneState['cultivation'] | undefined => {
-  if (!cultivation) {
-    return undefined;
-  }
-
-  const cloned: ZoneState['cultivation'] = {};
-  if (cultivation.container) {
-    cloned.container = { ...cultivation.container };
-  }
-  if (cultivation.substrate) {
-    cloned.substrate = { ...cultivation.substrate };
-  }
-  return cloned;
-};
-
-const createDefaultResources = (): ZoneResourceState => ({
-  waterLiters: DEFAULT_ZONE_WATER_LITERS,
-  nutrientSolutionLiters: DEFAULT_ZONE_NUTRIENT_LITERS,
-  nutrientStrength: 1,
-  substrateHealth: 1,
-  reservoirLevel: DEFAULT_ZONE_RESERVOIR_LEVEL,
-  lastTranspirationLiters: 0,
-});
-
-const createEmptyHealth = (): ZoneHealthState => ({
-  plantHealth: {},
-  pendingTreatments: [],
-  appliedTreatments: [],
-});
-
-const cloneEnvironment = (environment: ZoneState['environment']): ZoneState['environment'] => {
-  return {
-    temperature: environment.temperature,
-    relativeHumidity: environment.relativeHumidity,
-    co2: environment.co2,
-    ppfd: environment.ppfd,
-    vpd: environment.vpd,
-  };
-};
-
-const cloneControl = (control: ZoneState['control'] | undefined): ZoneState['control'] => {
-  if (!control) {
-    return { setpoints: {} } satisfies ZoneState['control'];
-  }
-  const setpoints = control.setpoints ?? {};
-  return {
-    setpoints: {
-      temperature: setpoints.temperature,
-      humidity: setpoints.humidity,
-      co2: setpoints.co2,
-      ppfd: setpoints.ppfd,
-      vpd: setpoints.vpd,
-    },
-  } satisfies ZoneState['control'];
-};
+export type { CreateZoneResult, DuplicateZoneResult } from './zoneService.js';
+export type { CreateRoomResult, DuplicateRoomResult } from './roomService.js';
+export type { DuplicateStructureResult } from './structureService.js';
 
 const DEFAULT_ECONOMICS: EconomicsSettings = {
   initialCapital: 1_500_000,
@@ -130,63 +60,6 @@ const DEFAULT_PLANT_STRESS_MODIFIERS: PlantStressModifiers = {
 const DEFAULT_DEVICE_FAILURE_MODIFIERS: DeviceFailureModifiers = {
   mtbfMultiplier: 1,
 };
-
-const clonePlantStressModifiers = (source: PlantStressModifiers): PlantStressModifiers => ({
-  optimalRangeMultiplier: source.optimalRangeMultiplier,
-  stressAccumulationMultiplier: source.stressAccumulationMultiplier,
-});
-
-const cloneDeviceFailureModifiers = (source: DeviceFailureModifiers): DeviceFailureModifiers => ({
-  mtbfMultiplier: source.mtbfMultiplier,
-});
-
-const deepCloneSettings = (settings: Record<string, unknown>): Record<string, unknown> => {
-  return JSON.parse(JSON.stringify(settings));
-};
-
-type DevicePurchaseMap = Map<string, number>;
-
-export interface DuplicateStructureResult {
-  structureId: string;
-}
-
-export interface DuplicateRoomResult {
-  roomId: string;
-}
-
-export interface CreateRoomResult {
-  roomId: string;
-}
-
-export interface CreateZoneResult {
-  zoneId: string;
-  method: {
-    blueprintId: string;
-    setupCost?: number;
-  };
-  container: {
-    blueprintId: string;
-    slug: string;
-    type: string;
-    count: number;
-    maxSupported: number;
-    unitCost?: number;
-    totalCost?: number;
-  };
-  substrate: {
-    blueprintId: string;
-    slug: string;
-    type: string;
-    totalVolumeLiters: number;
-    unitCost?: number;
-    totalCost?: number;
-  };
-  totalCost?: number;
-}
-
-export interface DuplicateZoneResult {
-  zoneId: string;
-}
 
 export interface WorldServiceOptions {
   state: GameState;
@@ -213,6 +86,12 @@ export class WorldService {
 
   private readonly repository: BlueprintRepository;
 
+  private readonly structureService: StructureService;
+
+  private readonly roomService: RoomService;
+
+  private readonly zoneService: ZoneService;
+
   constructor(options: WorldServiceOptions) {
     this.state = options.state;
     this.costAccounting = options.costAccounting;
@@ -221,6 +100,37 @@ export class WorldService {
     this.roomPurposeSource = options.roomPurposeSource;
     this.difficultyConfig = options.difficultyConfig;
     this.repository = options.repository;
+
+    const createId = (prefix: string) => this.createId(prefix);
+
+    this.zoneService = createZoneService({
+      state: this.state,
+      repository: this.repository,
+      costAccounting: this.costAccounting,
+      createId,
+      applyAccumulator: (accumulator) => this.applyAccumulator(accumulator),
+      failure: this.failure.bind(this),
+    });
+
+    this.roomService = createRoomService({
+      state: this.state,
+      costAccounting: this.costAccounting,
+      repository: this.repository,
+      createId,
+      roomPurposeSource: this.roomPurposeSource,
+      zoneService: this.zoneService,
+      failure: this.failure.bind(this),
+    });
+
+    this.structureService = createStructureService({
+      state: this.state,
+      costAccounting: this.costAccounting,
+      repository: this.repository,
+      createId,
+      structureBlueprints: this.structureBlueprints,
+      roomService: this.roomService,
+      failure: this.failure.bind(this),
+    });
   }
 
   private resolveEconomicsPreset(level: DifficultyLevel): EconomicsSettings {
@@ -236,26 +146,6 @@ export class WorldService {
   private resolveDeviceFailurePreset(level: DifficultyLevel): DeviceFailureModifiers {
     const preset = this.difficultyConfig?.[level]?.modifiers.deviceFailure;
     return cloneDeviceFailureModifiers(preset ?? DEFAULT_DEVICE_FAILURE_MODIFIERS);
-  }
-
-  private resolveMethodDefaults(method: CultivationMethodBlueprint): {
-    containerSlug?: string;
-    substrateSlug?: string;
-  } {
-    const meta = method.meta;
-    if (!meta || typeof meta !== 'object') {
-      return {};
-    }
-    const defaultsRaw = (meta as Record<string, unknown>).defaults;
-    if (!defaultsRaw || typeof defaultsRaw !== 'object') {
-      return {};
-    }
-    const defaults = defaultsRaw as Record<string, unknown>;
-    const containerSlug =
-      typeof defaults.containerSlug === 'string' ? defaults.containerSlug : undefined;
-    const substrateSlug =
-      typeof defaults.substrateSlug === 'string' ? defaults.substrateSlug : undefined;
-    return { containerSlug, substrateSlug };
   }
 
   private ensureDifficultyMetadata(): void {
@@ -281,914 +171,36 @@ export class WorldService {
     name: string,
     context: CommandExecutionContext,
   ): CommandResult {
-    const lookup = findStructure(this.state, structureId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
-        'world.renameStructure',
-        'structureId',
-      ]);
-    }
-
-    const trimmedName = name.trim();
-    lookup.structure.name = trimmedName;
-
-    context.events.queue(
-      'world.structureRenamed',
-      { structureId, name: trimmedName },
-      context.tick,
-      'info',
-    );
-    return { ok: true } satisfies CommandResult;
+    return this.structureService.renameStructure(structureId, name, context);
   }
 
   rentStructure(
     structureId: string,
     context: CommandExecutionContext,
   ): CommandResult<DuplicateStructureResult> {
-    if (!this.structureBlueprints) {
-      return this.failure('ERR_INVALID_STATE', 'Structure blueprints are not available.', [
-        'world.rentStructure',
-      ]);
-    }
-    const blueprint = this.structureBlueprints.find((s) => s.id === structureId);
-    if (!blueprint) {
-      return this.failure('ERR_NOT_FOUND', `Structure blueprint ${structureId} not found.`, [
-        'world.rentStructure',
-        'structureId',
-      ]);
-    }
-
-    // Allow renting multiple structures of any blueprint type
-
-    // Check if player has enough cash for upfront fee
-    if (this.state.finances.cashOnHand < blueprint.upfrontFee) {
-      return this.failure(
-        'ERR_INSUFFICIENT_FUNDS',
-        `Insufficient funds for upfront fee. Required: ${blueprint.upfrontFee}, Available: ${this.state.finances.cashOnHand}`,
-        ['world.rentStructure', 'upfrontFee'],
-      );
-    }
-
-    // Convert monthly rental cost to per-tick cost
-    // Assuming 30 days per month and tick length from game metadata
-    const tickLengthHours = this.state.metadata.tickLengthMinutes / 60;
-    const hoursPerMonth = 30 * 24; // 720 hours per month
-    const area = blueprint.footprint.length * blueprint.footprint.width;
-    const monthlyRentTotal = blueprint.rentalCostPerSqmPerMonth * area;
-    const hourlyRent = monthlyRentTotal / hoursPerMonth;
-    const rentPerTick = hourlyRent * tickLengthHours;
-
-    const newStructure: StructureState = {
-      id: this.createId('structure'),
-      blueprintId: blueprint.id,
-      name: blueprint.name,
-      status: 'active',
-      footprint: {
-        ...blueprint.footprint,
-        area: area,
-        volume: area * (blueprint.footprint.height || 2.5),
-        height: blueprint.footprint.height || 2.5,
-      },
-      rooms: [],
-      rentPerTick: rentPerTick,
-      upfrontCostPaid: blueprint.upfrontFee,
-      notes: undefined,
-    };
-
-    this.state.structures.push(newStructure);
-
-    // Deduct upfront fee from cash
-    this.state.finances.cashOnHand -= blueprint.upfrontFee;
-
-    // Record upfront fee as a capital expenditure if there's an amount
-    if (blueprint.upfrontFee > 0) {
-      const timestamp = new Date().toISOString();
-
-      // Create ledger entry for upfront fee
-      const ledgerEntry = {
-        id: `ledger_${this.state.finances.ledger.length + 1}`,
-        tick: context.tick,
-        timestamp,
-        amount: -blueprint.upfrontFee,
-        type: 'expense' as const,
-        category: 'rent' as const,
-        description: `Structure rental upfront fee: ${newStructure.name}`,
-      };
-
-      this.state.finances.ledger.push(ledgerEntry);
-
-      // Update finance summary
-      this.state.finances.summary.totalExpenses += blueprint.upfrontFee;
-      this.state.finances.summary.lastTickExpenses = blueprint.upfrontFee;
-      this.state.finances.summary.netIncome =
-        this.state.finances.summary.totalRevenue - this.state.finances.summary.totalExpenses;
-
-      context.events.queue(
-        'finance.capex',
-        {
-          tick: context.tick,
-          amount: blueprint.upfrontFee,
-          category: 'rent',
-          description: `Structure rental upfront fee: ${newStructure.name}`,
-          structureId: newStructure.id,
-        },
-        context.tick,
-        'info',
-      );
-    }
-
-    // Note: Structure rent costs are automatically handled by the accounting system during tick processing
-
-    context.events.queue(
-      'world.structureRented',
-      { structureId: newStructure.id, name: newStructure.name },
-      context.tick,
-      'info',
-    );
-
-    return {
-      ok: true,
-      data: { structureId: newStructure.id },
-    } satisfies CommandResult<DuplicateStructureResult>;
+    return this.structureService.rentStructure(structureId, context);
   }
 
   createRoom(
     intent: CreateRoomIntent,
     context: CommandExecutionContext,
   ): CommandResult<CreateRoomResult> {
-    const { structureId, room } = intent;
-    const lookup = findStructure(this.state, structureId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
-        'world.createRoom',
-        'structureId',
-      ]);
-    }
-
-    const structure = lookup.structure;
-
-    // Resolve room purpose ID from name
-    if (!this.roomPurposeSource) {
-      return this.failure('ERR_INVALID_STATE', 'Room purpose registry is not configured.', [
-        'world.createRoom',
-        'room.purpose',
-      ]);
-    }
-
-    let purposeId: string;
-    try {
-      purposeId = resolveRoomPurposeId(this.roomPurposeSource, room.purpose);
-    } catch (error) {
-      return this.failure('ERR_NOT_FOUND', `Unknown room purpose: ${room.purpose}`, [
-        'world.createRoom',
-        'room.purpose',
-      ]);
-    }
-
-    // Check if adding the room would exceed the structure footprint
-    const totalExistingArea = structure.rooms.reduce((sum, current) => sum + current.area, 0);
-    if (totalExistingArea + room.area > structure.footprint.area) {
-      return this.failure(
-        'ERR_CONFLICT',
-        'Adding the room would exceed the structure footprint area.',
-        ['world.createRoom', 'room.area'],
-      );
-    }
-
-    // Create the new room
-    const height = room.height ?? 2.5; // Default height if not specified
-    const newRoom: RoomState = {
-      id: this.createId('room'),
-      structureId,
-      name: room.name.trim(),
-      purposeId,
-      area: room.area,
-      height,
-      volume: room.area * height,
-      cleanliness: 1, // Start with perfect cleanliness
-      maintenanceLevel: 1, // Start with perfect maintenance
-      zones: [], // Start with no zones
-    } satisfies RoomState;
-
-    // Add the room to the structure
-    structure.rooms.push(newRoom);
-
-    // Validate the structure geometry
-    validateStructureGeometry(structure);
-
-    // Queue an event
-    context.events.queue(
-      'world.roomCreated',
-      { roomId: newRoom.id, structureId, name: newRoom.name },
-      context.tick,
-      'info',
-    );
-
-    return {
-      ok: true,
-      data: { roomId: newRoom.id },
-    } satisfies CommandResult<CreateRoomResult>;
+    return this.roomService.createRoom(intent, context);
   }
 
   createZone(
     intent: CreateZoneIntent,
     context: CommandExecutionContext,
   ): CommandResult<CreateZoneResult> {
-    const { roomId, zone } = intent;
-    const lookup = findRoom(this.state, roomId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Room ${roomId} was not found.`, [
-        'world.createZone',
-        'roomId',
-      ]);
-    }
-
-    const room = lookup.room;
-    const structure = lookup.structure;
-
-    // Check if adding the zone would exceed the room area
-    const totalExistingArea = room.zones.reduce((sum, current) => sum + current.area, 0);
-    if (totalExistingArea + zone.area > room.area) {
-      return this.failure('ERR_CONFLICT', 'Adding the zone would exceed the room area.', [
-        'world.createZone',
-        'zone.area',
-      ]);
-    }
-
-    const method = this.repository.getCultivationMethod(zone.methodId);
-    if (!method) {
-      return this.failure('ERR_NOT_FOUND', `Cultivation method ${zone.methodId} was not found.`, [
-        'world.createZone',
-        'zone.methodId',
-      ]);
-    }
-
-    const { container, substrate } = zone;
-
-    const containerBlueprint = this.repository.getContainer(container.blueprintId);
-    if (!containerBlueprint) {
-      return this.failure(
-        'ERR_NOT_FOUND',
-        `Container blueprint ${container.blueprintId} was not found.`,
-        ['world.createZone', 'zone.container.blueprintId'],
-      );
-    }
-
-    const containerType = containerBlueprint.type;
-    if (containerType !== container.type) {
-      return this.failure('ERR_VALIDATION', 'Container type does not match blueprint metadata.', [
-        'world.createZone',
-        'zone.container.type',
-      ]);
-    }
-
-    if (
-      Array.isArray(method.compatibleContainerTypes) &&
-      method.compatibleContainerTypes.length > 0 &&
-      !method.compatibleContainerTypes.includes(containerType)
-    ) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Container type '${containerType}' is incompatible with cultivation method '${method.name}'.`,
-        ['world.createZone', 'zone.container.type'],
-      );
-    }
-
-    const footprintArea = containerBlueprint.footprintArea;
-    if (!Number.isFinite(footprintArea) || footprintArea === undefined || footprintArea <= 0) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Container blueprint '${containerBlueprint.slug}' is missing a valid footprint area.`,
-        ['world.createZone', 'zone.container.blueprintId'],
-      );
-    }
-
-    const packingDensity = Number.isFinite(containerBlueprint.packingDensity)
-      ? Math.max(containerBlueprint.packingDensity ?? 0, 0)
-      : 1;
-    const effectiveDensity = packingDensity > 0 ? packingDensity : 1;
-    const theoreticalCapacity = (zone.area / footprintArea) * effectiveDensity;
-    const maxContainers = Number.isFinite(theoreticalCapacity)
-      ? Math.floor(Math.max(theoreticalCapacity, 0))
-      : 0;
-
-    if (maxContainers <= 0) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Zone area ${zone.area.toFixed(2)} m² cannot support container footprint ${footprintArea.toFixed(2)} m².`,
-        ['world.createZone', 'zone.container.count'],
-      );
-    }
-
-    if (container.count > maxContainers) {
-      return this.failure(
-        'ERR_CONFLICT',
-        `Requested ${container.count} containers exceeds maximum supported count of ${maxContainers}.`,
-        ['world.createZone', 'zone.container.count'],
-      );
-    }
-
-    const substrateBlueprint = this.repository.getSubstrate(substrate.blueprintId);
-    if (!substrateBlueprint) {
-      return this.failure(
-        'ERR_NOT_FOUND',
-        `Substrate blueprint ${substrate.blueprintId} was not found.`,
-        ['world.createZone', 'zone.substrate.blueprintId'],
-      );
-    }
-
-    const substrateType = substrateBlueprint.type;
-    if (substrateType !== substrate.type) {
-      return this.failure('ERR_VALIDATION', 'Substrate type does not match blueprint metadata.', [
-        'world.createZone',
-        'zone.substrate.type',
-      ]);
-    }
-
-    if (
-      Array.isArray(method.compatibleSubstrateTypes) &&
-      method.compatibleSubstrateTypes.length > 0 &&
-      !method.compatibleSubstrateTypes.includes(substrateType)
-    ) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Substrate type '${substrateType}' is incompatible with cultivation method '${method.name}'.`,
-        ['world.createZone', 'zone.substrate.type'],
-      );
-    }
-
-    const containerVolume = containerBlueprint.volumeInLiters;
-    if (
-      !Number.isFinite(containerVolume) ||
-      containerVolume === undefined ||
-      containerVolume <= 0
-    ) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Container blueprint '${containerBlueprint.slug}' is missing a valid volumeInLiters value.`,
-        ['world.createZone', 'zone.container.blueprintId'],
-      );
-    }
-
-    const requiredSubstrateVolume = containerVolume * container.count;
-    const warnings: string[] = [];
-
-    if (substrate.volumeLiters !== undefined) {
-      const providedVolume = substrate.volumeLiters;
-      if (!Number.isFinite(providedVolume) || providedVolume <= 0) {
-        warnings.push('Provided substrate volume was non-positive and has been ignored.');
-      } else {
-        const tolerance = Math.max(requiredSubstrateVolume * 0.05, 1);
-        if (Math.abs(providedVolume - requiredSubstrateVolume) > tolerance) {
-          warnings.push(
-            `Submitted substrate volume (${providedVolume.toFixed(2)} L) differs from the required ${requiredSubstrateVolume.toFixed(2)} L.`,
-          );
-        }
-      }
-    }
-
-    const methodPrice = this.repository.getCultivationMethodPrice(method.id);
-    const containerPrice = this.repository.getContainerPrice(containerBlueprint.slug);
-    const substratePrice = this.repository.getSubstratePrice(substrateBlueprint.slug);
-    const multiplier = this.state.metadata.economics.itemPriceMultiplier ?? 1;
-
-    const adjustedMethodCost =
-      methodPrice && Number.isFinite(methodPrice.setupCost)
-        ? Math.max(methodPrice.setupCost, 0) * multiplier
-        : undefined;
-    const adjustedContainerCost =
-      containerPrice && Number.isFinite(containerPrice.costPerUnit)
-        ? Math.max(containerPrice.costPerUnit, 0) * container.count * multiplier
-        : undefined;
-    const adjustedSubstrateCost =
-      substratePrice && Number.isFinite(substratePrice.costPerLiter)
-        ? Math.max(substratePrice.costPerLiter, 0) * requiredSubstrateVolume * multiplier
-        : undefined;
-
-    const totalCostCandidate = [
-      adjustedMethodCost,
-      adjustedContainerCost,
-      adjustedSubstrateCost,
-    ].reduce(
-      (sum, value) => sum + (typeof value === 'number' && Number.isFinite(value) ? value : 0),
-      0,
-    );
-    const totalCost =
-      totalCostCandidate > 0 &&
-      [adjustedMethodCost, adjustedContainerCost, adjustedSubstrateCost].some(
-        (value) => typeof value === 'number' && Number.isFinite(value) && value > 0,
-      )
-        ? totalCostCandidate
-        : undefined;
-
-    const ceilingHeight = room.height || 2.5;
-    const newZone: ZoneState = {
-      id: this.createId('zone'),
-      roomId,
-      name: zone.name.trim(),
-      cultivationMethodId: zone.methodId,
-      strainId: undefined,
-      area: zone.area,
-      ceilingHeight,
-      volume: zone.area * ceilingHeight,
-      environment: {
-        temperature: 22,
-        relativeHumidity: 0.6,
-        co2: 400,
-        ppfd: 0,
-        vpd: 1.2,
-      },
-      resources: createDefaultResources(),
-      plants: [],
-      devices: [],
-      metrics: {
-        averageTemperature: 22,
-        averageHumidity: 0.6,
-        averageCo2: 400,
-        averagePpfd: 0,
-        stressLevel: 0,
-        lastUpdatedTick: context.tick,
-      },
-      control: { setpoints: {} },
-      health: createEmptyHealth(),
-      activeTaskIds: [],
-      plantingPlan: undefined,
-      cultivation: {
-        container: {
-          blueprintId: containerBlueprint.id,
-          slug: containerBlueprint.slug,
-          type: containerBlueprint.type,
-          count: container.count,
-          name: containerBlueprint.name,
-        },
-        substrate: {
-          blueprintId: substrateBlueprint.id,
-          slug: substrateBlueprint.slug,
-          type: substrateBlueprint.type,
-          totalVolumeLiters: requiredSubstrateVolume,
-          name: substrateBlueprint.name,
-        },
-      },
-    } satisfies ZoneState;
-
-    room.zones.push(newZone);
-    validateStructureGeometry(structure);
-
-    context.events.queue(
-      'world.zoneCreated',
-      {
-        zoneId: newZone.id,
-        roomId,
-        structureId: structure.id,
-        name: newZone.name,
-        container: { slug: containerBlueprint.slug, count: container.count },
-        substrate: { slug: substrateBlueprint.slug, totalVolumeLiters: requiredSubstrateVolume },
-      },
-      context.tick,
-      'info',
-    );
-
-    return {
-      ok: true,
-      data: {
-        zoneId: newZone.id,
-        method: {
-          blueprintId: method.id,
-          setupCost: adjustedMethodCost,
-        },
-        container: {
-          blueprintId: containerBlueprint.id,
-          slug: containerBlueprint.slug,
-          type: containerBlueprint.type,
-          count: container.count,
-          maxSupported: maxContainers,
-          unitCost: containerPrice?.costPerUnit,
-          totalCost: adjustedContainerCost,
-        },
-        substrate: {
-          blueprintId: substrateBlueprint.id,
-          slug: substrateBlueprint.slug,
-          type: substrateBlueprint.type,
-          totalVolumeLiters: requiredSubstrateVolume,
-          unitCost: substratePrice?.costPerLiter,
-          totalCost: adjustedSubstrateCost,
-        },
-        totalCost,
-      },
-      warnings: warnings.length > 0 ? warnings : undefined,
-    } satisfies CommandResult<CreateZoneResult>;
+    return this.zoneService.createZone(intent, context);
   }
 
   updateZone(intent: UpdateZoneIntent, context: CommandExecutionContext): CommandResult {
-    const { zoneId, patch } = intent;
-    const lookup = findZone(this.state, zoneId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Zone ${zoneId} was not found.`, [
-        'world.updateZone',
-        'zoneId',
-      ]);
-    }
-
-    const { zone, room, structure } = lookup;
-    const warnings: string[] = [];
-    let geometryChanged = false;
-    let cultivationChanged = false;
-
-    if (typeof patch.name === 'string') {
-      const trimmed = patch.name.trim();
-      if (trimmed.length > 0) {
-        zone.name = trimmed;
-      }
-    }
-
-    if (typeof patch.area === 'number') {
-      if (!Number.isFinite(patch.area) || patch.area <= 0) {
-        return this.failure('ERR_VALIDATION', 'Zone area must be a positive number.', [
-          'world.updateZone',
-          'patch.area',
-        ]);
-      }
-      const siblingArea = room.zones.reduce((sum, candidate) => {
-        if (candidate.id === zone.id) {
-          return sum;
-        }
-        return sum + candidate.area;
-      }, 0);
-      if (siblingArea + patch.area > room.area + 1e-6) {
-        return this.failure('ERR_CONFLICT', 'Updated zone area would exceed the room capacity.', [
-          'world.updateZone',
-          'patch.area',
-        ]);
-      }
-      zone.area = patch.area;
-      zone.volume = patch.area * zone.ceilingHeight;
-      geometryChanged = true;
-    }
-
-    const targetArea = zone.area;
-    const previousContainerSlug = zone.cultivation?.container?.slug;
-    const previousSubstrateSlug = zone.cultivation?.substrate?.slug;
-
-    const requestedMethodId =
-      typeof patch.methodId === 'string' ? patch.methodId : zone.cultivationMethodId;
-    const methodChanged =
-      typeof patch.methodId === 'string' && patch.methodId !== zone.cultivationMethodId;
-
-    const method = requestedMethodId
-      ? this.repository.getCultivationMethod(requestedMethodId)
-      : undefined;
-    if (requestedMethodId && !method) {
-      return this.failure(
-        'ERR_NOT_FOUND',
-        `Cultivation method ${requestedMethodId} was not found.`,
-        typeof patch.methodId === 'string'
-          ? ['world.updateZone', 'patch.methodId']
-          : ['world.updateZone', 'zone.cultivationMethodId'],
-      );
-    }
-
-    if (!zone.cultivation) {
-      zone.cultivation = {};
-    }
-
-    let nextContainer = zone.cultivation.container ? { ...zone.cultivation.container } : undefined;
-    let containerBlueprint = nextContainer?.blueprintId
-      ? this.repository.getContainer(nextContainer.blueprintId)
-      : undefined;
-
-    if (patch.container) {
-      const blueprint = this.repository.getContainer(patch.container.blueprintId);
-      if (!blueprint) {
-        return this.failure(
-          'ERR_NOT_FOUND',
-          `Container blueprint ${patch.container.blueprintId} was not found.`,
-          ['world.updateZone', 'patch.container.blueprintId'],
-        );
-      }
-      if (blueprint.type !== patch.container.type) {
-        return this.failure('ERR_VALIDATION', 'Container type does not match blueprint metadata.', [
-          'world.updateZone',
-          'patch.container.type',
-        ]);
-      }
-      containerBlueprint = blueprint;
-      nextContainer = {
-        blueprintId: blueprint.id,
-        slug: blueprint.slug,
-        type: blueprint.type,
-        count: patch.container.count,
-        name: blueprint.name,
-      };
-    } else if (nextContainer && !containerBlueprint) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        `Container blueprint ${nextContainer.blueprintId} was not found.`,
-        ['world.updateZone', 'zone.cultivation.container.blueprintId'],
-      );
-    }
-
-    let nextSubstrate = zone.cultivation.substrate ? { ...zone.cultivation.substrate } : undefined;
-
-    if (patch.substrate) {
-      if (!nextContainer && !patch.container && !zone.cultivation.container) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          'Container configuration must be provided before updating substrate.',
-          ['world.updateZone', 'patch.substrate.blueprintId'],
-        );
-      }
-      const blueprint = this.repository.getSubstrate(patch.substrate.blueprintId);
-      if (!blueprint) {
-        return this.failure(
-          'ERR_NOT_FOUND',
-          `Substrate blueprint ${patch.substrate.blueprintId} was not found.`,
-          ['world.updateZone', 'patch.substrate.blueprintId'],
-        );
-      }
-      if (blueprint.type !== patch.substrate.type) {
-        return this.failure('ERR_VALIDATION', 'Substrate type does not match blueprint metadata.', [
-          'world.updateZone',
-          'patch.substrate.type',
-        ]);
-      }
-      nextSubstrate = {
-        blueprintId: blueprint.id,
-        slug: blueprint.slug,
-        type: blueprint.type,
-        totalVolumeLiters: patch.substrate.volumeLiters ?? nextSubstrate?.totalVolumeLiters ?? 0,
-        name: blueprint.name,
-      };
-    }
-
-    if (method && nextContainer?.type) {
-      if (
-        Array.isArray(method.compatibleContainerTypes) &&
-        method.compatibleContainerTypes.length > 0 &&
-        !method.compatibleContainerTypes.includes(nextContainer.type)
-      ) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          `Container type '${nextContainer.type}' is incompatible with cultivation method '${method.name}'.`,
-          patch.container
-            ? ['world.updateZone', 'patch.container.type']
-            : ['world.updateZone', 'patch.methodId'],
-        );
-      }
-    }
-
-    if (method && nextSubstrate?.type) {
-      if (
-        Array.isArray(method.compatibleSubstrateTypes) &&
-        method.compatibleSubstrateTypes.length > 0 &&
-        !method.compatibleSubstrateTypes.includes(nextSubstrate.type)
-      ) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          `Substrate type '${nextSubstrate.type}' is incompatible with cultivation method '${method.name}'.`,
-          patch.substrate
-            ? ['world.updateZone', 'patch.substrate.type']
-            : ['world.updateZone', 'patch.methodId'],
-        );
-      }
-    }
-
-    if (methodChanged && method) {
-      const defaults = this.resolveMethodDefaults(method);
-
-      if (!patch.container && defaults.containerSlug) {
-        const containerFromDefaults = this.repository.getContainerBySlug(defaults.containerSlug);
-        if (containerFromDefaults) {
-          const count = nextContainer?.count ?? zone.cultivation.container?.count ?? 0;
-          nextContainer = {
-            blueprintId: containerFromDefaults.id,
-            slug: containerFromDefaults.slug,
-            type: containerFromDefaults.type,
-            count,
-            name: containerFromDefaults.name,
-          };
-          containerBlueprint = containerFromDefaults;
-          if (previousContainerSlug && previousContainerSlug !== containerFromDefaults.slug) {
-            warnings.push(
-              `Existing containers were moved to storage (stub). Install ${containerFromDefaults.name} before planting.`,
-            );
-          }
-        }
-      }
-
-      if (!patch.substrate && defaults.substrateSlug) {
-        const substrateFromDefaults = this.repository.getSubstrateBySlug(defaults.substrateSlug);
-        if (substrateFromDefaults) {
-          nextSubstrate = {
-            blueprintId: substrateFromDefaults.id,
-            slug: substrateFromDefaults.slug,
-            type: substrateFromDefaults.type,
-            totalVolumeLiters: nextSubstrate?.totalVolumeLiters ?? 0,
-            name: substrateFromDefaults.name,
-          };
-          if (previousSubstrateSlug && previousSubstrateSlug !== substrateFromDefaults.slug) {
-            warnings.push(
-              `Existing substrate was routed to storage (stub). Restock with ${substrateFromDefaults.name} before planting.`,
-            );
-          }
-        }
-      }
-    }
-
-    if (patch.substrate && !nextSubstrate) {
-      return this.failure(
-        'ERR_INVALID_STATE',
-        'Substrate configuration could not be resolved for the update.',
-        ['world.updateZone', 'patch.substrate.blueprintId'],
-      );
-    }
-
-    if (nextContainer && containerBlueprint) {
-      const footprintArea = containerBlueprint.footprintArea;
-      if (!Number.isFinite(footprintArea) || footprintArea === undefined || footprintArea <= 0) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          `Container blueprint '${containerBlueprint.slug}' is missing a valid footprint area.`,
-          patch.container
-            ? ['world.updateZone', 'patch.container.blueprintId']
-            : ['world.updateZone', 'zone.cultivation.container.blueprintId'],
-        );
-      }
-
-      const packingDensity = Number.isFinite(containerBlueprint.packingDensity)
-        ? Math.max(containerBlueprint.packingDensity ?? 0, 0)
-        : 1;
-      const effectiveDensity = packingDensity > 0 ? packingDensity : 1;
-      const theoreticalCapacity = (targetArea / footprintArea) * effectiveDensity;
-      const maxContainers = Number.isFinite(theoreticalCapacity)
-        ? Math.floor(Math.max(theoreticalCapacity, 0))
-        : 0;
-
-      if (maxContainers <= 0) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          `Zone area ${targetArea.toFixed(2)} m² cannot support container footprint ${footprintArea.toFixed(2)} m².`,
-          patch.container
-            ? ['world.updateZone', 'patch.container.count']
-            : ['world.updateZone', 'zone.cultivation.container.count'],
-        );
-      }
-
-      const requestedCount = patch.container ? patch.container.count : nextContainer.count;
-      if (!Number.isFinite(requestedCount) || requestedCount <= 0) {
-        return this.failure('ERR_VALIDATION', 'Container count must be a positive integer.', [
-          'world.updateZone',
-          patch.container ? 'patch.container.count' : 'zone.cultivation.container.count',
-        ]);
-      }
-
-      const clampedCount = Math.min(requestedCount, maxContainers);
-      if (clampedCount !== requestedCount) {
-        warnings.push(
-          `Container count has been clamped to ${clampedCount} to fit the zone capacity (${maxContainers}).`,
-        );
-      }
-      nextContainer.count = clampedCount;
-    }
-
-    let requiredSubstrateVolume: number | null = null;
-    if (nextContainer && containerBlueprint) {
-      const containerVolume = containerBlueprint.volumeInLiters;
-      if (
-        !Number.isFinite(containerVolume) ||
-        containerVolume === undefined ||
-        containerVolume <= 0
-      ) {
-        return this.failure(
-          'ERR_INVALID_STATE',
-          `Container blueprint '${containerBlueprint.slug}' is missing a valid volumeInLiters value.`,
-          patch.container
-            ? ['world.updateZone', 'patch.container.blueprintId']
-            : ['world.updateZone', 'zone.cultivation.container.blueprintId'],
-        );
-      }
-      requiredSubstrateVolume = containerVolume * nextContainer.count;
-    }
-
-    if (nextSubstrate && requiredSubstrateVolume !== null) {
-      if (patch.substrate?.volumeLiters !== undefined) {
-        const providedVolume = patch.substrate.volumeLiters;
-        if (!Number.isFinite(providedVolume) || providedVolume <= 0) {
-          warnings.push('Provided substrate volume was non-positive and has been ignored.');
-        } else {
-          const tolerance = Math.max(requiredSubstrateVolume * 0.05, 1);
-          if (Math.abs(providedVolume - requiredSubstrateVolume) > tolerance) {
-            warnings.push(
-              `Submitted substrate volume (${providedVolume.toFixed(2)} L) differs from the required ${requiredSubstrateVolume.toFixed(2)} L.`,
-            );
-          }
-        }
-      }
-      nextSubstrate.totalVolumeLiters = requiredSubstrateVolume;
-    }
-
-    const originalContainer = zone.cultivation.container;
-    const originalSubstrate = zone.cultivation.substrate;
-
-    if (methodChanged && typeof patch.methodId === 'string') {
-      zone.cultivationMethodId = patch.methodId;
-    }
-
-    if (nextContainer) {
-      zone.cultivation.container = nextContainer;
-    }
-    if (nextSubstrate) {
-      zone.cultivation.substrate = nextSubstrate;
-    }
-
-    const containerChanged = (() => {
-      if (!originalContainer && !nextContainer) {
-        return false;
-      }
-      if (!originalContainer || !nextContainer) {
-        return true;
-      }
-      return (
-        originalContainer.blueprintId !== nextContainer.blueprintId ||
-        originalContainer.count !== nextContainer.count
-      );
-    })();
-
-    const substrateChanged = (() => {
-      if (!originalSubstrate && !nextSubstrate) {
-        return false;
-      }
-      if (!originalSubstrate || !nextSubstrate) {
-        return true;
-      }
-      return (
-        originalSubstrate.blueprintId !== nextSubstrate.blueprintId ||
-        originalSubstrate.totalVolumeLiters !== nextSubstrate.totalVolumeLiters
-      );
-    })();
-
-    if (methodChanged || containerChanged || substrateChanged) {
-      cultivationChanged = true;
-    }
-
-    if (geometryChanged) {
-      validateStructureGeometry(structure);
-    }
-
-    if (geometryChanged || cultivationChanged) {
-      const payload: Record<string, unknown> = {
-        zoneId: zone.id,
-        roomId: room.id,
-        structureId: structure.id,
-      };
-      if (cultivationChanged) {
-        payload.methodId = zone.cultivationMethodId;
-        if (zone.cultivation?.container) {
-          payload.container = {
-            slug: zone.cultivation.container.slug,
-            count: zone.cultivation.container.count,
-          };
-        }
-        if (zone.cultivation?.substrate) {
-          payload.substrate = {
-            slug: zone.cultivation.substrate.slug,
-            totalVolumeLiters: zone.cultivation.substrate.totalVolumeLiters,
-          };
-        }
-      }
-      if (geometryChanged) {
-        payload.area = zone.area;
-        payload.volume = zone.volume;
-      }
-      context.events.queue('world.zoneUpdated', payload, context.tick, 'info');
-    }
-
-    return {
-      ok: true,
-      warnings: warnings.length > 0 ? Array.from(new Set(warnings)) : undefined,
-    } satisfies CommandResult;
+    return this.zoneService.updateZone(intent, context);
   }
 
   deleteStructure(structureId: string, context: CommandExecutionContext): CommandResult {
-    const lookup = findStructure(this.state, structureId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
-        'world.deleteStructure',
-        'structureId',
-      ]);
-    }
-
-    const [removed] = this.state.structures.splice(lookup.index, 1);
-    if (removed) {
-      for (const room of removed.rooms) {
-        for (const zone of room.zones) {
-          zone.activeTaskIds = [];
-        }
-      }
-      this.removeTasksForStructure(structureId);
-    }
-
-    context.events.queue('world.structureDeleted', { structureId }, context.tick, 'info');
-    return { ok: true } satisfies CommandResult;
+    return this.structureService.deleteStructure(structureId, context);
   }
 
   duplicateStructure(
@@ -1196,54 +208,7 @@ export class WorldService {
     desiredName: string | undefined,
     context: CommandExecutionContext,
   ): CommandResult<DuplicateStructureResult> {
-    const lookup = findStructure(this.state, structureId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Structure ${structureId} was not found.`, [
-        'world.duplicateStructure',
-        'structureId',
-      ]);
-    }
-
-    const source = lookup.structure;
-    const newStructureId = this.createId('structure');
-    const duplicateName = desiredName?.trim().length
-      ? desiredName.trim()
-      : deriveDuplicateName(source.name, 'Structure Copy');
-    const rooms: StructureState['rooms'] = [];
-    const purchaseMap: DevicePurchaseMap = new Map();
-
-    for (const room of source.rooms) {
-      rooms.push(this.cloneRoom(room, newStructureId, purchaseMap, context));
-    }
-
-    const duplicated: StructureState = {
-      id: newStructureId,
-      blueprintId: source.blueprintId,
-      name: duplicateName,
-      status: 'active',
-      footprint: { ...source.footprint },
-      rooms,
-      rentPerTick: source.rentPerTick,
-      upfrontCostPaid: 0,
-      notes: undefined,
-    } satisfies StructureState;
-
-    validateStructureGeometry(duplicated);
-    this.state.structures.push(duplicated);
-
-    this.recordDevicePurchases(purchaseMap, context, `Structure duplication from ${structureId}`);
-
-    context.events.queue(
-      'world.structureDuplicated',
-      { structureId: newStructureId, sourceStructureId: structureId, name: duplicateName },
-      context.tick,
-      'info',
-    );
-
-    return {
-      ok: true,
-      data: { structureId: newStructureId },
-    } satisfies CommandResult<DuplicateStructureResult>;
+    return this.structureService.duplicateStructure(structureId, desiredName, context);
   }
 
   duplicateRoom(
@@ -1251,46 +216,7 @@ export class WorldService {
     desiredName: string | undefined,
     context: CommandExecutionContext,
   ): CommandResult<DuplicateRoomResult> {
-    const lookup = findRoom(this.state, roomId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Room ${roomId} was not found.`, [
-        'world.duplicateRoom',
-        'roomId',
-      ]);
-    }
-
-    const { structure, room } = lookup;
-    const totalArea = structure.rooms.reduce((sum, current) => sum + current.area, 0);
-    if (totalArea + room.area - structure.footprint.area > 1e-6) {
-      return this.failure(
-        'ERR_CONFLICT',
-        'Duplicating the room would exceed the structure footprint.',
-        ['world.duplicateRoom', 'roomId'],
-      );
-    }
-
-    const purchaseMap: DevicePurchaseMap = new Map();
-    const newRoom = this.cloneRoom(
-      room,
-      structure.id,
-      purchaseMap,
-      context,
-      desiredName?.trim().length ? desiredName.trim() : deriveDuplicateName(room.name, 'Room Copy'),
-    );
-
-    structure.rooms.push(newRoom);
-    validateStructureGeometry(structure);
-
-    this.recordDevicePurchases(purchaseMap, context, `Room duplication from ${roomId}`);
-
-    context.events.queue(
-      'world.roomDuplicated',
-      { roomId: newRoom.id, sourceRoomId: roomId, structureId: structure.id },
-      context.tick,
-      'info',
-    );
-
-    return { ok: true, data: { roomId: newRoom.id } } satisfies CommandResult<DuplicateRoomResult>;
+    return this.roomService.duplicateRoom(roomId, desiredName, context);
   }
 
   duplicateZone(
@@ -1298,83 +224,10 @@ export class WorldService {
     desiredName: string | undefined,
     context: CommandExecutionContext,
   ): CommandResult<DuplicateZoneResult> {
-    const lookup = findZone(this.state, zoneId);
-    if (!lookup) {
-      return this.failure('ERR_NOT_FOUND', `Zone ${zoneId} was not found.`, [
-        'world.duplicateZone',
-        'zoneId',
-      ]);
-    }
-
-    const { structure, room, zone } = lookup;
-    const totalZoneArea = room.zones.reduce((sum, current) => sum + current.area, 0);
-    if (totalZoneArea + zone.area - room.area > 1e-6) {
-      return this.failure('ERR_CONFLICT', 'Duplicating the zone would exceed the room area.', [
-        'world.duplicateZone',
-        'zoneId',
-      ]);
-    }
-
-    const purchaseMap: DevicePurchaseMap = new Map();
-    const newZone = this.cloneZone(
-      zone,
-      structure.id,
-      room.id,
-      purchaseMap,
-      context,
-      desiredName?.trim().length ? desiredName.trim() : deriveDuplicateName(zone.name, 'Zone Copy'),
-    );
-
-    room.zones.push(newZone);
-    validateStructureGeometry(structure);
-
-    this.recordDevicePurchases(purchaseMap, context, `Zone duplication from ${zoneId}`);
-
-    context.events.queue(
-      'world.zoneDuplicated',
-      {
-        zoneId: newZone.id,
-        sourceZoneId: zoneId,
-        roomId: room.id,
-        structureId: structure.id,
-      },
-      context.tick,
-      'info',
-    );
-
-    return { ok: true, data: { zoneId: newZone.id } } satisfies CommandResult<DuplicateZoneResult>;
+    return this.zoneService.duplicateZone(zoneId, desiredName, context);
   }
 
-  resetSession(context: CommandExecutionContext): CommandResult<DuplicateStructureResult> {
-    // Clear all existing structures
-    this.state.structures.length = 0;
-
-    // Clear all tasks as they reference structures
-    this.state.tasks.backlog.length = 0;
-    this.state.tasks.active.length = 0;
-    this.state.tasks.completed.length = 0;
-    this.state.tasks.cancelled.length = 0;
-
-    // Reset clock to initial state
-    this.state.clock.tick = 0;
-    this.state.clock.isPaused = true;
-    this.state.clock.lastUpdatedAt = new Date().toISOString();
-
-    // Clear notes
-    this.state.notes.length = 0;
-
-    this.ensureDifficultyMetadata();
-
-    // Reset personnel to initial state
-    this.state.personnel.employees.length = 0;
-    this.state.personnel.applicants.length = 0;
-    this.state.personnel.trainingPrograms.length = 0;
-    this.state.personnel.overallMorale = 0;
-
-    // Reset finances to initial state (preserve initial capital)
-    const initialCapital = this.state.metadata.economics.initialCapital;
-    this.state.finances.cashOnHand = initialCapital;
-    this.state.finances.reservedCash = 0;
+  resetSession(context: CommandExecutionContext): CommandResult {
     this.state.finances.outstandingLoans.length = 0;
     this.state.finances.ledger.length = 0;
     this.state.finances.summary = {
@@ -1526,130 +379,6 @@ export class WorldService {
     return { ok: true } satisfies CommandResult;
   }
 
-  private cloneRoom(
-    room: RoomState,
-    structureId: string,
-    purchaseMap: DevicePurchaseMap,
-    context: CommandExecutionContext,
-    forcedName?: string,
-  ): RoomState {
-    const newRoomId = this.createId('room');
-    const zones: RoomState['zones'] = [];
-
-    for (const zone of room.zones) {
-      zones.push(
-        this.cloneZone(
-          zone,
-          structureId,
-          newRoomId,
-          purchaseMap,
-          context,
-          forcedName ? zone.name : undefined,
-        ),
-      );
-    }
-
-    return {
-      id: newRoomId,
-      structureId,
-      name: forcedName ?? deriveDuplicateName(room.name, 'Room Copy'),
-      purposeId: room.purposeId,
-      area: room.area,
-      height: room.height,
-      volume: room.volume,
-      cleanliness: room.cleanliness,
-      maintenanceLevel: room.maintenanceLevel,
-      zones,
-    } satisfies RoomState;
-  }
-
-  private cloneZone(
-    zone: ZoneState,
-    structureId: string,
-    roomId: string,
-    purchaseMap: DevicePurchaseMap,
-    context: CommandExecutionContext,
-    forcedName?: string,
-  ): ZoneState {
-    const newZoneId = this.createId('zone');
-    const devices: ZoneState['devices'] = [];
-
-    for (const device of zone.devices) {
-      const cloned = {
-        id: this.createId('device'),
-        blueprintId: device.blueprintId,
-        kind: device.kind,
-        name: device.name,
-        zoneId: newZoneId,
-        status: 'operational',
-        efficiency: device.efficiency,
-        runtimeHours: 0,
-        maintenance: {
-          lastServiceTick: context.tick,
-          nextDueTick: context.tick + DEFAULT_MAINTENANCE_INTERVAL_TICKS,
-          condition: 1,
-          runtimeHoursAtLastService: 0,
-          degradation: 0,
-        },
-        settings: deepCloneSettings(device.settings),
-      } satisfies ZoneState['devices'][number];
-
-      devices.push(cloned);
-      const previous = purchaseMap.get(device.blueprintId) ?? 0;
-      purchaseMap.set(device.blueprintId, previous + 1);
-    }
-
-    const environment = cloneEnvironment(zone.environment);
-    const metrics = cloneMetrics(zone.metrics, context.tick);
-
-    return {
-      id: newZoneId,
-      roomId,
-      name: forcedName ?? deriveDuplicateName(zone.name, 'Zone Copy'),
-      cultivationMethodId: zone.cultivationMethodId,
-      strainId: zone.strainId,
-      area: zone.area,
-      ceilingHeight: zone.ceilingHeight,
-      volume: zone.volume,
-      environment,
-      resources: createDefaultResources(),
-      plants: [],
-      devices,
-      metrics,
-      control: cloneControl(zone.control),
-      health: createEmptyHealth(),
-      activeTaskIds: [],
-      plantingPlan: undefined,
-      cultivation: cloneCultivation(zone.cultivation),
-    } satisfies ZoneState;
-  }
-
-  private recordDevicePurchases(
-    purchases: DevicePurchaseMap,
-    context: CommandExecutionContext,
-    description: string,
-  ): void {
-    if (purchases.size === 0) {
-      return;
-    }
-
-    const accumulator = this.costAccounting.createAccumulator();
-    const timestamp = new Date().toISOString();
-    for (const [blueprintId, quantity] of purchases.entries()) {
-      this.costAccounting.recordDevicePurchase(
-        this.state,
-        blueprintId,
-        quantity,
-        context.tick,
-        timestamp,
-        accumulator,
-        context.events,
-        description,
-      );
-    }
-    this.applyAccumulator(accumulator);
-  }
-
   private applyAccumulator(accumulator: TickAccumulator): void {
     const summary = this.state.finances.summary;
     summary.totalRevenue += accumulator.revenue;
@@ -1659,16 +388,6 @@ export class WorldService {
     summary.lastTickRevenue = accumulator.revenue;
     summary.lastTickExpenses = accumulator.expenses;
     summary.netIncome = summary.totalRevenue - summary.totalExpenses;
-  }
-
-  private removeTasksForStructure(structureId: string): void {
-    const filterTasks = (collection: typeof this.state.tasks.backlog) =>
-      collection.filter((task) => task.location?.structureId !== structureId);
-
-    this.state.tasks.backlog = filterTasks(this.state.tasks.backlog);
-    this.state.tasks.active = filterTasks(this.state.tasks.active);
-    this.state.tasks.completed = filterTasks(this.state.tasks.completed);
-    this.state.tasks.cancelled = filterTasks(this.state.tasks.cancelled);
   }
 
   private createId(prefix: string): string {

--- a/src/backend/src/engine/world/zoneService.ts
+++ b/src/backend/src/engine/world/zoneService.ts
@@ -1,0 +1,951 @@
+import type { CostAccountingService, TickAccumulator } from '@/engine/economy/costAccounting.js';
+import type {
+  CommandExecutionContext,
+  CommandResult,
+  CreateZoneIntent,
+  ErrorCode,
+  UpdateZoneIntent,
+} from '@/facade/index.js';
+import type { BlueprintRepository } from '@/data/blueprintRepository.js';
+import { findRoom, findZone } from './stateSelectors.js';
+import { validateStructureGeometry } from '@/state/geometry.js';
+import type { GameState, ZoneState } from '@/state/models.js';
+import type { CultivationMethodBlueprint } from '@/data/schemas/index.js';
+import {
+  cloneControl,
+  cloneCultivation,
+  cloneEnvironment,
+  cloneMetrics,
+  createDefaultResources,
+  createEmptyHealth,
+  deepCloneSettings,
+  deriveDuplicateName,
+  defaultMaintenanceIntervalTicks,
+} from './worldDefaults.js';
+
+export type FailureFactory = <T>(
+  code: ErrorCode,
+  message: string,
+  path: string[],
+) => CommandResult<T>;
+
+export type DevicePurchaseMap = Map<string, number>;
+
+const resolveMethodDefaults = (
+  method: CultivationMethodBlueprint,
+): {
+  containerSlug?: string;
+  substrateSlug?: string;
+} => {
+  const meta = method.meta;
+  if (!meta || typeof meta !== 'object') {
+    return {};
+  }
+  const defaultsRaw = (meta as Record<string, unknown>).defaults;
+  if (!defaultsRaw || typeof defaultsRaw !== 'object') {
+    return {};
+  }
+  const defaults = defaultsRaw as Record<string, unknown>;
+  const containerSlug =
+    typeof defaults.containerSlug === 'string' ? defaults.containerSlug : undefined;
+  const substrateSlug =
+    typeof defaults.substrateSlug === 'string' ? defaults.substrateSlug : undefined;
+  return { containerSlug, substrateSlug };
+};
+
+export interface ZoneServiceDependencies {
+  state: GameState;
+  repository: BlueprintRepository;
+  costAccounting: CostAccountingService;
+  createId: (prefix: string) => string;
+  applyAccumulator: (accumulator: TickAccumulator) => void;
+  failure: FailureFactory;
+}
+
+export interface CreateZoneResult {
+  zoneId: string;
+  method: {
+    blueprintId: string;
+    setupCost?: number;
+  };
+  container: {
+    blueprintId: string;
+    slug: string;
+    type: string;
+    count: number;
+    maxSupported: number;
+    unitCost?: number;
+    totalCost?: number;
+  };
+  substrate: {
+    blueprintId: string;
+    slug: string;
+    type: string;
+    totalVolumeLiters: number;
+    unitCost?: number;
+    totalCost?: number;
+  };
+  totalCost?: number;
+}
+
+export interface DuplicateZoneResult {
+  zoneId: string;
+}
+
+export interface ZoneService {
+  createZone(
+    intent: CreateZoneIntent,
+    context: CommandExecutionContext,
+  ): CommandResult<CreateZoneResult>;
+  updateZone(intent: UpdateZoneIntent, context: CommandExecutionContext): CommandResult;
+  duplicateZone(
+    zoneId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateZoneResult>;
+  cloneZone(
+    zone: ZoneState,
+    structureId: string,
+    roomId: string,
+    context: CommandExecutionContext,
+    options?: { forcedName?: string; recordPurchases?: boolean },
+  ): { zone: ZoneState; purchases: DevicePurchaseMap };
+}
+
+export const createZoneService = (deps: ZoneServiceDependencies): ZoneService => {
+  const createZone = (
+    intent: CreateZoneIntent,
+    context: CommandExecutionContext,
+  ): CommandResult<CreateZoneResult> => {
+    const { roomId, zone } = intent;
+    const lookup = findRoom(deps.state, roomId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Room ${roomId} was not found.`, [
+        'world.createZone',
+        'roomId',
+      ]);
+    }
+
+    const room = lookup.room;
+    const structure = lookup.structure;
+
+    const totalExistingArea = room.zones.reduce((sum, current) => sum + current.area, 0);
+    if (totalExistingArea + zone.area > room.area) {
+      return deps.failure('ERR_CONFLICT', 'Adding the zone would exceed the room area.', [
+        'world.createZone',
+        'zone.area',
+      ]);
+    }
+
+    const method = deps.repository.getCultivationMethod(zone.methodId);
+    if (!method) {
+      return deps.failure('ERR_NOT_FOUND', `Cultivation method ${zone.methodId} was not found.`, [
+        'world.createZone',
+        'zone.methodId',
+      ]);
+    }
+
+    const { container, substrate } = zone;
+
+    const containerBlueprint = deps.repository.getContainer(container.blueprintId);
+    if (!containerBlueprint) {
+      return deps.failure(
+        'ERR_NOT_FOUND',
+        `Container blueprint ${container.blueprintId} was not found.`,
+        ['world.createZone', 'zone.container.blueprintId'],
+      );
+    }
+
+    const containerType = containerBlueprint.type;
+    if (containerType !== container.type) {
+      return deps.failure('ERR_VALIDATION', 'Container type does not match blueprint metadata.', [
+        'world.createZone',
+        'zone.container.type',
+      ]);
+    }
+
+    if (
+      Array.isArray(method.compatibleContainerTypes) &&
+      method.compatibleContainerTypes.length > 0 &&
+      !method.compatibleContainerTypes.includes(containerType)
+    ) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Container type '${containerType}' is incompatible with cultivation method '${method.name}'.`,
+        ['world.createZone', 'zone.container.type'],
+      );
+    }
+
+    const footprintArea = containerBlueprint.footprintArea;
+    if (!Number.isFinite(footprintArea) || footprintArea === undefined || footprintArea <= 0) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Container blueprint '${containerBlueprint.slug}' is missing a valid footprint area.`,
+        ['world.createZone', 'zone.container.blueprintId'],
+      );
+    }
+
+    const packingDensity = Number.isFinite(containerBlueprint.packingDensity)
+      ? Math.max(containerBlueprint.packingDensity ?? 0, 0)
+      : 1;
+    const effectiveDensity = packingDensity > 0 ? packingDensity : 1;
+    const theoreticalCapacity = (zone.area / footprintArea) * effectiveDensity;
+    const maxContainers = Number.isFinite(theoreticalCapacity)
+      ? Math.floor(Math.max(theoreticalCapacity, 0))
+      : 0;
+
+    if (maxContainers <= 0) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Zone area ${zone.area.toFixed(2)} m² cannot support container footprint ${footprintArea.toFixed(2)} m².`,
+        ['world.createZone', 'zone.container.count'],
+      );
+    }
+
+    if (container.count > maxContainers) {
+      return deps.failure(
+        'ERR_CONFLICT',
+        `Requested ${container.count} containers exceeds maximum supported count of ${maxContainers}.`,
+        ['world.createZone', 'zone.container.count'],
+      );
+    }
+
+    const substrateBlueprint = deps.repository.getSubstrate(substrate.blueprintId);
+    if (!substrateBlueprint) {
+      return deps.failure(
+        'ERR_NOT_FOUND',
+        `Substrate blueprint ${substrate.blueprintId} was not found.`,
+        ['world.createZone', 'zone.substrate.blueprintId'],
+      );
+    }
+
+    const substrateType = substrateBlueprint.type;
+    if (substrateType !== substrate.type) {
+      return deps.failure('ERR_VALIDATION', 'Substrate type does not match blueprint metadata.', [
+        'world.createZone',
+        'zone.substrate.type',
+      ]);
+    }
+
+    if (
+      Array.isArray(method.compatibleSubstrateTypes) &&
+      method.compatibleSubstrateTypes.length > 0 &&
+      !method.compatibleSubstrateTypes.includes(substrateType)
+    ) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Substrate type '${substrateType}' is incompatible with cultivation method '${method.name}'.`,
+        ['world.createZone', 'zone.substrate.type'],
+      );
+    }
+
+    const containerVolume = containerBlueprint.volumeInLiters;
+    if (
+      !Number.isFinite(containerVolume) ||
+      containerVolume === undefined ||
+      containerVolume <= 0
+    ) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Container blueprint '${containerBlueprint.slug}' is missing a valid volumeInLiters value.`,
+        ['world.createZone', 'zone.container.blueprintId'],
+      );
+    }
+
+    const requiredSubstrateVolume = containerVolume * container.count;
+    const warnings: string[] = [];
+
+    if (substrate.volumeLiters !== undefined) {
+      const providedVolume = substrate.volumeLiters;
+      if (!Number.isFinite(providedVolume) || providedVolume <= 0) {
+        warnings.push('Provided substrate volume was non-positive and has been ignored.');
+      } else {
+        const tolerance = Math.max(requiredSubstrateVolume * 0.05, 1);
+        if (Math.abs(providedVolume - requiredSubstrateVolume) > tolerance) {
+          warnings.push(
+            `Submitted substrate volume (${providedVolume.toFixed(2)} L) differs from the required ${requiredSubstrateVolume.toFixed(2)} L.`,
+          );
+        }
+      }
+    }
+
+    const methodPrice = deps.repository.getCultivationMethodPrice(method.id);
+    const containerPrice = deps.repository.getContainerPrice(containerBlueprint.slug);
+    const substratePrice = deps.repository.getSubstratePrice(substrateBlueprint.slug);
+    const multiplier = deps.state.metadata.economics.itemPriceMultiplier ?? 1;
+
+    const adjustedMethodCost =
+      methodPrice && Number.isFinite(methodPrice.setupCost)
+        ? Math.max(methodPrice.setupCost, 0) * multiplier
+        : undefined;
+    const adjustedContainerCost =
+      containerPrice && Number.isFinite(containerPrice.costPerUnit)
+        ? Math.max(containerPrice.costPerUnit, 0) * container.count * multiplier
+        : undefined;
+    const adjustedSubstrateCost =
+      substratePrice && Number.isFinite(substratePrice.costPerLiter)
+        ? Math.max(substratePrice.costPerLiter, 0) * requiredSubstrateVolume * multiplier
+        : undefined;
+
+    const totalCostCandidate = [
+      adjustedMethodCost,
+      adjustedContainerCost,
+      adjustedSubstrateCost,
+    ].reduce(
+      (sum, value) => sum + (typeof value === 'number' && Number.isFinite(value) ? value : 0),
+      0,
+    );
+    const totalCost =
+      totalCostCandidate > 0 &&
+      [adjustedMethodCost, adjustedContainerCost, adjustedSubstrateCost].some(
+        (value) => typeof value === 'number' && Number.isFinite(value) && value > 0,
+      )
+        ? totalCostCandidate
+        : undefined;
+
+    const ceilingHeight = room.height || 2.5;
+    const newZone: ZoneState = {
+      id: deps.createId('zone'),
+      roomId,
+      name: zone.name.trim(),
+      cultivationMethodId: zone.methodId,
+      strainId: undefined,
+      area: zone.area,
+      ceilingHeight,
+      volume: zone.area * ceilingHeight,
+      environment: {
+        temperature: 22,
+        relativeHumidity: 0.6,
+        co2: 400,
+        ppfd: 0,
+        vpd: 1.2,
+      },
+      resources: createDefaultResources(),
+      plants: [],
+      devices: [],
+      metrics: {
+        averageTemperature: 22,
+        averageHumidity: 0.6,
+        averageCo2: 400,
+        averagePpfd: 0,
+        stressLevel: 0,
+        lastUpdatedTick: context.tick,
+      },
+      control: { setpoints: {} },
+      health: createEmptyHealth(),
+      activeTaskIds: [],
+      plantingPlan: undefined,
+      cultivation: {
+        container: {
+          blueprintId: containerBlueprint.id,
+          slug: containerBlueprint.slug,
+          type: containerBlueprint.type,
+          count: container.count,
+          name: containerBlueprint.name,
+        },
+        substrate: {
+          blueprintId: substrateBlueprint.id,
+          slug: substrateBlueprint.slug,
+          type: substrateBlueprint.type,
+          totalVolumeLiters: requiredSubstrateVolume,
+          name: substrateBlueprint.name,
+        },
+      },
+    } satisfies ZoneState;
+
+    room.zones.push(newZone);
+    validateStructureGeometry(structure);
+
+    context.events.queue(
+      'world.zoneCreated',
+      {
+        zoneId: newZone.id,
+        roomId,
+        structureId: structure.id,
+        name: newZone.name,
+        container: { slug: containerBlueprint.slug, count: container.count },
+        substrate: { slug: substrateBlueprint.slug, totalVolumeLiters: requiredSubstrateVolume },
+      },
+      context.tick,
+      'info',
+    );
+
+    return {
+      ok: true,
+      data: {
+        zoneId: newZone.id,
+        method: {
+          blueprintId: method.id,
+          setupCost: adjustedMethodCost,
+        },
+        container: {
+          blueprintId: containerBlueprint.id,
+          slug: containerBlueprint.slug,
+          type: containerBlueprint.type,
+          count: container.count,
+          maxSupported: maxContainers,
+          unitCost: containerPrice?.costPerUnit,
+          totalCost: adjustedContainerCost,
+        },
+        substrate: {
+          blueprintId: substrateBlueprint.id,
+          slug: substrateBlueprint.slug,
+          type: substrateBlueprint.type,
+          totalVolumeLiters: requiredSubstrateVolume,
+          unitCost: substratePrice?.costPerLiter,
+          totalCost: adjustedSubstrateCost,
+        },
+        totalCost,
+      },
+      warnings: warnings.length > 0 ? warnings : undefined,
+    } satisfies CommandResult<CreateZoneResult>;
+  };
+
+  const updateZone = (
+    intent: UpdateZoneIntent,
+    context: CommandExecutionContext,
+  ): CommandResult => {
+    const { zoneId, patch } = intent;
+    const lookup = findZone(deps.state, zoneId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Zone ${zoneId} was not found.`, [
+        'world.updateZone',
+        'zoneId',
+      ]);
+    }
+
+    const { zone, room, structure } = lookup;
+    const warnings: string[] = [];
+    let geometryChanged = false;
+    let cultivationChanged = false;
+
+    if (typeof patch.name === 'string') {
+      const trimmed = patch.name.trim();
+      if (trimmed.length > 0) {
+        zone.name = trimmed;
+      }
+    }
+
+    if (typeof patch.area === 'number') {
+      if (!Number.isFinite(patch.area) || patch.area <= 0) {
+        return deps.failure('ERR_VALIDATION', 'Zone area must be a positive number.', [
+          'world.updateZone',
+          'patch.area',
+        ]);
+      }
+      const siblingArea = room.zones.reduce((sum, candidate) => {
+        if (candidate.id === zone.id) {
+          return sum;
+        }
+        return sum + candidate.area;
+      }, 0);
+      if (siblingArea + patch.area > room.area + 1e-6) {
+        return deps.failure('ERR_CONFLICT', 'Updated zone area would exceed the room capacity.', [
+          'world.updateZone',
+          'patch.area',
+        ]);
+      }
+      zone.area = patch.area;
+      zone.volume = patch.area * zone.ceilingHeight;
+      geometryChanged = true;
+    }
+
+    const targetArea = zone.area;
+    const previousContainerSlug = zone.cultivation?.container?.slug;
+    const previousSubstrateSlug = zone.cultivation?.substrate?.slug;
+
+    const requestedMethodId =
+      typeof patch.methodId === 'string' ? patch.methodId : zone.cultivationMethodId;
+    const methodChanged =
+      typeof patch.methodId === 'string' && patch.methodId !== zone.cultivationMethodId;
+
+    const method = requestedMethodId
+      ? deps.repository.getCultivationMethod(requestedMethodId)
+      : undefined;
+    if (requestedMethodId && !method) {
+      return deps.failure(
+        'ERR_NOT_FOUND',
+        `Cultivation method ${requestedMethodId} was not found.`,
+        typeof patch.methodId === 'string'
+          ? ['world.updateZone', 'patch.methodId']
+          : ['world.updateZone', 'zone.cultivationMethodId'],
+      );
+    }
+
+    if (!zone.cultivation) {
+      zone.cultivation = {};
+    }
+
+    let nextContainer = zone.cultivation.container ? { ...zone.cultivation.container } : undefined;
+    let containerBlueprint = nextContainer?.blueprintId
+      ? deps.repository.getContainer(nextContainer.blueprintId)
+      : undefined;
+
+    if (patch.container) {
+      const blueprint = deps.repository.getContainer(patch.container.blueprintId);
+      if (!blueprint) {
+        return deps.failure(
+          'ERR_NOT_FOUND',
+          `Container blueprint ${patch.container.blueprintId} was not found.`,
+          ['world.updateZone', 'patch.container.blueprintId'],
+        );
+      }
+      if (blueprint.type !== patch.container.type) {
+        return deps.failure('ERR_VALIDATION', 'Container type does not match blueprint metadata.', [
+          'world.updateZone',
+          'patch.container.type',
+        ]);
+      }
+      containerBlueprint = blueprint;
+      nextContainer = {
+        blueprintId: blueprint.id,
+        slug: blueprint.slug,
+        type: blueprint.type,
+        count: patch.container.count,
+        name: blueprint.name,
+      };
+    } else if (nextContainer && !containerBlueprint) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        `Container blueprint ${nextContainer.blueprintId} was not found.`,
+        ['world.updateZone', 'zone.cultivation.container.blueprintId'],
+      );
+    }
+
+    let nextSubstrate = zone.cultivation.substrate ? { ...zone.cultivation.substrate } : undefined;
+
+    if (patch.substrate) {
+      if (!nextContainer && !patch.container && !zone.cultivation.container) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          'Container configuration must be provided before updating substrate.',
+          ['world.updateZone', 'patch.substrate.blueprintId'],
+        );
+      }
+      const blueprint = deps.repository.getSubstrate(patch.substrate.blueprintId);
+      if (!blueprint) {
+        return deps.failure(
+          'ERR_NOT_FOUND',
+          `Substrate blueprint ${patch.substrate.blueprintId} was not found.`,
+          ['world.updateZone', 'patch.substrate.blueprintId'],
+        );
+      }
+      if (blueprint.type !== patch.substrate.type) {
+        return deps.failure('ERR_VALIDATION', 'Substrate type does not match blueprint metadata.', [
+          'world.updateZone',
+          'patch.substrate.type',
+        ]);
+      }
+      nextSubstrate = {
+        blueprintId: blueprint.id,
+        slug: blueprint.slug,
+        type: blueprint.type,
+        totalVolumeLiters: patch.substrate.volumeLiters ?? nextSubstrate?.totalVolumeLiters ?? 0,
+        name: blueprint.name,
+      };
+    }
+
+    if (method && nextContainer?.type) {
+      if (
+        Array.isArray(method.compatibleContainerTypes) &&
+        method.compatibleContainerTypes.length > 0 &&
+        !method.compatibleContainerTypes.includes(nextContainer.type)
+      ) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Container type '${nextContainer.type}' is incompatible with cultivation method '${method.name}'.`,
+          patch.container
+            ? ['world.updateZone', 'patch.container.type']
+            : ['world.updateZone', 'patch.methodId'],
+        );
+      }
+    }
+
+    if (method && nextSubstrate?.type) {
+      if (
+        Array.isArray(method.compatibleSubstrateTypes) &&
+        method.compatibleSubstrateTypes.length > 0 &&
+        !method.compatibleSubstrateTypes.includes(nextSubstrate.type)
+      ) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Substrate type '${nextSubstrate.type}' is incompatible with cultivation method '${method.name}'.`,
+          patch.substrate
+            ? ['world.updateZone', 'patch.substrate.type']
+            : ['world.updateZone', 'patch.methodId'],
+        );
+      }
+    }
+
+    if (methodChanged && method) {
+      const defaults = resolveMethodDefaults(method);
+
+      if (!patch.container && defaults.containerSlug) {
+        const containerFromDefaults = deps.repository.getContainerBySlug(defaults.containerSlug);
+        if (containerFromDefaults) {
+          const count = nextContainer?.count ?? zone.cultivation.container?.count ?? 0;
+          nextContainer = {
+            blueprintId: containerFromDefaults.id,
+            slug: containerFromDefaults.slug,
+            type: containerFromDefaults.type,
+            count,
+            name: containerFromDefaults.name,
+          };
+          containerBlueprint = containerFromDefaults;
+          if (previousContainerSlug && previousContainerSlug !== containerFromDefaults.slug) {
+            warnings.push(
+              `Existing containers were moved to storage (stub). Install ${containerFromDefaults.name} before planting.`,
+            );
+          }
+        }
+      }
+
+      if (!patch.substrate && defaults.substrateSlug) {
+        const substrateFromDefaults = deps.repository.getSubstrateBySlug(defaults.substrateSlug);
+        if (substrateFromDefaults) {
+          nextSubstrate = {
+            blueprintId: substrateFromDefaults.id,
+            slug: substrateFromDefaults.slug,
+            type: substrateFromDefaults.type,
+            totalVolumeLiters: nextSubstrate?.totalVolumeLiters ?? 0,
+            name: substrateFromDefaults.name,
+          };
+          if (previousSubstrateSlug && previousSubstrateSlug !== substrateFromDefaults.slug) {
+            warnings.push(
+              `Existing substrate was routed to storage (stub). Restock with ${substrateFromDefaults.name} before planting.`,
+            );
+          }
+        }
+      }
+    }
+
+    if (patch.substrate && !nextSubstrate) {
+      return deps.failure(
+        'ERR_INVALID_STATE',
+        'Substrate configuration could not be resolved for the update.',
+        ['world.updateZone', 'patch.substrate.blueprintId'],
+      );
+    }
+
+    if (nextSubstrate) {
+      const substrateBlueprint = deps.repository.getSubstrate(nextSubstrate.blueprintId);
+      if (!substrateBlueprint) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Substrate blueprint ${nextSubstrate.blueprintId} was not found.`,
+          patch.substrate
+            ? ['world.updateZone', 'patch.substrate.blueprintId']
+            : ['world.updateZone', 'zone.cultivation.substrate.blueprintId'],
+        );
+      }
+    }
+
+    if (nextContainer && containerBlueprint) {
+      const footprintArea = containerBlueprint.footprintArea;
+      if (!Number.isFinite(footprintArea) || footprintArea === undefined || footprintArea <= 0) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Container blueprint '${containerBlueprint.slug}' is missing a valid footprint area.`,
+          patch.container
+            ? ['world.updateZone', 'patch.container.blueprintId']
+            : ['world.updateZone', 'zone.cultivation.container.blueprintId'],
+        );
+      }
+
+      const packingDensity = Number.isFinite(containerBlueprint.packingDensity)
+        ? Math.max(containerBlueprint.packingDensity ?? 0, 0)
+        : 1;
+      const effectiveDensity = packingDensity > 0 ? packingDensity : 1;
+      const theoreticalCapacity = (targetArea / footprintArea) * effectiveDensity;
+      const maxContainers = Number.isFinite(theoreticalCapacity)
+        ? Math.floor(Math.max(theoreticalCapacity, 0))
+        : 0;
+
+      if (maxContainers <= 0) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Zone area ${targetArea.toFixed(2)} m² cannot support container footprint ${footprintArea.toFixed(2)} m².`,
+          patch.container
+            ? ['world.updateZone', 'patch.container.count']
+            : ['world.updateZone', 'zone.cultivation.container.count'],
+        );
+      }
+
+      const requestedCount = patch.container ? patch.container.count : nextContainer.count;
+      if (!Number.isFinite(requestedCount) || requestedCount <= 0) {
+        return deps.failure('ERR_VALIDATION', 'Container count must be a positive integer.', [
+          'world.updateZone',
+          patch.container ? 'patch.container.count' : 'zone.cultivation.container.count',
+        ]);
+      }
+
+      const clampedCount = Math.min(requestedCount, maxContainers);
+      if (clampedCount !== requestedCount) {
+        warnings.push(
+          `Container count has been clamped to ${clampedCount} to fit the zone capacity (${maxContainers}).`,
+        );
+      }
+      nextContainer.count = clampedCount;
+    }
+
+    let requiredSubstrateVolume: number | null = null;
+    if (nextContainer && containerBlueprint) {
+      const containerVolume = containerBlueprint.volumeInLiters;
+      if (
+        !Number.isFinite(containerVolume) ||
+        containerVolume === undefined ||
+        containerVolume <= 0
+      ) {
+        return deps.failure(
+          'ERR_INVALID_STATE',
+          `Container blueprint '${containerBlueprint.slug}' is missing a valid volumeInLiters value.`,
+          patch.container
+            ? ['world.updateZone', 'patch.container.blueprintId']
+            : ['world.updateZone', 'zone.cultivation.container.blueprintId'],
+        );
+      }
+      requiredSubstrateVolume = containerVolume * nextContainer.count;
+    }
+
+    if (nextSubstrate && requiredSubstrateVolume !== null) {
+      if (patch.substrate?.volumeLiters !== undefined) {
+        const providedVolume = patch.substrate.volumeLiters;
+        if (!Number.isFinite(providedVolume) || providedVolume <= 0) {
+          warnings.push('Provided substrate volume was non-positive and has been ignored.');
+        } else {
+          const tolerance = Math.max(requiredSubstrateVolume * 0.05, 1);
+          if (Math.abs(providedVolume - requiredSubstrateVolume) > tolerance) {
+            warnings.push(
+              `Submitted substrate volume (${providedVolume.toFixed(2)} L) differs from the required ${requiredSubstrateVolume.toFixed(2)} L.`,
+            );
+          }
+        }
+      }
+      nextSubstrate.totalVolumeLiters = requiredSubstrateVolume;
+    }
+
+    const originalContainer = zone.cultivation.container;
+    const originalSubstrate = zone.cultivation.substrate;
+
+    if (methodChanged && typeof patch.methodId === 'string') {
+      zone.cultivationMethodId = patch.methodId;
+    }
+
+    if (nextContainer) {
+      zone.cultivation.container = nextContainer;
+    }
+    if (nextSubstrate) {
+      zone.cultivation.substrate = nextSubstrate;
+    }
+
+    const containerChanged = (() => {
+      if (!originalContainer && !nextContainer) {
+        return false;
+      }
+      if (!originalContainer || !nextContainer) {
+        return true;
+      }
+      return (
+        originalContainer.blueprintId !== nextContainer.blueprintId ||
+        originalContainer.count !== nextContainer.count
+      );
+    })();
+
+    const substrateChanged = (() => {
+      if (!originalSubstrate && !nextSubstrate) {
+        return false;
+      }
+      if (!originalSubstrate || !nextSubstrate) {
+        return true;
+      }
+      return (
+        originalSubstrate.blueprintId !== nextSubstrate.blueprintId ||
+        originalSubstrate.totalVolumeLiters !== nextSubstrate.totalVolumeLiters
+      );
+    })();
+
+    if (methodChanged || containerChanged || substrateChanged) {
+      cultivationChanged = true;
+    }
+
+    if (geometryChanged) {
+      validateStructureGeometry(structure);
+    }
+
+    if (geometryChanged || cultivationChanged) {
+      const payload: Record<string, unknown> = {
+        zoneId: zone.id,
+        roomId: room.id,
+        structureId: structure.id,
+      };
+      if (cultivationChanged) {
+        payload.methodId = zone.cultivationMethodId;
+        if (zone.cultivation?.container) {
+          payload.container = {
+            slug: zone.cultivation.container.slug,
+            count: zone.cultivation.container.count,
+          };
+        }
+        if (zone.cultivation?.substrate) {
+          payload.substrate = {
+            slug: zone.cultivation.substrate.slug,
+            totalVolumeLiters: zone.cultivation.substrate.totalVolumeLiters,
+          };
+        }
+      }
+      if (geometryChanged) {
+        payload.area = zone.area;
+        payload.volume = zone.volume;
+      }
+      context.events.queue('world.zoneUpdated', payload, context.tick, 'info');
+    }
+
+    return {
+      ok: true,
+      warnings: warnings.length > 0 ? Array.from(new Set(warnings)) : undefined,
+    } satisfies CommandResult;
+  };
+
+  const recordDevicePurchases = (
+    purchases: DevicePurchaseMap,
+    context: CommandExecutionContext,
+    description: string,
+  ): void => {
+    if (purchases.size === 0) {
+      return;
+    }
+
+    const accumulator = deps.costAccounting.createAccumulator();
+    const timestamp = new Date().toISOString();
+    for (const [blueprintId, quantity] of purchases.entries()) {
+      deps.costAccounting.recordDevicePurchase(
+        deps.state,
+        blueprintId,
+        quantity,
+        context.tick,
+        timestamp,
+        accumulator,
+        context.events,
+        description,
+      );
+    }
+    deps.applyAccumulator(accumulator);
+  };
+
+  const cloneZone = (
+    zone: ZoneState,
+    _structureId: string,
+    roomId: string,
+    context: CommandExecutionContext,
+    options?: { forcedName?: string; recordPurchases?: boolean },
+  ): { zone: ZoneState; purchases: DevicePurchaseMap } => {
+    const forcedName = options?.forcedName;
+    const shouldRecord = options?.recordPurchases ?? false;
+    const newZoneId = deps.createId('zone');
+    const devices: ZoneState['devices'] = [];
+    const purchases: DevicePurchaseMap = new Map();
+
+    for (const device of zone.devices) {
+      const cloned = {
+        id: deps.createId('device'),
+        blueprintId: device.blueprintId,
+        kind: device.kind,
+        name: device.name,
+        zoneId: newZoneId,
+        status: 'operational' as const,
+        efficiency: device.efficiency,
+        runtimeHours: 0,
+        maintenance: {
+          lastServiceTick: context.tick,
+          nextDueTick: context.tick + defaultMaintenanceIntervalTicks,
+          condition: 1,
+          runtimeHoursAtLastService: 0,
+          degradation: 0,
+        },
+        settings: deepCloneSettings(device.settings),
+      } satisfies ZoneState['devices'][number];
+
+      devices.push(cloned);
+      const previous = purchases.get(device.blueprintId) ?? 0;
+      purchases.set(device.blueprintId, previous + 1);
+    }
+
+    const environment = cloneEnvironment(zone.environment);
+    const metrics = cloneMetrics(zone.metrics, context.tick);
+
+    const clonedZone: ZoneState = {
+      id: newZoneId,
+      roomId,
+      name: forcedName ?? deriveDuplicateName(zone.name, 'Zone Copy'),
+      cultivationMethodId: zone.cultivationMethodId,
+      strainId: zone.strainId,
+      area: zone.area,
+      ceilingHeight: zone.ceilingHeight,
+      volume: zone.volume,
+      environment,
+      resources: createDefaultResources(),
+      plants: [],
+      devices,
+      metrics,
+      control: cloneControl(zone.control),
+      health: createEmptyHealth(),
+      activeTaskIds: [],
+      plantingPlan: undefined,
+      cultivation: cloneCultivation(zone.cultivation),
+    } satisfies ZoneState;
+
+    if (shouldRecord) {
+      recordDevicePurchases(purchases, context, `Zone duplication from ${zone.id}`);
+    }
+
+    return { zone: clonedZone, purchases };
+  };
+
+  const duplicateZone = (
+    zoneId: string,
+    desiredName: string | undefined,
+    context: CommandExecutionContext,
+  ): CommandResult<DuplicateZoneResult> => {
+    const lookup = findZone(deps.state, zoneId);
+    if (!lookup) {
+      return deps.failure('ERR_NOT_FOUND', `Zone ${zoneId} was not found.`, [
+        'world.duplicateZone',
+        'zoneId',
+      ]);
+    }
+
+    const { structure, room, zone } = lookup;
+    const totalZoneArea = room.zones.reduce((sum, current) => sum + current.area, 0);
+    if (totalZoneArea + zone.area - room.area > 1e-6) {
+      return deps.failure('ERR_CONFLICT', 'Duplicating the zone would exceed the room area.', [
+        'world.duplicateZone',
+        'zoneId',
+      ]);
+    }
+
+    const forcedName = desiredName?.trim().length ? desiredName.trim() : undefined;
+    const { zone: newZone } = cloneZone(zone, structure.id, room.id, context, {
+      forcedName,
+      recordPurchases: true,
+    });
+
+    room.zones.push(newZone);
+    validateStructureGeometry(structure);
+
+    context.events.queue(
+      'world.zoneDuplicated',
+      { zoneId: newZone.id, sourceZoneId: zoneId, roomId: room.id, structureId: structure.id },
+      context.tick,
+      'info',
+    );
+
+    return { ok: true, data: { zoneId: newZone.id } } satisfies CommandResult<DuplicateZoneResult>;
+  };
+
+  return {
+    createZone,
+    updateZone,
+    duplicateZone,
+    cloneZone,
+  };
+};


### PR DESCRIPTION
## Summary
- finalize the `ZoneService.updateZone` delegate so cultivation defaults, compatibility checks, and warnings match the pre-refactor behavior
- share cloning/default helpers through `worldDefaults` and wire `WorldService` to the dedicated structure/room/zone collaborators
- update the zone service tests to exercise the new delegate directly and document the refactor in the changelog

## Testing
- pnpm --filter @weebbreed/backend lint
- pnpm --filter @weebbreed/backend test
- pnpm run check *(fails: frontend lint still missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68dabbe259688325b9e7bbff598b0664