### PR TITLE
Refactor zone modals to reuse cultivation setup section

### DIFF
--- a/src/frontend/src/components/modals/zones/ChangeZoneMethodModal.tsx
+++ b/src/frontend/src/components/modals/zones/ChangeZoneMethodModal.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ActionFooter, Feedback } from '@/components/modals/common';
 import type { SimulationBridge } from '@/facade/systemFacade';
 import { useSimulationStore } from '@/store/simulation';
 import { formatNumber } from '@/utils/formatNumber';
+import {
+  CultivationSetupSection,
+  useCultivationSetup,
+} from '@/components/modals/zones/CultivationSetupSection';
 import { getCultivationMethodHint } from './cultivationHints';
 import { requestStorageHandoff } from './storageHandoff';
 
@@ -21,247 +25,54 @@ export const ChangeZoneMethodModal = ({
   const zone = useSimulationStore((state) =>
     zoneId ? (state.snapshot?.zones.find((item) => item.id === zoneId) ?? null) : null,
   );
-  const cultivationCatalog = useSimulationStore((state) => state.catalogs.cultivationMethods);
-  const containerCatalog = useSimulationStore((state) => state.catalogs.containers);
-  const substrateCatalog = useSimulationStore((state) => state.catalogs.substrates);
+  const catalogs = useSimulationStore((state) => state.catalogs);
 
-  const readyMethods = cultivationCatalog.status === 'ready' ? cultivationCatalog.data : [];
-  const readyContainers = containerCatalog.status === 'ready' ? containerCatalog.data : [];
-  const readySubstrates = substrateCatalog.status === 'ready' ? substrateCatalog.data : [];
+  const readyContainers = catalogs.containers.status === 'ready' ? catalogs.containers.data : [];
+  const readySubstrates = catalogs.substrates.status === 'ready' ? catalogs.substrates.data : [];
 
   const zoneContainer = zone?.cultivation?.container ?? null;
   const zoneSubstrate = zone?.cultivation?.substrate ?? null;
 
-  const [selectedMethodId, setSelectedMethodId] = useState(() => zone?.cultivationMethodId ?? '');
-  const [selectedContainerId, setSelectedContainerId] = useState<string | null>(
-    () => zoneContainer?.blueprintId ?? null,
-  );
-  const [selectedSubstrateId, setSelectedSubstrateId] = useState<string | null>(
-    () => zoneSubstrate?.blueprintId ?? null,
-  );
-  const [containerCount, setContainerCount] = useState<number>(() => zoneContainer?.count ?? 0);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
-  const methodSelectId = useId();
-  const containerSelectId = useId();
-  const substrateSelectId = useId();
-  const containerCountInputId = useId();
-  const containerCountHelperId = `${containerCountInputId}-helper`;
-  const containerCountWarningId = `${containerCountInputId}-warning`;
 
-  const methodOptions = useMemo(
-    () => [...readyMethods].sort((a, b) => a.name.localeCompare(b.name)),
-    [readyMethods],
-  );
+  const cultivationSetup = useCultivationSetup({
+    catalogs,
+    availableArea: zone?.area ?? 0,
+    initialArea: zone?.area ?? 0.1,
+    areaEditable: false,
+    minArea: 0.1,
+    initialMethodId: zone?.cultivationMethodId ?? null,
+    initialContainerId: zoneContainer?.blueprintId ?? null,
+    initialSubstrateId: zoneSubstrate?.blueprintId ?? null,
+    initialContainerCount: zoneContainer?.count ?? 0,
+    existingContainer: zoneContainer
+      ? { blueprintId: zoneContainer.blueprintId ?? null, count: zoneContainer.count }
+      : null,
+    existingSubstrate: zoneSubstrate ? { blueprintId: zoneSubstrate.blueprintId ?? null } : null,
+    containerCountMin: 1,
+  });
 
-  useEffect(() => {
-    if (!selectedMethodId && methodOptions.length > 0) {
-      setSelectedMethodId(methodOptions[0]!.id);
-      return;
-    }
-    if (selectedMethodId && !methodOptions.some((method) => method.id === selectedMethodId)) {
-      const fallback =
-        methodOptions.find((method) => method.id === zone?.cultivationMethodId) ??
-        methodOptions[0] ??
-        null;
-      setSelectedMethodId(fallback?.id ?? '');
-    }
-  }, [methodOptions, selectedMethodId, zone?.cultivationMethodId]);
-
-  const selectedMethod = useMemo(() => {
-    if (!selectedMethodId) {
-      return null;
-    }
-    return methodOptions.find((method) => method.id === selectedMethodId) ?? null;
-  }, [methodOptions, selectedMethodId]);
-
-  const compatibleContainerTypes = selectedMethod?.compatibility?.compatibleContainerTypes;
-  const containerOptions = useMemo(() => {
-    if (!compatibleContainerTypes || compatibleContainerTypes.length === 0) {
-      return readyContainers;
-    }
-    return readyContainers.filter((entry) => compatibleContainerTypes.includes(entry.type));
-  }, [readyContainers, compatibleContainerTypes]);
-
-  useEffect(() => {
-    if (containerOptions.length === 0) {
-      setSelectedContainerId(null);
-      return;
-    }
-    if (
-      !selectedContainerId ||
-      !containerOptions.some((entry) => entry.id === selectedContainerId)
-    ) {
-      const fallbackFromZone =
-        zoneContainer && containerOptions.find((entry) => entry.id === zoneContainer.blueprintId);
-      setSelectedContainerId((fallbackFromZone ?? containerOptions[0]!).id);
-    }
-  }, [containerOptions, selectedContainerId, zoneContainer]);
-
-  const selectedContainer = useMemo(
-    () => containerOptions.find((entry) => entry.id === selectedContainerId) ?? null,
-    [containerOptions, selectedContainerId],
-  );
-
-  const compatibleSubstrateTypes = selectedMethod?.compatibility?.compatibleSubstrateTypes;
-  const substrateOptions = useMemo(() => {
-    if (!compatibleSubstrateTypes || compatibleSubstrateTypes.length === 0) {
-      return readySubstrates;
-    }
-    return readySubstrates.filter((entry) => compatibleSubstrateTypes.includes(entry.type));
-  }, [readySubstrates, compatibleSubstrateTypes]);
-
-  useEffect(() => {
-    if (substrateOptions.length === 0) {
-      setSelectedSubstrateId(null);
-      return;
-    }
-    if (
-      !selectedSubstrateId ||
-      !substrateOptions.some((entry) => entry.id === selectedSubstrateId)
-    ) {
-      const fallbackFromZone =
-        zoneSubstrate && substrateOptions.find((entry) => entry.id === zoneSubstrate.blueprintId);
-      setSelectedSubstrateId((fallbackFromZone ?? substrateOptions[0]!).id);
-    }
-  }, [substrateOptions, selectedSubstrateId, zoneSubstrate]);
-
-  const selectedSubstrate = useMemo(
-    () => substrateOptions.find((entry) => entry.id === selectedSubstrateId) ?? null,
-    [substrateOptions, selectedSubstrateId],
-  );
-
-  const zoneArea = zone?.area ?? 0;
-  const previousContainerRef = useRef<string | null>(null);
-  const previousMaxRef = useRef<number>(0);
-
-  const maxContainers = useMemo(() => {
-    if (!zone || !selectedContainer) {
-      return 0;
-    }
-    const footprint = selectedContainer.footprintArea;
-    if (!footprint || !Number.isFinite(footprint) || footprint <= 0) {
-      return 0;
-    }
-    const densityRaw = selectedContainer.packingDensity;
-    const density = densityRaw && Number.isFinite(densityRaw) && densityRaw > 0 ? densityRaw : 1;
-    const theoretical = (zone.area / footprint) * density;
-    if (!Number.isFinite(theoretical) || theoretical <= 0) {
-      return 0;
-    }
-    return Math.floor(theoretical);
-  }, [selectedContainer, zone]);
-
-  useEffect(() => {
-    const currentContainerId = selectedContainer?.id ?? null;
-    const max = maxContainers;
-
-    if (!selectedContainer || max <= 0) {
-      setContainerCount(0);
-      previousContainerRef.current = currentContainerId;
-      previousMaxRef.current = max;
-      return;
-    }
-
-    setContainerCount((current) => {
-      const containerChanged = previousContainerRef.current !== currentContainerId;
-      const maxChanged = previousMaxRef.current !== max;
-      if (containerChanged || maxChanged || current <= 0) {
-        const existing =
-          zoneContainer && zoneContainer.blueprintId === currentContainerId
-            ? zoneContainer.count
-            : 0;
-        if (existing > 0 && existing <= max) {
-          return existing;
-        }
-        return max;
-      }
-      if (current > max) {
-        return max;
-      }
-      return current;
-    });
-
-    previousContainerRef.current = currentContainerId;
-    previousMaxRef.current = max;
-  }, [selectedContainer, maxContainers, zoneContainer]);
-
-  const handleContainerCountChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const parsed = Number(event.target.value);
-      if (Number.isNaN(parsed)) {
-        return;
-      }
-      const max = maxContainers;
-      if (max <= 0) {
-        setContainerCount(0);
-        return;
-      }
-      const clamped = Math.min(Math.max(Math.floor(parsed), 1), max);
-      setContainerCount(clamped);
-      setFeedback(null);
-    },
-    [maxContainers],
-  );
-
-  const containerOverCapacity = maxContainers > 0 && containerCount > maxContainers;
-
-  const substrateVolumeLiters = useMemo(() => {
-    if (!selectedContainer || containerCount <= 0) {
-      return null;
-    }
-    const volume = selectedContainer.volumeInLiters;
-    if (!volume || !Number.isFinite(volume) || volume <= 0) {
-      return null;
-    }
-    return volume * containerCount;
-  }, [selectedContainer, containerCount]);
-
-  const methodSetupCost = selectedMethod?.price?.setupCost ?? 0;
-  const containerUnitCost = selectedContainer?.price?.costPerUnit ?? 0;
-  const containerTotalCost = containerCount > 0 ? containerUnitCost * containerCount : 0;
-  const substrateUnitCost = selectedSubstrate?.price?.costPerLiter ?? 0;
-  const substrateTotalCost =
-    substrateVolumeLiters && substrateVolumeLiters > 0
-      ? substrateUnitCost * substrateVolumeLiters
-      : 0;
-  const estimatedTotalCost = methodSetupCost + containerTotalCost + substrateTotalCost;
-
-  const methodHint = getCultivationMethodHint(selectedMethodId);
-
-  const compatibilitySummary = useMemo(() => {
-    if (!selectedMethod) {
-      return null;
-    }
-    const pieces: string[] = [];
-    const containerList = selectedMethod.compatibility?.compatibleContainerTypes;
-    if (Array.isArray(containerList) && containerList.length > 0) {
-      pieces.push(`Supports containers: ${containerList.join(', ')}`);
-    }
-    const substrateList = selectedMethod.compatibility?.compatibleSubstrateTypes;
-    if (Array.isArray(substrateList) && substrateList.length > 0) {
-      pieces.push(`Supports substrates: ${substrateList.join(', ')}`);
-    }
-    return pieces.length ? pieces.join(' · ') : null;
-  }, [selectedMethod]);
-
-  const methodStatus = cultivationCatalog.status;
-  const containerStatus = containerCatalog.status;
-  const substrateStatus = substrateCatalog.status;
-
-  const catalogError =
-    (methodStatus === 'error' && cultivationCatalog.error) ||
-    (containerStatus === 'error' && containerCatalog.error) ||
-    (substrateStatus === 'error' && substrateCatalog.error) ||
-    null;
-
-  const isCatalogLoading =
-    methodStatus === 'loading' || containerStatus === 'loading' || substrateStatus === 'loading';
+  const {
+    methodId,
+    selectedMethod,
+    selectedContainer,
+    selectedSubstrate,
+    containerCount,
+    maxContainers,
+    containerOverCapacity,
+    substrateVolumeLiters,
+    catalogError,
+    isCatalogLoading,
+    methodOptions,
+    containerOptions,
+    substrateOptions,
+  } = cultivationSetup;
 
   useEffect(() => {
     setWarnings([]);
-  }, [selectedMethodId, selectedContainerId, selectedSubstrateId, containerCount]);
+  }, [methodId, cultivationSetup.containerId, cultivationSetup.substrateId, containerCount]);
 
   if (!zone || !zoneId) {
     return (
@@ -311,6 +122,24 @@ export const ChangeZoneMethodModal = ({
       </div>
     );
   }
+
+  const methodHint = getCultivationMethodHint(methodId ?? '');
+
+  const compatibilitySummary = useMemo(() => {
+    if (!selectedMethod) {
+      return null;
+    }
+    const pieces: string[] = [];
+    const containerList = selectedMethod.compatibility?.compatibleContainerTypes;
+    if (Array.isArray(containerList) && containerList.length > 0) {
+      pieces.push(`Supports containers: ${containerList.join(', ')}`);
+    }
+    const substrateList = selectedMethod.compatibility?.compatibleSubstrateTypes;
+    if (Array.isArray(substrateList) && substrateList.length > 0) {
+      pieces.push(`Supports substrates: ${substrateList.join(', ')}`);
+    }
+    return pieces.length ? pieces.join(' · ') : null;
+  }, [selectedMethod]);
 
   const resolvedContainerName = (() => {
     if (zoneContainer?.name) {
@@ -434,29 +263,29 @@ export const ChangeZoneMethodModal = ({
             : ''}
         </span>
       </div>
-      <div className="grid gap-1">
-        <label
-          className="text-xs font-semibold uppercase tracking-wide text-text-muted"
-          htmlFor={methodSelectId}
-        >
-          New method
-        </label>
-        <select
-          id={methodSelectId}
-          value={selectedMethodId}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            setSelectedMethodId(event.target.value);
-            setFeedback(null);
-          }}
-          className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none"
-        >
-          {methodOptions.map((method) => (
-            <option key={method.id} value={method.id}>
-              {method.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      <CultivationSetupSection
+        setup={cultivationSetup}
+        areaEditable={false}
+        showMaxButton={false}
+        areaHelperText={`Zone area: ${formatNumber(zone.area, { maximumFractionDigits: 1 })} m²`}
+        labels={{
+          method: 'New method',
+          container: 'Container',
+          substrate: 'Substrate',
+          area: 'Zone area (m²)',
+          containerCount: 'Container count',
+        }}
+        capacityMessages={{
+          positive: ({ maxContainers: max }) =>
+            `Max supported: ${formatNumber(max, { maximumFractionDigits: 0 })} containers · Zone area ${formatNumber(
+              zone.area,
+              { maximumFractionDigits: 1 },
+            )} m²`,
+          zero: () =>
+            `Selected container cannot fit into ${formatNumber(zone.area, { maximumFractionDigits: 1 })} m².`,
+        }}
+        disabled={busy}
+      />
       {selectedMethod ? (
         <div className="grid gap-1 rounded-xl border border-border/40 bg-surface-muted/20 p-3 text-xs text-text-muted">
           <span className="text-sm font-semibold text-text">{selectedMethod.name}</span>
@@ -469,202 +298,38 @@ export const ChangeZoneMethodModal = ({
           {compatibilitySummary ? <span>{compatibilitySummary}</span> : null}
         </div>
       ) : null}
-      <div className="grid gap-3 rounded-xl border border-border/40 bg-surface-muted/20 p-3 text-sm">
-        <div className="grid gap-1">
-          <label
-            className="text-xs font-semibold uppercase tracking-wide text-text-muted"
-            htmlFor={containerSelectId}
-          >
-            Container
-          </label>
-          <select
-            id={containerSelectId}
-            value={selectedContainerId ?? ''}
-            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-              setSelectedContainerId(event.target.value || null);
-              setFeedback(null);
-            }}
-            className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none"
-          >
-            {containerOptions.map((container) => (
-              <option key={container.id} value={container.id}>
-                {container.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        {selectedContainer ? (
-          <div className="grid gap-1 text-xs text-text-muted">
-            <span>Type: {selectedContainer.type}</span>
-            {selectedContainer.footprintArea ? (
-              <span>
-                Footprint:{' '}
-                {formatNumber(selectedContainer.footprintArea, { maximumFractionDigits: 2 })} m²
-              </span>
-            ) : null}
-            {selectedContainer.packingDensity ? (
-              <span>
-                Packing density:{' '}
-                {formatNumber(selectedContainer.packingDensity, { maximumFractionDigits: 2 })}
-              </span>
-            ) : null}
-            {selectedContainer.volumeInLiters ? (
-              <span>
-                Volume:{' '}
-                {formatNumber(selectedContainer.volumeInLiters, { maximumFractionDigits: 1 })} L per
-                unit
-              </span>
-            ) : null}
-          </div>
-        ) : null}
-        <div className="grid gap-1">
-          <label
-            className="text-xs font-semibold uppercase tracking-wide text-text-muted"
-            htmlFor={containerCountInputId}
-          >
-            Container count
-          </label>
-          <input
-            id={containerCountInputId}
-            type="number"
-            min={1}
-            max={maxContainers > 0 ? maxContainers : undefined}
-            value={containerCount}
-            onChange={handleContainerCountChange}
-            disabled={!selectedContainer || maxContainers <= 0}
-            aria-describedby={
-              maxContainers > 0
-                ? containerCountHelperId
-                : selectedContainer
-                  ? containerCountWarningId
-                  : undefined
-            }
-            className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-          />
-          {maxContainers > 0 ? (
-            <span id={containerCountHelperId} className="text-xs text-text-muted">
-              Max supported: {formatNumber(maxContainers, { maximumFractionDigits: 0 })} containers
-              · Zone area {formatNumber(zoneArea, { maximumFractionDigits: 1 })} m²
-            </span>
-          ) : (
-            <span id={containerCountWarningId} className="text-xs text-warning">
-              Selected container cannot fit into{' '}
-              {formatNumber(zoneArea, { maximumFractionDigits: 1 })} m².
-            </span>
-          )}
-        </div>
-        <div className="grid gap-1">
-          <label
-            className="text-xs font-semibold uppercase tracking-wide text-text-muted"
-            htmlFor={substrateSelectId}
-          >
-            Substrate
-          </label>
-          <select
-            id={substrateSelectId}
-            value={selectedSubstrateId ?? ''}
-            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-              setSelectedSubstrateId(event.target.value || null);
-              setFeedback(null);
-            }}
-            className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none"
-          >
-            {substrateOptions.map((substrate) => (
-              <option key={substrate.id} value={substrate.id}>
-                {substrate.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        {selectedSubstrate ? (
-          <div className="grid gap-1 text-xs text-text-muted">
-            <span>Type: {selectedSubstrate.type}</span>
-          </div>
-        ) : null}
+      {selectedContainer ? (
         <div className="grid gap-1 text-xs text-text-muted">
-          <span>
-            Estimated substrate volume:{' '}
-            {substrateVolumeLiters
-              ? `${formatNumber(substrateVolumeLiters, { maximumFractionDigits: 1 })} L`
-              : 'Not available'}
-          </span>
-          {selectedSubstrate?.price?.costPerLiter ? (
+          <span>Type: {selectedContainer.type}</span>
+          {selectedContainer.footprintArea ? (
             <span>
-              Substrate unit cost{' '}
-              {formatNumber(selectedSubstrate.price.costPerLiter, {
-                style: 'currency',
-                currency: 'EUR',
-                maximumFractionDigits: 0,
-              })}
-              {substrateTotalCost > 0
-                ? ` · Total ${formatNumber(substrateTotalCost, {
-                    style: 'currency',
-                    currency: 'EUR',
-                    maximumFractionDigits: 0,
-                  })}`
-                : ''}
+              Footprint{' '}
+              {formatNumber(selectedContainer.footprintArea, { maximumFractionDigits: 2 })} m²
             </span>
           ) : null}
-          {selectedContainer?.price?.costPerUnit ? (
+          {selectedContainer.packingDensity ? (
             <span>
-              Container unit cost{' '}
-              {formatNumber(selectedContainer.price.costPerUnit, {
-                style: 'currency',
-                currency: 'EUR',
-                maximumFractionDigits: 0,
-              })}
-              {containerTotalCost > 0
-                ? ` · Total ${formatNumber(containerTotalCost, {
-                    style: 'currency',
-                    currency: 'EUR',
-                    maximumFractionDigits: 0,
-                  })}`
-                : ''}
+              Packing density{' '}
+              {formatNumber(selectedContainer.packingDensity, { maximumFractionDigits: 2 })}
+            </span>
+          ) : null}
+          {selectedContainer.volumeInLiters ? (
+            <span>
+              Volume {formatNumber(selectedContainer.volumeInLiters, { maximumFractionDigits: 1 })}{' '}
+              L per unit
             </span>
           ) : null}
         </div>
-      </div>
-      {methodSetupCost > 0 || containerTotalCost > 0 || substrateTotalCost > 0 ? (
-        <div className="grid gap-1 rounded-xl border border-border/40 bg-surface-muted/20 p-3 text-xs text-text-muted">
-          <span className="text-sm font-semibold text-text">Estimated costs</span>
-          {methodSetupCost > 0 ? (
-            <span>
-              Method setup{' '}
-              {formatNumber(methodSetupCost, {
-                style: 'currency',
-                currency: 'EUR',
-                maximumFractionDigits: 0,
-              })}
-            </span>
-          ) : null}
-          {containerTotalCost > 0 ? (
-            <span>
-              Containers{' '}
-              {formatNumber(containerTotalCost, {
-                style: 'currency',
-                currency: 'EUR',
-                maximumFractionDigits: 0,
-              })}
-            </span>
-          ) : null}
-          {substrateTotalCost > 0 ? (
-            <span>
-              Substrate{' '}
-              {formatNumber(substrateTotalCost, {
-                style: 'currency',
-                currency: 'EUR',
-                maximumFractionDigits: 0,
-              })}
-            </span>
-          ) : null}
-          <span>
-            Total{' '}
-            {formatNumber(estimatedTotalCost, {
-              style: 'currency',
-              currency: 'EUR',
-              maximumFractionDigits: 0,
-            })}
-          </span>
+      ) : null}
+      {selectedSubstrate ? (
+        <div className="grid gap-1 text-xs text-text-muted">
+          <span>Type: {selectedSubstrate.type}</span>
+        </div>
+      ) : null}
+      {substrateVolumeLiters ? (
+        <div className="text-xs text-text-muted">
+          Estimated substrate volume{' '}
+          {formatNumber(substrateVolumeLiters, { maximumFractionDigits: 1 })} L
         </div>
       ) : null}
       {warnings.length ? (

--- a/src/frontend/src/components/modals/zones/CultivationSetupSection.tsx
+++ b/src/frontend/src/components/modals/zones/CultivationSetupSection.tsx
@@ -1,0 +1,631 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { Button } from '@/components/primitives/Button';
+import { formatNumber } from '@/utils/formatNumber';
+import type {
+  ContainerCatalogEntry,
+  CultivationMethodCatalogEntry,
+  SubstrateCatalogEntry,
+} from '@/types/blueprints';
+import { useSimulationStore } from '@/store/simulation';
+
+type CatalogState = ReturnType<typeof useSimulationStore.getState>['catalogs'];
+
+type CatalogSlice<T> = {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  data: T[];
+  error: string | null;
+};
+
+interface ExistingSelection {
+  blueprintId: string | null;
+  count?: number;
+}
+
+export interface CultivationSetupOptions {
+  catalogs: CatalogState;
+  availableArea: number;
+  initialArea: number;
+  areaEditable: boolean;
+  minArea?: number;
+  initialMethodId?: string | null;
+  initialContainerId?: string | null;
+  initialSubstrateId?: string | null;
+  initialContainerCount?: number;
+  existingContainer?: ExistingSelection | null;
+  existingSubstrate?: ExistingSelection | null;
+  containerCountMin?: number;
+}
+
+export interface CultivationSetupState {
+  methodId: string | null;
+  setMethodId: (value: string | null) => void;
+  methodOptions: CultivationMethodCatalogEntry[];
+  selectedMethod: CultivationMethodCatalogEntry | null;
+  containerId: string | null;
+  setContainerId: (value: string | null) => void;
+  containerOptions: ContainerCatalogEntry[];
+  selectedContainer: ContainerCatalogEntry | null;
+  substrateId: string | null;
+  setSubstrateId: (value: string | null) => void;
+  substrateOptions: SubstrateCatalogEntry[];
+  selectedSubstrate: SubstrateCatalogEntry | null;
+  area: number;
+  areaInput: string;
+  handleAreaInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleApplyMaxArea: () => void;
+  containerCount: number;
+  handleContainerCountChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  maxContainers: number;
+  containerOverCapacity: boolean;
+  substrateVolumeLiters: number | null;
+  methodSetupCost: number;
+  containerUnitCost: number;
+  containerTotalCost: number;
+  substrateUnitCost: number;
+  substrateTotalCost: number;
+  totalCost: number;
+  catalogError: string | null;
+  isCatalogLoading: boolean;
+  containerCountMin: number;
+}
+
+const getReadyEntries = <T,>(slice: CatalogSlice<T>): T[] => {
+  return slice.status === 'ready' ? slice.data : [];
+};
+
+export const useCultivationSetup = ({
+  catalogs,
+  availableArea,
+  initialArea,
+  areaEditable,
+  minArea = 0.1,
+  initialMethodId = null,
+  initialContainerId = null,
+  initialSubstrateId = null,
+  initialContainerCount = 0,
+  existingContainer,
+  existingSubstrate,
+  containerCountMin = 0,
+}: CultivationSetupOptions): CultivationSetupState => {
+  const methodStatus = catalogs.cultivationMethods.status;
+  const containerStatus = catalogs.containers.status;
+  const substrateStatus = catalogs.substrates.status;
+
+  const readyMethods = useMemo(
+    () => getReadyEntries<CultivationMethodCatalogEntry>(catalogs.cultivationMethods),
+    [catalogs.cultivationMethods],
+  );
+  const readyContainers = useMemo(
+    () => getReadyEntries<ContainerCatalogEntry>(catalogs.containers),
+    [catalogs.containers],
+  );
+  const readySubstrates = useMemo(
+    () => getReadyEntries<SubstrateCatalogEntry>(catalogs.substrates),
+    [catalogs.substrates],
+  );
+
+  const computeClampedArea = useCallback(
+    (value: number) => {
+      if (!Number.isFinite(value)) {
+        return 0;
+      }
+      const maxArea = Math.max(availableArea, minArea);
+      const clamped = Math.min(Math.max(value, minArea), maxArea);
+      return Number(clamped.toFixed(2));
+    },
+    [availableArea, minArea],
+  );
+
+  const [area, setArea] = useState(() => computeClampedArea(initialArea));
+  const [areaInput, setAreaInput] = useState(() => computeClampedArea(initialArea).toString());
+
+  useEffect(() => {
+    setArea((current) => computeClampedArea(current));
+  }, [availableArea, computeClampedArea]);
+
+  const updateArea = useCallback(
+    (value: number) => {
+      const normalized = computeClampedArea(value);
+      setArea(normalized);
+      setAreaInput(normalized.toString());
+    },
+    [computeClampedArea],
+  );
+
+  const handleAreaInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (!areaEditable) {
+        return;
+      }
+      const { value } = event.target;
+      setAreaInput(value);
+      if (value === '') {
+        setArea(0);
+        return;
+      }
+      const parsed = Number(value);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      updateArea(parsed);
+    },
+    [areaEditable, updateArea],
+  );
+
+  const handleApplyMaxArea = useCallback(() => {
+    if (!areaEditable) {
+      return;
+    }
+    const maxArea = Math.max(availableArea, minArea);
+    updateArea(maxArea);
+  }, [areaEditable, availableArea, minArea, updateArea]);
+
+  const [methodId, setMethodId] = useState<string | null>(() => initialMethodId);
+  const [containerId, setContainerId] = useState<string | null>(() => initialContainerId);
+  const [substrateId, setSubstrateId] = useState<string | null>(() => initialSubstrateId);
+  const [containerCount, setContainerCount] = useState(() => initialContainerCount);
+
+  useEffect(() => {
+    if (!readyMethods.length) {
+      setMethodId(null);
+      return;
+    }
+    if (methodId && readyMethods.some((method) => method.id === methodId)) {
+      return;
+    }
+    const fallback =
+      (initialMethodId && readyMethods.find((method) => method.id === initialMethodId)) ||
+      readyMethods[0]!;
+    setMethodId(fallback.id);
+  }, [readyMethods, methodId, initialMethodId]);
+
+  const selectedMethod = useMemo(() => {
+    if (!methodId) {
+      return null;
+    }
+    return readyMethods.find((method) => method.id === methodId) ?? null;
+  }, [methodId, readyMethods]);
+
+  const compatibleContainerTypes = selectedMethod?.compatibility?.compatibleContainerTypes;
+  const containerOptions = useMemo(() => {
+    if (!compatibleContainerTypes || compatibleContainerTypes.length === 0) {
+      return readyContainers;
+    }
+    return readyContainers.filter((entry) => compatibleContainerTypes.includes(entry.type));
+  }, [readyContainers, compatibleContainerTypes]);
+
+  useEffect(() => {
+    if (containerOptions.length === 0) {
+      setContainerId(null);
+      return;
+    }
+    if (containerId && containerOptions.some((entry) => entry.id === containerId)) {
+      return;
+    }
+    const fallbackFromInitial =
+      (initialContainerId && containerOptions.find((entry) => entry.id === initialContainerId)) ||
+      null;
+    const fallbackFromExisting =
+      (existingContainer?.blueprintId &&
+        containerOptions.find((entry) => entry.id === existingContainer.blueprintId)) ||
+      null;
+    const fallback = fallbackFromInitial ?? fallbackFromExisting ?? containerOptions[0]!;
+    setContainerId(fallback.id);
+  }, [containerOptions, containerId, initialContainerId, existingContainer?.blueprintId]);
+
+  const selectedContainer = useMemo(() => {
+    if (!containerId) {
+      return null;
+    }
+    return containerOptions.find((entry) => entry.id === containerId) ?? null;
+  }, [containerId, containerOptions]);
+
+  const compatibleSubstrateTypes = selectedMethod?.compatibility?.compatibleSubstrateTypes;
+  const substrateOptions = useMemo(() => {
+    if (!compatibleSubstrateTypes || compatibleSubstrateTypes.length === 0) {
+      return readySubstrates;
+    }
+    return readySubstrates.filter((entry) => compatibleSubstrateTypes.includes(entry.type));
+  }, [readySubstrates, compatibleSubstrateTypes]);
+
+  useEffect(() => {
+    if (substrateOptions.length === 0) {
+      setSubstrateId(null);
+      return;
+    }
+    if (substrateId && substrateOptions.some((entry) => entry.id === substrateId)) {
+      return;
+    }
+    const fallbackFromInitial =
+      (initialSubstrateId && substrateOptions.find((entry) => entry.id === initialSubstrateId)) ||
+      null;
+    const fallbackFromExisting =
+      (existingSubstrate?.blueprintId &&
+        substrateOptions.find((entry) => entry.id === existingSubstrate.blueprintId)) ||
+      null;
+    const fallback = fallbackFromInitial ?? fallbackFromExisting ?? substrateOptions[0]!;
+    setSubstrateId(fallback.id);
+  }, [substrateOptions, substrateId, initialSubstrateId, existingSubstrate?.blueprintId]);
+
+  const selectedSubstrate = useMemo(() => {
+    if (!substrateId) {
+      return null;
+    }
+    return substrateOptions.find((entry) => entry.id === substrateId) ?? null;
+  }, [substrateId, substrateOptions]);
+
+  const previousAreaRef = useRef(area);
+  const previousMaxContainersRef = useRef(0);
+  const previousContainerIdRef = useRef<string | null>(null);
+
+  const maxContainers = useMemo(() => {
+    if (!selectedContainer || !selectedContainer.footprintArea) {
+      return 0;
+    }
+    const footprint = selectedContainer.footprintArea;
+    const density = selectedContainer.packingDensity ?? 1;
+    if (
+      !Number.isFinite(footprint) ||
+      footprint <= 0 ||
+      !Number.isFinite(density) ||
+      density <= 0
+    ) {
+      return 0;
+    }
+    const rawCapacity = (area / footprint) * density;
+    if (!Number.isFinite(rawCapacity)) {
+      return 0;
+    }
+    return Math.max(Math.floor(rawCapacity), 0);
+  }, [selectedContainer, area]);
+
+  useEffect(() => {
+    const currentContainerId = selectedContainer?.id ?? null;
+
+    if (!selectedContainer || maxContainers <= 0) {
+      setContainerCount(containerCountMin);
+      previousAreaRef.current = area;
+      previousMaxContainersRef.current = maxContainers;
+      previousContainerIdRef.current = currentContainerId;
+      return;
+    }
+
+    setContainerCount((current) => {
+      const containerChanged = previousContainerIdRef.current !== currentContainerId;
+      const maxChanged = previousMaxContainersRef.current !== maxContainers;
+      const areaChanged = previousAreaRef.current !== area;
+
+      if (
+        containerChanged ||
+        maxChanged ||
+        (areaEditable && areaChanged) ||
+        current < containerCountMin ||
+        current > maxContainers
+      ) {
+        const existingMatch =
+          existingContainer && existingContainer.blueprintId === currentContainerId
+            ? (existingContainer.count ?? 0)
+            : 0;
+        if (
+          existingMatch &&
+          Number.isFinite(existingMatch) &&
+          existingMatch >= containerCountMin &&
+          existingMatch <= maxContainers
+        ) {
+          return existingMatch;
+        }
+        return Math.max(maxContainers, containerCountMin);
+      }
+
+      return current;
+    });
+
+    previousAreaRef.current = area;
+    previousMaxContainersRef.current = maxContainers;
+    previousContainerIdRef.current = currentContainerId;
+  }, [
+    selectedContainer,
+    maxContainers,
+    area,
+    areaEditable,
+    containerCountMin,
+    existingContainer?.blueprintId,
+    existingContainer?.count,
+  ]);
+
+  const handleContainerCountChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const parsed = Number(event.target.value);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      const max = maxContainers;
+      if (max <= 0) {
+        setContainerCount(containerCountMin);
+        return;
+      }
+      const clamped = Math.min(Math.max(Math.floor(parsed), containerCountMin), max);
+      setContainerCount(clamped);
+    },
+    [maxContainers, containerCountMin],
+  );
+
+  const containerOverCapacity = maxContainers > 0 && containerCount > maxContainers;
+
+  const substrateVolumeLiters = useMemo(() => {
+    if (!selectedContainer || containerCount <= 0) {
+      return null;
+    }
+    const volume = selectedContainer.volumeInLiters;
+    if (!volume || !Number.isFinite(volume) || volume <= 0) {
+      return null;
+    }
+    return volume * containerCount;
+  }, [selectedContainer, containerCount]);
+
+  const methodSetupCost = selectedMethod?.price?.setupCost ?? 0;
+  const containerUnitCost = selectedContainer?.price?.costPerUnit ?? 0;
+  const containerTotalCost = containerCount > 0 ? containerUnitCost * containerCount : 0;
+  const substrateUnitCost = selectedSubstrate?.price?.costPerLiter ?? 0;
+  const substrateTotalCost =
+    substrateVolumeLiters && substrateVolumeLiters > 0
+      ? substrateUnitCost * substrateVolumeLiters
+      : 0;
+  const totalCost = methodSetupCost + containerTotalCost + substrateTotalCost;
+
+  const catalogError =
+    (methodStatus === 'error' && catalogs.cultivationMethods.error) ||
+    (containerStatus === 'error' && catalogs.containers.error) ||
+    (substrateStatus === 'error' && catalogs.substrates.error) ||
+    null;
+
+  const isCatalogLoading =
+    methodStatus === 'loading' || containerStatus === 'loading' || substrateStatus === 'loading';
+
+  return {
+    methodId,
+    setMethodId,
+    methodOptions: readyMethods,
+    selectedMethod,
+    containerId,
+    setContainerId,
+    containerOptions,
+    selectedContainer,
+    substrateId,
+    setSubstrateId,
+    substrateOptions,
+    selectedSubstrate,
+    area,
+    areaInput,
+    handleAreaInputChange,
+    handleApplyMaxArea,
+    containerCount,
+    handleContainerCountChange,
+    maxContainers,
+    containerOverCapacity,
+    substrateVolumeLiters,
+    methodSetupCost,
+    containerUnitCost,
+    containerTotalCost,
+    substrateUnitCost,
+    substrateTotalCost,
+    totalCost,
+    catalogError,
+    isCatalogLoading,
+    containerCountMin,
+  };
+};
+
+interface CultivationSetupSectionProps {
+  setup: CultivationSetupState;
+  areaEditable: boolean;
+  areaHelperText?: string | null;
+  labels?: {
+    method?: string;
+    container?: string;
+    substrate?: string;
+    area?: string;
+    containerCount?: string;
+  };
+  showMaxButton?: boolean;
+  capacityMessages?: {
+    positive?: (context: { maxContainers: number; area: number }) => string;
+    zero?: (context: { area: number }) => string;
+  };
+  disabled?: boolean;
+}
+
+export const CultivationSetupSection = ({
+  setup,
+  areaEditable,
+  areaHelperText,
+  labels,
+  showMaxButton = areaEditable,
+  capacityMessages,
+  disabled = false,
+}: CultivationSetupSectionProps) => {
+  const containerCountInputId = useId();
+  const containerCountHelperId = `${containerCountInputId}-helper`;
+  const containerCountWarningId = `${containerCountInputId}-warning`;
+
+  const methodLabel = labels?.method ?? 'Cultivation Method';
+  const containerLabel = labels?.container ?? 'Container Blueprint';
+  const substrateLabel = labels?.substrate ?? 'Substrate Blueprint';
+  const areaLabel = labels?.area ?? 'Area (m²)';
+  const containerCountLabel = labels?.containerCount ?? 'Container count';
+
+  const positiveCapacityMessage =
+    capacityMessages?.positive?.({
+      maxContainers: setup.maxContainers,
+      area: setup.area,
+    }) ??
+    `Maximum supported: ${formatNumber(setup.maxContainers, { maximumFractionDigits: 0 })} containers`;
+
+  const zeroCapacityMessage =
+    capacityMessages?.zero?.({ area: setup.area }) ??
+    'Container footprint metadata required to compute capacity.';
+
+  return (
+    <div className="grid gap-3">
+      <label className="grid gap-1 text-sm">
+        <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          {methodLabel}
+        </span>
+        <select
+          value={setup.methodId ?? ''}
+          onChange={(event) => setup.setMethodId(event.target.value || null)}
+          disabled={disabled || setup.isCatalogLoading || setup.methodOptions.length === 0}
+          className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {setup.methodOptions.map((method) => (
+            <option key={method.id} value={method.id}>
+              {method.name}
+            </option>
+          ))}
+        </select>
+        {setup.selectedMethod?.metadata?.description ? (
+          <span className="text-xs text-text-muted">
+            {setup.selectedMethod.metadata.description as string}
+          </span>
+        ) : null}
+      </label>
+      <label className="grid gap-1 text-sm">
+        <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          {containerLabel}
+        </span>
+        <select
+          value={setup.containerId ?? ''}
+          onChange={(event) => setup.setContainerId(event.target.value || null)}
+          disabled={disabled || setup.isCatalogLoading || setup.containerOptions.length === 0}
+          className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {setup.containerOptions.map((container) => (
+            <option key={container.id} value={container.id}>
+              {container.name} · {container.type}
+              {container.footprintArea
+                ? ` · ${formatNumber(container.footprintArea, { maximumFractionDigits: 2 })} m²`
+                : ''}
+            </option>
+          ))}
+        </select>
+        {setup.selectedContainer?.metadata?.description ? (
+          <span className="text-xs text-text-muted">
+            {setup.selectedContainer.metadata.description as string}
+          </span>
+        ) : null}
+      </label>
+      <label className="grid gap-1 text-sm">
+        <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          {substrateLabel}
+        </span>
+        <select
+          value={setup.substrateId ?? ''}
+          onChange={(event) => setup.setSubstrateId(event.target.value || null)}
+          disabled={disabled || setup.isCatalogLoading || setup.substrateOptions.length === 0}
+          className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {setup.substrateOptions.map((substrate) => (
+            <option key={substrate.id} value={substrate.id}>
+              {substrate.name} · {substrate.type}
+            </option>
+          ))}
+        </select>
+        {setup.selectedSubstrate?.metadata?.description ? (
+          <span className="text-xs text-text-muted">
+            {setup.selectedSubstrate.metadata.description as string}
+          </span>
+        ) : null}
+      </label>
+      <label className="grid gap-1 text-sm">
+        <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          {areaLabel}
+        </span>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            value={setup.areaInput}
+            onChange={setup.handleAreaInputChange}
+            min={0.1}
+            step="0.1"
+            disabled={!areaEditable || disabled}
+            className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          />
+          {showMaxButton ? (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={setup.handleApplyMaxArea}
+              disabled={!areaEditable || disabled}
+            >
+              Max
+            </Button>
+          ) : null}
+        </div>
+        {areaHelperText ? <span className="text-xs text-text-muted">{areaHelperText}</span> : null}
+      </label>
+      <div className="grid gap-1 text-sm">
+        <label
+          className="text-xs font-semibold uppercase tracking-wide text-text-muted"
+          htmlFor={containerCountInputId}
+        >
+          {containerCountLabel}
+        </label>
+        <input
+          id={containerCountInputId}
+          type="number"
+          min={setup.containerCountMin}
+          max={setup.maxContainers > 0 ? setup.maxContainers : undefined}
+          value={setup.containerCount}
+          onChange={setup.handleContainerCountChange}
+          disabled={disabled || !setup.selectedContainer || setup.maxContainers <= 0}
+          aria-describedby={
+            setup.maxContainers > 0
+              ? containerCountHelperId
+              : setup.selectedContainer
+                ? containerCountWarningId
+                : undefined
+          }
+          className="w-full rounded-lg border border-border/60 bg-surface-muted/50 px-3 py-2 text-sm text-text focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        />
+        {setup.maxContainers > 0 ? (
+          <span id={containerCountHelperId} className="text-xs text-text-muted">
+            {positiveCapacityMessage}
+          </span>
+        ) : (
+          <span id={containerCountWarningId} className="text-xs text-warning">
+            {zeroCapacityMessage}
+          </span>
+        )}
+      </div>
+      <div className="space-y-2 rounded-lg border border-border/60 bg-surface-muted/40 p-3 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-text-muted">Method setup</span>
+          <span className="font-medium text-text">
+            €{formatNumber(setup.methodSetupCost, { maximumFractionDigits: 0 })}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-text-muted">Containers ({setup.containerCount})</span>
+          <span className="font-medium text-text">
+            €{formatNumber(setup.containerTotalCost, { maximumFractionDigits: 0 })}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-text-muted">
+            Substrate
+            {setup.substrateVolumeLiters && setup.substrateVolumeLiters > 0
+              ? ` (${formatNumber(setup.substrateVolumeLiters, { maximumFractionDigits: 1 })} L)`
+              : ''}
+          </span>
+          <span className="font-medium text-text">
+            €{formatNumber(setup.substrateTotalCost, { maximumFractionDigits: 0 })}
+          </span>
+        </div>
+        <div className="flex items-center justify-between border-t border-border/60 pt-2 text-base font-semibold">
+          <span>Total estimate</span>
+          <span>€{formatNumber(setup.totalCost, { maximumFractionDigits: 0 })}</span>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- extract a reusable CultivationSetupSection hook and component that encapsulate cultivation catalog selection logic and cost breakdown
- update CreateZoneModal to delegate method/container/substrate controls to the shared section and simplify submission logic
- migrate ChangeZoneMethodModal to use the shared section for consistent UI while preserving storage handoff and warnings

## Testing
- pnpm --filter "@weebbreed/frontend" test -- src/components/modals/__tests__/ChangeZoneMethodModal.test.tsx *(fails: missing @testing-library/user-event in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daebca1d048325ba2c66c8b76bca27