### PR TITLE
Normalize pending treatment categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   personnel blueprint loaders into dedicated `state/personnel/*` modules, and updated
   backend imports/tests to rely on the smaller entry points instead of the monolithic
   `state/models` export.
+- Extended pending treatment applications with treatment categories, updating save
+  schemas, engine normalization, and tests so workforce safety policies can infer
+  hazard levels immediately after load.
 - Typed the workforce candidate refresh command to surface the job-market summary through
   the facade and server layers, aligning downstream consumers on the structured result.
 - Extended the `UtilityPrices` state type with an index signature so passthrough schema

--- a/src/backend/src/engine/health/healthEngine.test.ts
+++ b/src/backend/src/engine/health/healthEngine.test.ts
@@ -394,12 +394,14 @@ describe('PlantHealthEngine', () => {
       target: 'disease',
       plantIds: [plant.id],
       scheduledTick: 2,
+      category: 'biological',
     });
     zone.health.pendingTreatments.push({
       optionId: 'bio-boost',
       target: 'pest',
       plantIds: [plant.id],
       scheduledTick: 2,
+      category: 'biological',
     });
 
     const tick2Events: SimulationEvent[] = [];

--- a/src/backend/src/engine/health/healthEngine.ts
+++ b/src/backend/src/engine/health/healthEngine.ts
@@ -324,6 +324,7 @@ export class PlantHealthEngine {
             if (!option) {
               continue;
             }
+            pending.category ??= option.category;
             if (!option.targets.includes(pending.target)) {
               continue;
             }

--- a/src/backend/src/lib/uiSnapshot.test.ts
+++ b/src/backend/src/lib/uiSnapshot.test.ts
@@ -412,6 +412,7 @@ describe('buildSimulationSnapshot plants', () => {
         target: 'disease',
         plantIds: ['plant-1'],
         scheduledTick: 42,
+        category: 'cultural',
         diseaseIds: ['powdery-mildew'],
       },
     ] as unknown as typeof zone.health.pendingTreatments;

--- a/src/backend/src/persistence/schemas.ts
+++ b/src/backend/src/persistence/schemas.ts
@@ -114,6 +114,7 @@ const pendingTreatmentSchema = z.object({
   target: z.enum(['disease', 'pest']),
   plantIds: z.array(nonEmptyString),
   scheduledTick: z.number().int().nonnegative(),
+  category: z.enum(['cultural', 'biological', 'mechanical', 'chemical', 'physical']).optional(),
   diseaseIds: z.array(nonEmptyString).optional(),
   pestIds: z.array(nonEmptyString).optional(),
   reentryIntervalTicks: z.number().int().nonnegative().optional(),

--- a/src/backend/src/state/types.ts
+++ b/src/backend/src/state/types.ts
@@ -210,6 +210,7 @@ export interface PendingTreatmentApplication {
   target: HealthTarget;
   plantIds: string[];
   scheduledTick: number;
+  category?: TreatmentCategory;
   diseaseIds?: string[];
   pestIds?: string[];
   reentryIntervalTicks?: number;


### PR DESCRIPTION
## Summary
- add an optional treatment category to pending treatment applications and persistence validation
- normalize pending treatments to inherit their blueprint category during application and update related tests and docs

## Testing
- pnpm run check *(fails: frontend lint command exits with status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdb9b83088325b291b5dd2d27bb0f