### PR TITLE
Handle degraded blueprint loads gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened the backend bootstrap pipeline to surface data-load summaries,
+  propagate structured state-factory degradation events, and keep the server
+  responsive when blueprints are missing, alongside a resilience integration
+  test covering incomplete data directories.
 - Wrapped the simulation loop phases in per-phase state drafts, cloning structures and
   accounting buffers so recoverable errors restore both state and telemetry buffers before
   emitting any events.

--- a/src/backend/src/bench.ts
+++ b/src/backend/src/bench.ts
@@ -237,7 +237,7 @@ export const runBenchmark = async (ticks = Number(process.env.WEEBBREED_BENCH_TI
       structureBlueprints && structureBlueprints.length > 0 ? structureBlueprints : undefined,
   });
 
-  const state = await createInitialState(context);
+  const { state } = await createInitialState(context);
 
   const phenologies = new Map<string, PhenologyState>();
   const metrics = new Map<number, { biomassDelta: number; avgVpd: number; avgHealth: number }>();

--- a/src/backend/src/data/blueprintRepository.ts
+++ b/src/backend/src/data/blueprintRepository.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 import { watchData } from '@runtime/dataWatcher.js';
 import { DataLoaderError, loadBlueprintData } from './dataLoader.js';
-import type { BlueprintData, DataLoadResult, DataLoadSummary } from './dataLoader.js';
+import type {
+  BlueprintData,
+  DataLoadResult,
+  DataLoadSummary,
+  LoadBlueprintDataOptions,
+} from './dataLoader.js';
 import type {
   DevicePriceEntry,
   StrainPriceEntry,
@@ -40,9 +45,12 @@ export class BlueprintRepository {
     this.rebuildSlugIndexes();
   }
 
-  static async loadFrom(dataDirectory: string): Promise<BlueprintRepository> {
+  static async loadFrom(
+    dataDirectory: string,
+    options: LoadBlueprintDataOptions = {},
+  ): Promise<BlueprintRepository> {
     const absoluteDir = path.resolve(dataDirectory);
-    const result = await loadBlueprintData(absoluteDir);
+    const result = await loadBlueprintData(absoluteDir, options);
     return new BlueprintRepository(absoluteDir, result);
   }
 

--- a/src/backend/src/difficulty.integration.test.ts
+++ b/src/backend/src/difficulty.integration.test.ts
@@ -62,7 +62,7 @@ describe('Difficulty presets sync with JSON config', () => {
       difficultyConfig: TEST_CONFIG,
     });
 
-    const state = await createInitialState(context, { difficulty: 'easy' });
+    const { state } = await createInitialState(context, { difficulty: 'easy' });
 
     expect(state.metadata.difficulty).toBe('easy');
     expect(state.metadata.economics).toEqual(TEST_CONFIG.easy.modifiers.economics);
@@ -78,7 +78,7 @@ describe('Difficulty presets sync with JSON config', () => {
     const context = createStateFactoryContext('diff-world', {
       difficultyConfig: TEST_CONFIG,
     });
-    const initialState = await createInitialState(context, { difficulty: 'normal' });
+    const { state: initialState } = await createInitialState(context, { difficulty: 'normal' });
 
     const repository = context.repository;
     const rng = new RngService('world-service');
@@ -119,7 +119,7 @@ describe('Difficulty presets sync with JSON config', () => {
     const context = createStateFactoryContext('diff-world-override', {
       difficultyConfig: TEST_CONFIG,
     });
-    const initialState = await createInitialState(context, { difficulty: 'normal' });
+    const { state: initialState } = await createInitialState(context, { difficulty: 'normal' });
 
     const repository = context.repository;
     const rng = new RngService('world-service');

--- a/src/backend/src/index.test.ts
+++ b/src/backend/src/index.test.ts
@@ -49,7 +49,7 @@ describe('resolveDataDirectory', () => {
 
     mockLoadFrom.mockClear();
     await bootstrap({ envOverride: undefined });
-    expect(mockLoadFrom).toHaveBeenCalledWith(expected);
+    expect(mockLoadFrom).toHaveBeenCalledWith(expected, { allowErrors: undefined });
   });
 
   it('prefers a packaged data directory colocated with the dist build', async () => {
@@ -88,7 +88,7 @@ describe('resolveDataDirectory', () => {
 
       mockLoadFrom.mockClear();
       await bootstrap(options);
-      expect(mockLoadFrom).toHaveBeenCalledWith(packagedDataDirectory);
+      expect(mockLoadFrom).toHaveBeenCalledWith(packagedDataDirectory, { allowErrors: undefined });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -7,8 +7,8 @@ import {
   bootstrap,
   formatError,
   logDataLoaderIssues,
+  type BootstrapOptions,
   type BootstrapResult,
-  type ResolveDataDirectoryOptions,
 } from './bootstrap.js';
 import { logger } from '@runtime/logger.js';
 
@@ -160,7 +160,7 @@ const registerFatalProcessHandlers = () => {
   });
 };
 
-export const main = async (options?: ResolveDataDirectoryOptions): Promise<BootstrapResult> => {
+export const main = async (options?: BootstrapOptions): Promise<BootstrapResult> => {
   const result = await bootstrap(options);
   startupLogger.info(
     {

--- a/src/backend/src/persistence/hotReload.integration.test.ts
+++ b/src/backend/src/persistence/hotReload.integration.test.ts
@@ -32,7 +32,11 @@ describe('Blueprint hot reload integration', () => {
   it('applies room purpose changes on the next committed tick', async () => {
     const repository = await BlueprintRepository.loadFrom(tempDataDirectory);
     const rng = new RngService('hot-reload-integration');
-    const state = await createInitialState({ repository, rng, dataDirectory: tempDataDirectory });
+    const { state } = await createInitialState({
+      repository,
+      rng,
+      dataDirectory: tempDataDirectory,
+    });
     const bus = new EventBus();
     const manager = new BlueprintHotReloadManager(repository, bus, () => state.clock.tick);
     await manager.start();
@@ -111,7 +115,11 @@ describe('Blueprint hot reload integration', () => {
   it('commits staged data on the first tick even when staging is slow', async () => {
     const repository = await BlueprintRepository.loadFrom(tempDataDirectory);
     const rng = new RngService('hot-reload-slow-reload');
-    const state = await createInitialState({ repository, rng, dataDirectory: tempDataDirectory });
+    const { state } = await createInitialState({
+      repository,
+      rng,
+      dataDirectory: tempDataDirectory,
+    });
     const bus = new EventBus();
     const manager = new BlueprintHotReloadManager(repository, bus, () => state.clock.tick);
     await manager.start();

--- a/src/backend/src/persistence/schemas.test.ts
+++ b/src/backend/src/persistence/schemas.test.ts
@@ -6,7 +6,7 @@ import { createStateFactoryContext } from '@/testing/fixtures.js';
 describe('saveGameEnvelopeSchema', () => {
   it('accepts a well-formed save game envelope', async () => {
     const context = createStateFactoryContext('schema-seed');
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
 
     const createdAt = '2025-01-01T00:00:00.000Z';
     const envelope = {
@@ -29,7 +29,7 @@ describe('saveGameEnvelopeSchema', () => {
 
   it('rejects envelopes with invalid metadata', async () => {
     const context = createStateFactoryContext('schema-seed');
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
     const base = {
       header: { kind: SAVEGAME_KIND, version: '1.0.0', createdAt: '2025-01-01T00:00:00.000Z' },
       metadata: {
@@ -50,7 +50,7 @@ describe('saveGameEnvelopeSchema', () => {
 
   it('rejects save games that contain unknown personnel skills', async () => {
     const context = createStateFactoryContext('schema-skill-unknown');
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
     const employee = state.personnel.employees[0];
     expect(employee).toBeDefined();
     if (employee) {

--- a/src/backend/src/server/startServer.degradation.test.ts
+++ b/src/backend/src/server/startServer.degradation.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startBackendServer } from '@/server/startServer.js';
+import { eventBus as telemetryEventBus } from '@runtime/eventBus.js';
+import type { SimulationEvent } from '@/lib/eventBus.js';
+
+const createEmptyJsonFile = async (target: string, payload: unknown) => {
+  await writeFile(target, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+};
+
+const createIncompleteDataDirectory = async (): Promise<string> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'weebbreed-incomplete-data-'));
+  const blueprintRoot = path.join(root, 'blueprints');
+  const subdirectories = [
+    ['blueprints'],
+    ['blueprints', 'strains'],
+    ['blueprints', 'devices'],
+    ['blueprints', 'cultivationMethods'],
+    ['blueprints', 'roomPurposes'],
+    ['blueprints', 'structures'],
+    ['blueprints', 'substrates'],
+    ['blueprints', 'containers'],
+    ['configs'],
+    ['prices'],
+    ['personnel'],
+    ['personnel', 'names'],
+  ];
+
+  for (const segments of subdirectories) {
+    await mkdir(path.join(root, ...segments), { recursive: true });
+  }
+
+  await createEmptyJsonFile(path.join(root, 'prices', 'devicePrices.json'), {
+    version: 'test',
+    devicePrices: {},
+  });
+  await createEmptyJsonFile(path.join(root, 'prices', 'strainPrices.json'), {
+    version: 'test',
+    strainPrices: {},
+  });
+  await createEmptyJsonFile(path.join(root, 'prices', 'cultivationMethodPrices.json'), {
+    version: 'test',
+    cultivationMethodPrices: {},
+  });
+  await createEmptyJsonFile(path.join(root, 'prices', 'consumablePrices.json'), {
+    version: 'test',
+    substrates: {},
+    containers: {},
+  });
+  await createEmptyJsonFile(path.join(root, 'prices', 'utilityPrices.json'), {
+    version: 'test',
+    pricePerKwh: 0,
+    pricePerLiterWater: 0,
+    pricePerGramNutrients: 0,
+  });
+
+  await createEmptyJsonFile(path.join(root, 'configs', 'difficulty.json'), {
+    easy: {
+      name: 'Easy',
+      description: 'Testing preset - easy',
+      modifiers: {
+        plantStress: {
+          optimalRangeMultiplier: 1,
+          stressAccumulationMultiplier: 1,
+        },
+        deviceFailure: {
+          mtbfMultiplier: 1,
+        },
+        economics: {
+          initialCapital: 0,
+          itemPriceMultiplier: 1,
+          harvestPriceMultiplier: 1,
+          rentPerSqmStructurePerTick: 0,
+          rentPerSqmRoomPerTick: 0,
+        },
+      },
+    },
+    normal: {
+      name: 'Normal',
+      description: 'Testing preset - normal',
+      modifiers: {
+        plantStress: {
+          optimalRangeMultiplier: 1,
+          stressAccumulationMultiplier: 1,
+        },
+        deviceFailure: {
+          mtbfMultiplier: 1,
+        },
+        economics: {
+          initialCapital: 0,
+          itemPriceMultiplier: 1,
+          harvestPriceMultiplier: 1,
+          rentPerSqmStructurePerTick: 0,
+          rentPerSqmRoomPerTick: 0,
+        },
+      },
+    },
+    hard: {
+      name: 'Hard',
+      description: 'Testing preset - hard',
+      modifiers: {
+        plantStress: {
+          optimalRangeMultiplier: 1,
+          stressAccumulationMultiplier: 1,
+        },
+        deviceFailure: {
+          mtbfMultiplier: 1,
+        },
+        economics: {
+          initialCapital: 0,
+          itemPriceMultiplier: 1,
+          harvestPriceMultiplier: 1,
+          rentPerSqmStructurePerTick: 0,
+          rentPerSqmRoomPerTick: 0,
+        },
+      },
+    },
+  });
+
+  // Provide a placeholder room purpose so the loader succeeds while the state
+  // factory still records degradation because the grow room purpose is absent.
+  await createEmptyJsonFile(path.join(blueprintRoot, 'roomPurposes', 'breakroom.json'), {
+    id: 'break-room',
+    name: 'Break Room',
+    kind: 'breakroom',
+  });
+
+  const personnelNamesDir = path.join(root, 'personnel', 'names');
+  await createEmptyJsonFile(path.join(personnelNamesDir, 'firstNamesMale.json'), ['Alex']);
+  await createEmptyJsonFile(path.join(personnelNamesDir, 'firstNamesFemale.json'), ['Jamie']);
+  await createEmptyJsonFile(path.join(personnelNamesDir, 'lastNames.json'), ['Taylor']);
+  await createEmptyJsonFile(path.join(root, 'personnel', 'traits.json'), []);
+  await createEmptyJsonFile(path.join(root, 'personnel', 'randomSeeds.json'), ['seed-1']);
+
+  return root;
+};
+
+describe('startBackendServer (degradation handling)', () => {
+  let dataDirectory: string;
+
+  beforeEach(async () => {
+    dataDirectory = await createIncompleteDataDirectory();
+  });
+
+  afterEach(async () => {
+    await rm(dataDirectory, { recursive: true, force: true });
+  });
+
+  it('keeps the server responsive and emits degradation telemetry when blueprints are missing', async () => {
+    const captured: SimulationEvent[] = [];
+    const subscription = telemetryEventBus
+      .events(
+        (event) => event.type.startsWith('bootstrap.') || event.type.startsWith('stateFactory.'),
+      )
+      .subscribe((event) => {
+        captured.push(event);
+      });
+
+    const handle = await startBackendServer({
+      dataDirectoryOverride: dataDirectory,
+      port: 7332,
+    });
+
+    try {
+      const pauseResult = await handle.facade.time.pause();
+      expect(pauseResult.ok).toBe(true);
+
+      const summaryEvent = captured.find((event) => event.type === 'bootstrap.dataSummary');
+      expect(summaryEvent).toBeDefined();
+      expect(summaryEvent?.payload).toMatchObject({ issueCount: expect.any(Number) });
+
+      const degradationTypes = captured
+        .filter((event) => event.type.startsWith('stateFactory.'))
+        .map((event) => event.type)
+        .sort();
+
+      expect(degradationTypes).toEqual(
+        expect.arrayContaining([
+          'stateFactory.structures.missingBlueprints',
+          'stateFactory.strains.missingBlueprints',
+          'stateFactory.methods.missingBlueprints',
+          'stateFactory.devices.missingBlueprints',
+          'stateFactory.roomPurpose.growRoomMissing',
+        ]),
+      );
+
+      expect(handle.summary.loadedFiles).toBeGreaterThanOrEqual(0);
+      expect(handle.facade).toBeDefined();
+    } finally {
+      subscription.unsubscribe();
+      await handle.shutdown();
+    }
+  });
+});

--- a/src/backend/src/sim/integrationScenarios.test.ts
+++ b/src/backend/src/sim/integrationScenarios.test.ts
@@ -159,7 +159,7 @@ describe('integration scenarios', () => {
         createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
       ],
     });
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
     const zone = state.structures[0].rooms[0].zones[0];
 
     zone.environment.ppfd = 0;
@@ -212,7 +212,7 @@ describe('integration scenarios', () => {
         createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
       ],
     });
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
     const zone = state.structures[0].rooms[0].zones[0];
 
     zone.environment.temperature = 26;
@@ -252,7 +252,7 @@ describe('integration scenarios', () => {
         createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
       ],
     });
-    const state = await createInitialState(context);
+    const { state } = await createInitialState(context);
     const zone = state.structures[0].rooms[0].zones[0];
 
     const initialHumidity = zone.environment.relativeHumidity;
@@ -310,7 +310,7 @@ describe('integration scenarios', () => {
         createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
       ],
     });
-    const stateSingle = await createInitialState(contextSingle);
+    const { state: stateSingle } = await createInitialState(contextSingle);
     const zoneSingle = stateSingle.structures[0].rooms[0].zones[0];
     zoneSingle.environment.ppfd = 0;
 
@@ -329,7 +329,7 @@ describe('integration scenarios', () => {
         createStructureBlueprint({ footprint: { length: 12, width: 6, height: 4 } }),
       ],
     });
-    const stateDouble = await createInitialState(contextDouble);
+    const { state: stateDouble } = await createInitialState(contextDouble);
     const zoneDouble = stateDouble.structures[0].rooms[0].zones[0];
     zoneDouble.environment.ppfd = 0;
     const lamp = zoneDouble.devices.find((device) => device.kind === 'Lamp');

--- a/src/backend/src/sim/loop.golden.test.ts
+++ b/src/backend/src/sim/loop.golden.test.ts
@@ -364,7 +364,7 @@ const runReferenceSimulation = async (): Promise<SimulationKpiSummary> => {
   const sampleStream = rng.getStream(RNG_STREAM_IDS.simulationTest);
   const context = createStateFactoryContext(seed, { repository, rng });
   const tickLengthMinutes = 60;
-  const state = await createInitialState(context, { tickLengthMinutes });
+  const { state } = await createInitialState(context, { tickLengthMinutes });
 
   const ticksPerDayRaw = (24 * 60) / state.metadata.tickLengthMinutes;
   if (!Number.isInteger(ticksPerDayRaw)) {


### PR DESCRIPTION
## Summary
- refactor the state factory to surface structured degradation events and build safe fallbacks when blueprints are missing
- surface the allowErrors option through bootstrap/startServer, emit data-load telemetry, and keep the server running during degraded startup
- add an integration test covering incomplete data directories and document the resiliency work in the changelog

## Testing
- pnpm --filter @weebbreed/backend test
- pnpm run check *(fails: existing frontend eslint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe8f3e6dc8325addd2c422721b191