### PR TITLE
Ensure time pause/resume handlers accept payload

### DIFF
--- a/src/backend/src/facade/commands/time.ts
+++ b/src/backend/src/facade/commands/time.ts
@@ -72,13 +72,13 @@ export const buildTimeCommands = (handlers: TimeCommandHandlers): TimeCommandReg
     name: 'time.pause',
     schema: emptyObjectSchema,
     preprocess: () => ({}),
-    handler: handlers.handlePause,
+    handler: (_payload, context) => handlers.handlePause(context),
   },
   resume: {
     name: 'time.resume',
     schema: emptyObjectSchema,
     preprocess: () => ({}),
-    handler: handlers.handleResume,
+    handler: (_payload, context) => handlers.handleResume(context),
   },
   step: {
     name: 'time.step',


### PR DESCRIPTION
## Summary
- update the time facade command registrations for pause and resume so the handler wrappers accept the payload argument before delegating to the underlying handlers

## Testing
- pnpm run check *(fails: frontend lint cannot resolve @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd8b45d5083259c7a46cb5ce38726