### PR TITLE
Allow additional utility price metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   personnel blueprint loaders into dedicated `state/personnel/*` modules, and updated
   backend imports/tests to rely on the smaller entry points instead of the monolithic
   `state/models` export.
+- Extended the `UtilityPrices` state type with an index signature so passthrough schema
+  metadata can round-trip without breaking strongly-typed access to known price fields.
 - Replaced the monolithic world service with dedicated structure/room/zone collaborators,
   extracted cloning helpers, and completed the `ZoneService.updateZone` migration so
   cultivation defaults, validations, and telemetry align with the refactored delegates.

--- a/src/backend/src/state/types.ts
+++ b/src/backend/src/state/types.ts
@@ -415,6 +415,7 @@ export interface LoanState {
 }
 
 export interface UtilityPrices {
+  [key: string]: unknown;
   version?: string;
   pricePerKwh: number;
   pricePerLiterWater: number;


### PR DESCRIPTION
## Summary
- allow extra passthrough keys on the backend UtilityPrices state type via an index signature
- document the UtilityPrices type update in the changelog

## Testing
- `pnpm --filter @weebbreed/backend typecheck` *(fails: existing backend type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc90995e083259a4dec8852391722