### PR TITLE
docs: document refactoring roadmap and governance thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented the refactoring roadmap covering world service, state model, and modal host decompositions under `docs/tasks/20250929-refactoring-roadmap.md`.
+- Captured refactoring governance thresholds and reuse triggers in ADR 0012.
 - Documented the cultivation setup UI consolidation in ADR 0011, covering the shared
   hook/component contract for zone modals.【F:docs/system/adr/0011-cultivation-setup-sharing.md†L1-L50】
 - Dokumentiert den Umsetzungsplan für die Irrigation-&-Nutrient-Überarbeitung unter

--- a/docs/system/adr/0012-refactoring-governance.md
+++ b/docs/system/adr/0012-refactoring-governance.md
@@ -1,0 +1,28 @@
+# ADR 0012 — Refactoring Governance & Modularisation Thresholds
+
+- **Status:** Accepted (2025-09-29)
+- **Owner:** Simulation Platform
+- **Context:** Multiple core modules (backend world service, shared models, frontend modal host) have exceeded 1,000 lines and now blend unrelated responsibilities. The lack of explicit thresholds let these god modules grow unchecked, making defects harder to isolate, discouraging reuse, and delaying architectural cleanups that would otherwise have been incremental.
+
+## Decision
+
+- Establish quantitative guardrails for module size and responsibility to trigger a refactoring review:
+  - Backend/Frontend source files above **600 lines** or containing **three or more distinct responsibilities** (e.g., state orchestration, schema parsing, UI rendering) must be queued for decomposition.
+  - Shared utility modules that introduce **runtime-only dependencies** into pure type/contract layers must be split so type definitions remain dependency-light.
+- Require feature and platform teams to document approved refactoring plans in `/docs/tasks/*-refactoring-*.md`, capturing problem statement, goals, and sequencing before code changes land.
+- Encourage reuse by default: modal, service, or hook implementations that are consumed in **two or more contexts** must be extracted into dedicated modules (e.g., `components/modals/<feature>/` or `engine/world/<domain>/`).
+- Embed refactoring checkpoints into quarterly planning: review modules breaching thresholds, prioritise remediation, and update this ADR if thresholds need adjustment.
+
+## Consequences
+
+- Teams have a clear, documented trigger for when to invest in structural cleanups, reducing ambiguity around "too big" modules.
+- Documentation of refactorings becomes a prerequisite, improving knowledge transfer and aligning cross-team expectations.
+- Component and service reuse increases because extraction is mandated once a second consumer exists, lowering duplication and divergence.
+- Planning cadences explicitly account for refactoring debt, making it harder for oversized modules to persist unnoticed.
+
+## References
+
+- `docs/tasks/20250929-refactoring-roadmap.md`
+- `src/backend/src/engine/world/worldService.ts`
+- `src/backend/src/state/models.ts`
+- `src/frontend/src/components/ModalHost.tsx`

--- a/docs/tasks/20250929-refactoring-roadmap.md
+++ b/docs/tasks/20250929-refactoring-roadmap.md
@@ -1,0 +1,52 @@
+# Refactoring Roadmap — Backend & Frontend Monolith Decomposition
+
+## Context
+
+Several critical modules have grown well beyond the size and responsibility boundaries outlined in our architecture guardrails. The affected areas are the backend world orchestration, the shared state models, and the frontend modal framework. Each has become a "god module" that hampers onboarding, testing, and reuse of their underlying concepts.
+
+## Targeted Refactorings
+
+### 1. World service modularisation (backend)
+
+- **Problem:** `worldService.ts` couples structure rental, room/zone lifecycle, finance hooks, and blueprint defaulting inside a 1,494-line class. Touching any workflow forces full-context understanding and broad test impact.
+- **Goal:** Introduce focused collaborators (structure, room, zone services plus shared defaults utilities) that isolate responsibilities while keeping the `WorldService` façade intact.
+- **Key Steps:**
+  1. Extract defaulting/helpers into `worldDefaults.ts` with deterministic cloning utilities.
+  2. Add `structureService.ts`, `roomService.ts`, and `zoneService.ts` under `src/backend/src/engine/world/`, each accepting explicit dependencies and returning typed results.
+  3. Refactor existing command handlers to depend on the new services and update unit tests for the delegated behaviour.
+
+### 2. Game state model modularisation (backend)
+
+- **Problem:** `models.ts` (1,069 lines) mixes TypeScript interfaces, schema parsing, blueprint defaults, and file I/O. Any schema change forces unrelated rebuilds and complicates reuse of pure types.
+- **Goal:** Separate type declarations from runtime loaders so each consumer imports only what it requires.
+- **Key Steps:**
+  1. Move pure interfaces into `src/backend/src/state/types.ts` (and sub-folders as needed).
+  2. Relocate blueprint defaults and loaders into dedicated modules (e.g., `state/personnel/skillBlueprints.ts`).
+  3. Update imports across the backend and adjust tests to reference the new modules.
+
+### 3. Modal host decomposition (frontend)
+
+- **Problem:** `ModalHost.tsx` (3,386 lines) combines modal registry logic, modal implementations, and shared helpers in a single file, blocking reuse and incremental rendering optimisations.
+- **Goal:** Establish a modular modal registry with per-modal components to promote reuse and independent testing.
+- **Key Steps:**
+  1. Create `src/frontend/src/components/modals/registry/` with one component per modal.
+  2. Introduce a `modalRegistry.ts` mapping descriptors to the extracted components.
+  3. Slim `ModalHost` down to a lookup/render shell and refresh the associated tests to target individual modals plus the registry contract.
+
+## Sequencing & Dependencies
+
+1. Start with backend world service extraction to unlock cleaner command handlers.
+2. Follow with model modularisation so subsequent refactors (including the modal work) can lean on slimmer type imports.
+3. Close with the frontend modal split, leveraging backend clarity for telemetry-driven modals.
+
+## Risks & Mitigations
+
+- **Regression surface:** Introduce comprehensive unit coverage for each new module and smoke-test command flows end-to-end.
+- **Dependency churn:** Document new imports in `/docs/system/` references and adjust path alias guidance.
+- **Knowledge transfer:** Pair the refactors with developer walkthroughs and update onboarding checklists.
+
+## Acceptance Criteria
+
+- Services expose typed, dependency-injected collaborators with deterministic behaviour.
+- Modules do not exceed 500 lines; new files carry module-scoped tests.
+- Documentation and changelog entries reflect the extracted architecture.


### PR DESCRIPTION
## Summary
- add a refactoring roadmap outlining decomposition steps for oversized backend and frontend modules
- capture governance thresholds for triggering refactors and enforcing reuse in ADR 0012
- record the new documentation in the changelog

## Testing
- pnpm run check *(fails: frontend lint already failing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68daae362ab88325b67de2512c4f4fc1