### PR TITLE
Enforce strict device blueprint schema validation

### DIFF
--- a/docs/system/data-validation.md
+++ b/docs/system/data-validation.md
@@ -52,10 +52,38 @@ executes three independent jobs on every push and pull request:
 Each job installs dependencies with the pinned pnpm and Node.js versions so a
 failure in any command marks the workflow as failed.
 
-## Device Setpoint Casing Guard
+## Device Blueprint Strictness
 
 Device blueprints rely on precise casing for control setpoints that the engine
 expects (for example `targetTemperature`, `targetHumidity`, and `targetCO2`).
 The Zod schema backing `pnpm validate:data` now rejects mis-cased variants such
 as `targetCo2` and surfaces a clear suggestion in the validation report. This
 keeps blueprint typos from silently disabling device controllers.
+
+In addition to casing hints, the `settings`, `coverage`, `limits`, `meta`, and
+top-level device blocks are now **strict objects**. Blueprint authors must stay
+within the explicit set of keys encoded in the schema:
+
+- **Settings** — numeric controls such as `power`, `ppfd`,
+  `coverageArea`, `spectralRange`, `heatFraction`, `airflow`,
+  `coolingCapacity`, `cop`, `hysteresisK`, `fullPowerAtDeltaK`,
+  `moistureRemoval`, `targetTemperature`, `targetTemperatureRange`,
+  `targetHumidity`, `targetCO2`, `targetCO2Range`, `hysteresis`,
+  `pulsePpmPerTick`, `latentRemovalKgPerTick`,
+  `humidifyRateKgPerTick`, and `dehumidifyRateKgPerTick`.
+- **Coverage** — geometry descriptors limited to
+  `maxArea_m2`, `maxVolume_m3`, `effectivePPFD_at_m`, `beamProfile`,
+  `airflowPattern`, `distributionPattern`, `ventilationPattern`,
+  `removalPattern`, and `controlPattern`.
+- **Limits** — operational bounds including `power_W`, `maxPPFD`,
+  `minPPFD`, `coolingCapacity_kW`, `airflow_m3_h`, `maxAirflow_m3_h`,
+  `minAirflow_m3_h`, `maxStaticPressure_Pa`, `co2Rate_ppm_min`,
+  `maxCO2_ppm`, `minCO2_ppm`, `removalRate_kg_h`, `capacity_kg_h`,
+  `minTemperature_C`, `maxTemperature_C`, `minHumidity_percent`, and
+  `maxHumidity_percent`.
+- **Meta** — optional descriptive fields (`description`, `advantages`,
+  `disadvantages`, `notes`).
+
+Any new attribute must be added to the schema alongside documentation updates
+before it appears in JSON. This keeps validation aligned with the engine's
+expectations and makes blueprint errors fail fast during `pnpm validate:data`.

--- a/src/backend/src/data/schemas/deviceSchema.ts
+++ b/src/backend/src/data/schemas/deviceSchema.ts
@@ -17,22 +17,31 @@ const canonicalSetpointKeys = new Map(
   ].map((key) => [key.toLowerCase(), key] as const),
 );
 
-const settingsSchema = z
-  .object({
-    power: optionalNumericSetting,
-    ppfd: optionalNumericSetting,
-    coverageArea: optionalNumericSetting,
-    spectralRange: optionalRangeTuple,
-    heatFraction: optionalNumericSetting,
-    airflow: optionalNumericSetting,
-    coolingCapacity: optionalNumericSetting,
-    moistureRemoval: optionalNumericSetting,
-    targetTemperature: optionalNumericSetting,
-    targetTemperatureRange: optionalRangeTuple,
-    targetHumidity: optionalNumericSetting,
-    targetCO2: optionalNumericSetting,
-    targetCO2Range: optionalRangeTuple,
-  })
+const settingsBaseObject = z.object({
+  power: optionalNumericSetting,
+  ppfd: optionalNumericSetting,
+  coverageArea: optionalNumericSetting,
+  spectralRange: optionalRangeTuple,
+  heatFraction: optionalNumericSetting,
+  airflow: optionalNumericSetting,
+  coolingCapacity: optionalNumericSetting,
+  cop: optionalNumericSetting,
+  hysteresisK: optionalNumericSetting,
+  fullPowerAtDeltaK: optionalNumericSetting,
+  moistureRemoval: optionalNumericSetting,
+  targetTemperature: optionalNumericSetting,
+  targetTemperatureRange: optionalRangeTuple,
+  targetHumidity: optionalNumericSetting,
+  targetCO2: optionalNumericSetting,
+  targetCO2Range: optionalRangeTuple,
+  hysteresis: optionalNumericSetting,
+  pulsePpmPerTick: optionalNumericSetting,
+  latentRemovalKgPerTick: optionalNumericSetting,
+  humidifyRateKgPerTick: optionalNumericSetting,
+  dehumidifyRateKgPerTick: optionalNumericSetting,
+});
+
+const settingsSchema = settingsBaseObject
   .passthrough()
   .superRefine((settings, ctx) => {
     if (!settings || typeof settings !== 'object') {
@@ -50,7 +59,8 @@ const settingsSchema = z
         });
       }
     }
-  });
+  })
+  .pipe(settingsBaseObject.strict());
 
 // Coverage schema for different device types
 const coverageSchema = z
@@ -65,7 +75,7 @@ const coverageSchema = z
     removalPattern: z.enum(['ambient', 'targeted']).optional(),
     controlPattern: z.enum(['single-mode', 'dual-mode', 'multi-zone']).optional(),
   })
-  .passthrough();
+  .strict();
 
 // Limits schema for device operational boundaries
 const limitsSchema = z
@@ -88,7 +98,7 @@ const limitsSchema = z
     minHumidity_percent: z.number().min(0).max(100).optional(),
     maxHumidity_percent: z.number().min(0).max(100).optional(),
   })
-  .passthrough();
+  .strict();
 
 // Maintenance schema for service requirements
 const maintenanceSchema = z.object({
@@ -119,11 +129,11 @@ export const deviceSchema = z
         disadvantages: z.array(z.string()).optional(),
         notes: z.string().optional(),
       })
-      .passthrough(),
+      .strict(),
     // Legacy field for backward compatibility
     lifespan: numericSetting.optional(),
   })
-  .passthrough();
+  .strict();
 
 export type DeviceRoomPurposeCompatibility = z.infer<typeof roomPurposeCompatibilitySchema>;
 export type DeviceBlueprint = z.infer<typeof deviceSchema>;


### PR DESCRIPTION
## Summary
- tighten the device schema by enumerating allowed settings, coverage, limits, meta, and top-level keys and keep canonical setpoint hints
- expand the schema unit tests to cover mis-cased keys and stray properties for settings, coverage, meta, and the top-level object
- document the stricter contract for blueprint authors in the data validation guide

## Testing
- `pnpm exec vitest run src/data/schemas/deviceSchema.test.ts`
- `pnpm validate:data`
- `pnpm exec eslint --max-warnings=0 src/backend/src/data/schemas/deviceSchema.test.ts src/backend/src/data/schemas/deviceSchema.ts`

------
https://chatgpt.com/codex/tasks/task_e_68dbfce48580832585a63a1d7452dec2