### PR TITLE
Add index signatures to command registries

### DIFF
--- a/src/backend/src/facade/commands/config.ts
+++ b/src/backend/src/facade/commands/config.ts
@@ -4,6 +4,7 @@ import { emptyObjectSchema } from './commonSchemas.js';
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -18,6 +19,7 @@ export interface ConfigIntentHandlers {
 
 export interface ConfigCommandRegistry {
   getDifficultyConfig: CommandRegistration<GetDifficultyConfigIntent, DifficultyConfig>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface ConfigCommandOptions {

--- a/src/backend/src/facade/commands/devices.ts
+++ b/src/backend/src/facade/commands/devices.ts
@@ -5,6 +5,7 @@ import { entityIdentifier, settingsRecord, uuid } from './commonSchemas.js';
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -84,6 +85,7 @@ export interface DeviceCommandRegistry {
   removeDevice: CommandRegistration<RemoveDeviceIntent>;
   toggleDeviceGroup: CommandRegistration<ToggleDeviceGroupIntent, DeviceGroupToggleResult>;
   adjustLightingCycle: CommandRegistration<AdjustLightingCycleIntent, AdjustLightingCycleResult>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface DeviceCommandOptions {

--- a/src/backend/src/facade/commands/finance.ts
+++ b/src/backend/src/facade/commands/finance.ts
@@ -3,6 +3,7 @@ import { nonNegativeNumber, positiveNumber, uuid } from './commonSchemas.js';
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -53,6 +54,7 @@ export interface FinanceCommandRegistry {
   sellInventory: CommandRegistration<SellInventoryIntent>;
   setUtilityPrices: CommandRegistration<SetUtilityPricesIntent>;
   setMaintenancePolicy: CommandRegistration<SetMaintenancePolicyIntent>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface FinanceCommandOptions {

--- a/src/backend/src/facade/commands/health.ts
+++ b/src/backend/src/facade/commands/health.ts
@@ -3,6 +3,7 @@ import { uuid } from './commonSchemas.js';
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -41,6 +42,7 @@ export interface HealthCommandRegistry {
   scheduleScouting: CommandRegistration<ScheduleScoutingIntent>;
   applyTreatment: CommandRegistration<ApplyTreatmentIntent>;
   quarantineZone: CommandRegistration<QuarantineZoneIntent>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface HealthCommandOptions {

--- a/src/backend/src/facade/commands/plants.ts
+++ b/src/backend/src/facade/commands/plants.ts
@@ -8,6 +8,7 @@ import { entityIdentifier, nonNegativeNumber, positiveInteger, uuid } from './co
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -102,6 +103,7 @@ export interface PlantCommandRegistry {
   applyIrrigation: CommandRegistration<ApplyIrrigationIntent>;
   applyFertilizer: CommandRegistration<ApplyFertilizerIntent>;
   togglePlantingPlan: CommandRegistration<TogglePlantingPlanIntent, PlantingPlanToggleResult>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface PlantCommandOptions {

--- a/src/backend/src/facade/commands/time.ts
+++ b/src/backend/src/facade/commands/time.ts
@@ -4,6 +4,7 @@ import type {
   CommandExecutionContext,
   CommandRegistration,
   CommandResult,
+  GenericCommandRegistration,
 } from './commandRegistry.js';
 
 export interface TimeStatus {
@@ -57,6 +58,7 @@ export interface TimeCommandRegistry {
   resume: CommandRegistration<z.infer<typeof emptyObjectSchema>, TimeStatus>;
   step: CommandRegistration<TimeStepIntent, TimeStatus>;
   setSpeed: CommandRegistration<SetSpeedIntent, TimeStatus>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export const buildTimeCommands = (handlers: TimeCommandHandlers): TimeCommandRegistry => ({

--- a/src/backend/src/facade/commands/workforce.ts
+++ b/src/backend/src/facade/commands/workforce.ts
@@ -11,6 +11,7 @@ import {
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -81,6 +82,7 @@ export interface WorkforceCommandRegistry {
   setOvertimePolicy: CommandRegistration<SetOvertimePolicyIntent>;
   assignStructure: CommandRegistration<AssignStructureIntent>;
   enqueueTask: CommandRegistration<EnqueueTaskIntent>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface WorkforceCommandOptions {

--- a/src/backend/src/facade/commands/world.ts
+++ b/src/backend/src/facade/commands/world.ts
@@ -25,6 +25,7 @@ import {
 import {
   createServiceCommand,
   type CommandRegistration,
+  type GenericCommandRegistration,
   type MissingCommandHandler,
   type ServiceCommandHandler,
 } from './commandRegistry.js';
@@ -310,6 +311,7 @@ export interface WorldCommandRegistry {
   duplicateStructure: CommandRegistration<DuplicateStructureIntent, DuplicateStructureResult>;
   duplicateRoom: CommandRegistration<DuplicateRoomIntent, DuplicateRoomResult>;
   duplicateZone: CommandRegistration<DuplicateZoneIntent, DuplicateZoneResult>;
+  [key: string]: GenericCommandRegistration;
 }
 
 export interface WorldCommandOptions {


### PR DESCRIPTION
## Summary
- add `GenericCommandRegistration` index signatures to each command registry so they satisfy `DomainCommandRegistryMap`
- import the alias alongside existing command registration types where required

## Testing
- pnpm --reporter=append-only typecheck *(fails: existing TypeScript errors in backend project)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd78bdfbc8325a50b6b1589062a78