### PR TITLE
Ensure scheduler tick executor awaits simulation loop

### DIFF
--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -993,7 +993,9 @@ export class SimulationFacade {
       frameCanceler: this.schedulerConfig.frameCanceler,
       onError: (error) => this.emitSchedulerError(error),
     };
-    return new SimulationScheduler(() => this.loop.processTick(), options);
+    return new SimulationScheduler(async () => {
+      await this.loop.processTick();
+    }, options);
   }
 
   private emitSchedulerError(error: unknown): void {


### PR DESCRIPTION
## Summary
- update the simulation facade scheduler to use an async executor that only awaits the loop tick

## Testing
- pnpm run check *(fails: frontend lint exits with module resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd6c42ee08325bc654c251fe72c5c