### PR TITLE
Align workforce refresh typing with job market summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   personnel blueprint loaders into dedicated `state/personnel/*` modules, and updated
   backend imports/tests to rely on the smaller entry points instead of the monolithic
   `state/models` export.
+- Typed the workforce candidate refresh command to surface the job-market summary through
+  the facade and server layers, aligning downstream consumers on the structured result.
 - Extended the `UtilityPrices` state type with an index signature so passthrough schema
   metadata can round-trip without breaking strongly-typed access to known price fields.
 - Replaced the monolithic world service with dedicated structure/room/zone collaborators,

--- a/src/backend/src/facade/commands/workforce.ts
+++ b/src/backend/src/facade/commands/workforce.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { JobMarketRefreshSummary } from '@/engine/workforce/jobMarketService.js';
 import {
   emptyObjectSchema,
   nonEmptyString,
@@ -65,7 +66,7 @@ export type AssignStructureIntent = z.infer<typeof assignStructureSchema>;
 export type EnqueueTaskIntent = z.infer<typeof enqueueTaskSchema>;
 
 export interface WorkforceIntentHandlers {
-  refreshCandidates: ServiceCommandHandler<RefreshCandidatesIntent>;
+  refreshCandidates: ServiceCommandHandler<RefreshCandidatesIntent, JobMarketRefreshSummary>;
   hire: ServiceCommandHandler<HireIntent>;
   fire: ServiceCommandHandler<FireIntent>;
   setOvertimePolicy: ServiceCommandHandler<SetOvertimePolicyIntent>;
@@ -74,7 +75,7 @@ export interface WorkforceIntentHandlers {
 }
 
 export interface WorkforceCommandRegistry {
-  refreshCandidates: CommandRegistration<RefreshCandidatesIntent>;
+  refreshCandidates: CommandRegistration<RefreshCandidatesIntent, JobMarketRefreshSummary>;
   hire: CommandRegistration<HireIntent>;
   fire: CommandRegistration<FireIntent>;
   setOvertimePolicy: CommandRegistration<SetOvertimePolicyIntent>;
@@ -91,7 +92,7 @@ export const buildWorkforceCommands = ({
   services,
   onMissingHandler,
 }: WorkforceCommandOptions): WorkforceCommandRegistry => ({
-  refreshCandidates: createServiceCommand(
+  refreshCandidates: createServiceCommand<RefreshCandidatesIntent, JobMarketRefreshSummary>(
     'workforce.refreshCandidates',
     refreshCandidatesSchema,
     () => services().refreshCandidates,

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -1,6 +1,7 @@
 import { eventBus as telemetryEventBus } from '@runtime/eventBus.js';
 import { DEFAULT_TICK_INTERVAL_MS, MINUTES_PER_HOUR } from '@/constants/time.js';
 import { EventBus, type EventFilter } from '@/lib/eventBus.js';
+import type { JobMarketRefreshSummary } from '@/engine/workforce/jobMarketService.js';
 import {
   computeHumidityForVpd,
   ensureZoneControl,
@@ -225,6 +226,7 @@ export type {
   EnqueueTaskIntent,
   WorkforceIntentHandlers,
 } from './commands/workforce.js';
+export type { JobMarketRefreshSummary } from '@/engine/workforce/jobMarketService.js';
 export type {
   SellInventoryIntent,
   SetUtilityPricesIntent,
@@ -350,7 +352,9 @@ export interface HealthIntentAPI {
 }
 
 export interface WorkforceIntentAPI {
-  refreshCandidates(intent?: RefreshCandidatesIntent): Promise<CommandResult>;
+  refreshCandidates(
+    intent?: RefreshCandidatesIntent,
+  ): Promise<CommandResult<JobMarketRefreshSummary>>;
   hire(intent: HireIntent): Promise<CommandResult>;
   fire(intent: FireIntent): Promise<CommandResult>;
   setOvertimePolicy(intent: SetOvertimePolicyIntent): Promise<CommandResult>;

--- a/src/backend/src/server/startServer.ts
+++ b/src/backend/src/server/startServer.ts
@@ -18,6 +18,7 @@ import {
   type SetUtilityPricesIntent,
   type CommandResult,
   type CommandExecutionContext,
+  type JobMarketRefreshSummary,
 } from '@/facade/index.js';
 import {
   buildDeviceBlueprintCatalog,
@@ -432,7 +433,10 @@ export const startBackendServer = async (
         plantingPlanService.togglePlantingPlan(intent.zoneId, intent.enabled, context),
     },
     workforce: {
-      refreshCandidates: (intent, serviceContext) =>
+      refreshCandidates: (
+        intent,
+        serviceContext,
+      ): Promise<CommandResult<JobMarketRefreshSummary>> =>
         jobMarketService.refreshCandidates(intent, serviceContext),
     },
     finance: {


### PR DESCRIPTION
## Summary
- type the workforce refresh command to surface the job-market summary result
- re-export the summary through the facade and annotate the server handler for improved typing
- document the typing update in the changelog

## Testing
- pnpm run check *(fails: frontend lint missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcdf8b2ac83259f07a0f0d5076696