### PR TITLE
Fix facade imports for time and world command registries

### DIFF
--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -59,6 +59,7 @@ import {
 } from './commands/plants.js';
 import {
   buildTimeCommands,
+  type TimeCommandRegistry,
   type TimeStatus,
   type TimeStartIntent,
   type TimeStepIntent,
@@ -81,6 +82,9 @@ import {
   type GetStructureBlueprintsIntent,
   type GetStrainBlueprintsIntent,
   type GetDeviceBlueprintsIntent,
+  type GetCultivationMethodBlueprintsIntent,
+  type GetContainerBlueprintsIntent,
+  type GetSubstrateBlueprintsIntent,
   type CreateRoomIntent,
   type UpdateRoomIntent,
   type DeleteRoomIntent,


### PR DESCRIPTION
## Summary
- import the time command registry type in the facade to match existing usage
- add cultivation method, container, and substrate blueprint intent types to the world command facade imports

## Testing
- pnpm run check *(fails: frontend lint currently errors during module resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd5c5806c832591e7c20029253663