### PR TITLE
Add zone control schemas to persistence

### DIFF
--- a/src/backend/src/persistence/schemas.ts
+++ b/src/backend/src/persistence/schemas.ts
@@ -42,6 +42,18 @@ const zoneMetricSchema = z.object({
   lastUpdatedTick: z.number().int().nonnegative(),
 });
 
+const zoneControlSetpointsSchema = z.object({
+  temperature: z.number().optional(),
+  humidity: z.number().optional(),
+  co2: z.number().optional(),
+  ppfd: z.number().optional(),
+  vpd: z.number().optional(),
+});
+
+const zoneControlStateSchema = z.object({
+  setpoints: zoneControlSetpointsSchema,
+});
+
 const diseaseTreatmentEffectSchema = z.object({
   optionId: nonEmptyString,
   expiresTick: z.number().int().nonnegative(),
@@ -187,6 +199,7 @@ const zoneStateSchema = z.object({
   plants: z.array(plantStateSchema),
   devices: z.array(deviceInstanceSchema),
   metrics: zoneMetricSchema,
+  control: zoneControlStateSchema.optional(),
   health: zoneHealthSchema,
   activeTaskIds: z.array(nonEmptyString),
 });


### PR DESCRIPTION
## Summary
- add zone control setpoint/state schemas alongside existing zone definitions
- allow legacy save payloads by accepting missing control data when validating zone state

## Testing
- pnpm --filter @weebbreed/backend typecheck *(fails: existing type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc7e9135c83258c203066d6239152