### PR TITLE
chore: expand frontend alias coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expanded the frontend Vite and TypeScript path aliases to cover scoped
+  `@/components`, `@/store`, `@/hooks`, `@/styles`, `@/data`, `@/facade`,
+  `@/config`, `@/types`, and `@/utils` imports so build tooling resolves the
+  shared modules consistently.
 - Extracted lightweight state type exports into `src/backend/src/state/types.ts`, split
   personnel blueprint loaders into dedicated `state/personnel/*` modules, and updated
   backend imports/tests to rely on the smaller entry points instead of the monolithic

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -15,6 +15,8 @@
       "@/data/*": ["data/*"],
       "@/facade/*": ["facade/*"],
       "@/config/*": ["config/*"],
+      "@/types/*": ["types/*"],
+      "@/utils/*": ["utils/*"],
       "clsx": ["utils/clsx"]
     }
   },

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -11,6 +11,15 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),
+        '@/components': path.resolve(__dirname, 'src/components'),
+        '@/store': path.resolve(__dirname, 'src/store'),
+        '@/hooks': path.resolve(__dirname, 'src/hooks'),
+        '@/styles': path.resolve(__dirname, 'src/styles'),
+        '@/data': path.resolve(__dirname, 'src/data'),
+        '@/facade': path.resolve(__dirname, 'src/facade'),
+        '@/config': path.resolve(__dirname, 'src/config'),
+        '@/types': path.resolve(__dirname, 'src/types'),
+        '@/utils': path.resolve(__dirname, 'src/utils'),
         clsx: path.resolve(__dirname, 'src/utils/clsx.ts'),
       },
     },


### PR DESCRIPTION
## Summary
- expand the Vite resolve aliases to map each scoped @/... folder to its source directory while keeping existing entries intact
- mirror the expanded alias coverage in the frontend tsconfig paths for types and utilities
- document the alias updates in the changelog for visibility

## Testing
- pnpm --filter @weebbreed/frontend build *(fails: tailwindcss package not available in environment)*
- pnpm run check *(fails: @eslint/js package missing for frontend lint script)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdf05e3e48325b344727e2b51e4ea