### PR TITLE
Classify command errors and harden socket gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tagged command errors with `category` metadata and taught the socket gateway to
+  budget per-socket internal failures, leaving clients connected on user
+  mistakes while disconnecting after repeated `ERR_INTERNAL` responses.
 - Hardened the backend bootstrap pipeline to surface data-load summaries,
   propagate structured state-factory degradation events, and keep the server
   responsive when blueprints are missing, alongside a resilience integration

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -1,6 +1,6 @@
 # Simulation Facade Intents
 
-The simulation exposes a small number of validated intent domains. Each domain groups related commands that are available both through the in-process API and the Socket.IO `facade.intent` envelope. All commands return the shared `CommandResult` contract (`{ ok, data?, warnings?, errors? }`).【F:src/backend/src/facade/commands/commandRegistry.ts†L20-L67】【F:src/backend/src/server/socketGateway.ts†L364-L402】
+The simulation exposes a small number of validated intent domains. Each domain groups related commands that are available both through the in-process API and the Socket.IO `facade.intent` envelope. All commands return the shared `CommandResult` contract (`{ ok, data?, warnings?, errors? }`) where each error item includes `{ code, message, path?, category }` so callers can distinguish user mistakes from internal faults.【F:src/backend/src/facade/commands/commandRegistry.ts†L20-L114】【F:src/backend/src/server/socketGateway.ts†L518-L568】
 
 ## Domain Overview
 

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -133,7 +133,7 @@ Common categories are below.
 - `setUtilityPrices({ electricityCostPerKWh, waterCostPerM3, nutrientsCostPerKg })`
 - `setMaintenancePolicy(patch)`
 
-**All commands** return `{ ok: boolean, warnings?: string[], errors?: string[] }` and emit events on success.
+**All commands** return `{ ok: boolean, warnings?: string[], errors?: { code: string, message: string, path?: string[], category: 'user' | 'internal' }[] }` and emit events on success.
 
 ---
 
@@ -146,7 +146,7 @@ Common categories are below.
 
 **Standard errors**
 
-- `ERR_NOT_FOUND`, `ERR_FORBIDDEN`, `ERR_CONFLICT`, `ERR_INVALID_STATE`, `ERR_VALIDATION`, `ERR_RATE_LIMIT`, `ERR_DATA_RELOAD_PENDING`.
+- `ERR_NOT_FOUND`, `ERR_FORBIDDEN`, `ERR_CONFLICT`, `ERR_INVALID_STATE`, `ERR_VALIDATION`, `ERR_RATE_LIMIT`, `ERR_DATA_RELOAD_PENDING` (tagged as `internal`), `ERR_INTERNAL`.
 
 ---
 

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -562,6 +562,13 @@ future without breaking existing clients.
 - Internal failures (`ERR_INTERNAL`) surface the error message and the command
   path. The gateway never throws – failures are returned via the Socket.IO ACK
   callback and the mirrored `*.result` event.
+- Every error entry carries a `category` field: `'user'` for caller mistakes or
+  rejected states, `'internal'` for fatal/back-end issues (`ERR_INTERNAL`,
+  `ERR_DATA_RELOAD_PENDING`). Clients can use this to drive UI messaging and
+  retry logic.
+- The gateway tracks consecutive internal failures per socket. After three
+  responses carrying `'internal'` errors it schedules a short disconnect so
+  clients back off before retrying.
 - Unsupported commands yield `ERR_INVALID_STATE`.
 
 ## Batching Guarantees

--- a/src/backend/src/engine/devices/deviceGroupService.ts
+++ b/src/backend/src/engine/devices/deviceGroupService.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
+  createError,
 } from '@/facade/index.js';
 import type { GameState, TaskState } from '@/state/types.js';
 import { findZone } from '@/engine/world/stateSelectors.js';
@@ -114,13 +115,7 @@ export class DeviceGroupService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     };
   }
 }

--- a/src/backend/src/engine/devices/deviceInstallationService.ts
+++ b/src/backend/src/engine/devices/deviceInstallationService.ts
@@ -6,6 +6,7 @@ import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
+  createError,
 } from '@/facade/index.js';
 import type { GameState, DeviceInstanceState, ZoneState } from '@/state/types.js';
 import type { DeviceBlueprint } from '@/data/schemas/deviceSchema.js';
@@ -147,13 +148,7 @@ export class DeviceInstallationService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     } satisfies CommandResult<T>;
   }
 }

--- a/src/backend/src/engine/devices/deviceRemovalService.ts
+++ b/src/backend/src/engine/devices/deviceRemovalService.ts
@@ -5,6 +5,7 @@ import {
   LIGHT_DEVICE_KINDS,
 } from '@/constants/environment.js';
 import type { CommandExecutionContext, CommandResult, ErrorCode } from '@/facade/index.js';
+import { createError } from '@/facade/index.js';
 import type { EventQueueFunction } from '@/lib/eventBus.js';
 import type {
   GameState,
@@ -159,13 +160,7 @@ export class DeviceRemovalService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     } satisfies CommandResult<T>;
   }
 }

--- a/src/backend/src/engine/devices/lightingCycleService.ts
+++ b/src/backend/src/engine/devices/lightingCycleService.ts
@@ -1,4 +1,5 @@
 import type { CommandExecutionContext, CommandResult, ErrorCode } from '@/facade/index.js';
+import { createError } from '@/facade/index.js';
 import { findZone } from '@/engine/world/stateSelectors.js';
 import type { GameState, ZoneLightingState } from '@/state/types.js';
 
@@ -111,13 +112,7 @@ export class LightingCycleService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     } satisfies CommandResult<T>;
   }
 }

--- a/src/backend/src/engine/plants/plantLifecycleService.ts
+++ b/src/backend/src/engine/plants/plantLifecycleService.ts
@@ -1,6 +1,7 @@
 import { generateId } from '@/state/initialization/common.js';
 import { RNG_STREAM_IDS, type RngService, type RngStream } from '@/lib/rng.js';
 import type { CommandExecutionContext, CommandResult, ErrorCode } from '@/facade/index.js';
+import { createError } from '@/facade/index.js';
 import type {
   GameState,
   HarvestBatch,
@@ -305,13 +306,7 @@ export class PlantLifecycleService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     } satisfies CommandResult<T>;
   }
 }

--- a/src/backend/src/engine/plants/plantingPlanService.ts
+++ b/src/backend/src/engine/plants/plantingPlanService.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
+  createError,
 } from '@/facade/index.js';
 import type { GameState, TaskState } from '@/state/types.js';
 import { findZone } from '@/engine/world/stateSelectors.js';
@@ -98,13 +99,7 @@ export class PlantingPlanService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     };
   }
 }

--- a/src/backend/src/engine/plants/plantingService.ts
+++ b/src/backend/src/engine/plants/plantingService.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
   type CommandResult,
   type ErrorCode,
+  createError,
 } from '@/facade/index.js';
 import type { GameState, PlantState, ZoneState, PlantHealthState } from '@/state/types.js';
 import type { BlueprintRepository } from '@/data/blueprintRepository.js';
@@ -230,13 +231,7 @@ export class PlantingService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     } satisfies CommandResult<T>;
   }
 }

--- a/src/backend/src/engine/world/worldService.ts
+++ b/src/backend/src/engine/world/worldService.ts
@@ -8,6 +8,7 @@ import {
   type CreateRoomIntent,
   type CreateZoneIntent,
   type UpdateZoneIntent,
+  createError,
 } from '@/facade/index.js';
 import {
   type DeviceFailureModifiers,
@@ -397,13 +398,7 @@ export class WorldService {
   private failure<T = never>(code: ErrorCode, message: string, path: string[]): CommandResult<T> {
     return {
       ok: false,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     };
   }
 }

--- a/src/backend/src/engine/world/worldService.updateZone.test.ts
+++ b/src/backend/src/engine/world/worldService.updateZone.test.ts
@@ -11,6 +11,7 @@ import {
   createCultivationMethodBlueprint,
   createSubstrateBlueprint,
 } from '@/testing/fixtures.js';
+import { createError } from '@/facade/index.js';
 import type { CommandExecutionContext } from '@/facade/index.js';
 import type { GameState } from '@/state/types.js';
 
@@ -331,13 +332,7 @@ describe('ZoneService.updateZone', () => {
     };
     const failure: FailureFactory = (code, message, path) => ({
       ok: false as const,
-      errors: [
-        {
-          code,
-          message,
-          path,
-        },
-      ],
+      errors: [createError(code, message, path)],
     });
 
     zoneService = createZoneService({

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -147,12 +147,25 @@ const cloneState = <T>(value: T): T => {
 };
 
 export { CommandExecutionError } from './commands/commandRegistry.js';
+export {
+  createError,
+  createFailure,
+  normalizeWarnings,
+  normalizeErrors,
+  normalizeResult,
+  stripIntentMetadata,
+  handleCommandError,
+  handleValidationError,
+  classifyErrorCode,
+  isInternalErrorCode,
+} from './commands/commandRegistry.js';
 export type {
   CommandError,
   CommandResult,
   CommandExecutionContext,
   ServiceCommandHandler,
   ErrorCode,
+  ErrorCategory,
 } from './commands/commandRegistry.js';
 export type {
   TimeStatus,


### PR DESCRIPTION
## Summary
- tag command errors with user versus internal categories and update helpers/services to emit classified errors
- track per-socket internal failure counts in the gateway so repeated ERR_INTERNAL responses trigger a timed disconnect while user mistakes reset the budget
- exercise the new behaviour with socket gateway tests and document the error taxonomy/backoff in the protocol guides

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68dbf1f62968832580e37ed1ef20d690