### PR TITLE
Tighten device settings facade validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tightened façade device-setting schemas to accept only canonical numeric controls and
+  two-value tuples, rejecting undefined patches and unknown keys. Updated command docs and
+  regression tests capture the stricter validation.
 - Tagged command errors with `category` metadata and taught the socket gateway to
   budget per-socket internal failures, leaving clients connected on user
   mistakes while disconnecting after repeated `ERR_INTERNAL` responses.

--- a/docs/system/facade.md
+++ b/docs/system/facade.md
@@ -96,6 +96,14 @@ Common categories are below.
 - `removeDevice(instanceId)`
 - `toggleDeviceGroup({ zoneId, kind, enabled })` — flips operational status in bulk and returns `{ deviceIds }` of affected units.
 
+  Device commands only accept the canonical control keys from the active blueprint catalog. All settings must be finite numbers unless noted:
+  - Scalar controls: `power`, `ppfd`, `coverageArea`, `heatFraction`, `airflow`, `coolingCapacity`, `cop`,
+    `hysteresisK`, `fullPowerAtDeltaK`, `moistureRemoval`, `hysteresis`, `pulsePpmPerTick`,
+    `latentRemovalKgPerTick`, `humidifyRateKgPerTick`, `dehumidifyRateKgPerTick`.
+  - Setpoints: `targetTemperature`, `targetHumidity` (0–1), `targetCO2`.
+  - Ranges: `spectralRange`, `targetTemperatureRange`, `targetCO2Range` must be two-number tuples `[min, max]`.
+  - Patches must define at least one concrete value; undefined entries are ignored, and unknown keys are rejected with validation errors.
+
 ### 4.5 Plants & Plantings
 
 - `addPlanting(zoneId, { strainId, count, startTick? })` — enforces cultivation method capacity, strain/method

--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -412,6 +412,11 @@ object:
 - **devices** — `installDevice`, `updateDevice`, `moveDevice`, `removeDevice`,
   `toggleDeviceGroup`. The toggle action returns `{ deviceIds: string[] }` with
   every instance that changed status.
+  - `installDevice` and `updateDevice` validate settings against the device blueprint contract: only
+    numeric control keys (`power`, `ppfd`, `coverageArea`, airflow/cooling controls, hysteresis/pulse
+    knobs, humidity/CO₂/temperature setpoints) are accepted. Range fields (`spectralRange`,
+    `targetTemperatureRange`, `targetCO2Range`) must be `[min, max]` tuples. Partial patches must supply
+    at least one defined value; unknown keys are rejected before a service handler runs.
 - **plants** — `addPlanting`, `cullPlanting`, `harvestPlanting`, `harvestPlant`,
   `cullPlant`, `applyIrrigation`, `applyFertilizer`, `togglePlantingPlan`. The
   automation toggle responds with `{ enabled: boolean }` and emits a follow-up

--- a/src/backend/src/facade/commands/commonSchemas.ts
+++ b/src/backend/src/facade/commands/commonSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { DeviceBlueprint } from '@/data/schemas/deviceSchema.js';
 
 export const uuid = z.string().uuid();
 
@@ -32,6 +33,91 @@ export const nonNegativeInteger = z
   .int({ message: 'Value must be an integer.' })
   .min(0, { message: 'Value must be zero or greater.' });
 
-export const settingsRecord = z.record(z.string(), z.unknown());
+type DeviceSettings = DeviceBlueprint['settings'];
+
+const deviceSettingsKeys = [
+  'power',
+  'ppfd',
+  'coverageArea',
+  'spectralRange',
+  'heatFraction',
+  'airflow',
+  'coolingCapacity',
+  'cop',
+  'hysteresisK',
+  'fullPowerAtDeltaK',
+  'moistureRemoval',
+  'targetTemperature',
+  'targetTemperatureRange',
+  'targetHumidity',
+  'targetCO2',
+  'targetCO2Range',
+  'hysteresis',
+  'pulsePpmPerTick',
+  'latentRemovalKgPerTick',
+  'humidifyRateKgPerTick',
+  'dehumidifyRateKgPerTick',
+] as const;
+
+const canonicalDeviceSettingKeys = new Map(
+  deviceSettingsKeys.map((key) => [key.toLowerCase(), key] as const),
+);
+
+const numericSetting = finiteNumber;
+const rangeTuple = z.tuple([finiteNumber, finiteNumber]);
+
+const deviceSettingsShape = {
+  power: numericSetting.optional(),
+  ppfd: numericSetting.optional(),
+  coverageArea: numericSetting.optional(),
+  spectralRange: rangeTuple.optional(),
+  heatFraction: numericSetting.optional(),
+  airflow: numericSetting.optional(),
+  coolingCapacity: numericSetting.optional(),
+  cop: numericSetting.optional(),
+  hysteresisK: numericSetting.optional(),
+  fullPowerAtDeltaK: numericSetting.optional(),
+  moistureRemoval: numericSetting.optional(),
+  targetTemperature: numericSetting.optional(),
+  targetTemperatureRange: rangeTuple.optional(),
+  targetHumidity: numericSetting.optional(),
+  targetCO2: numericSetting.optional(),
+  targetCO2Range: rangeTuple.optional(),
+  hysteresis: numericSetting.optional(),
+  pulsePpmPerTick: numericSetting.optional(),
+  latentRemovalKgPerTick: numericSetting.optional(),
+  humidifyRateKgPerTick: numericSetting.optional(),
+  dehumidifyRateKgPerTick: numericSetting.optional(),
+} satisfies Record<keyof DeviceSettings, z.ZodTypeAny>;
+
+const deviceSettingsBase = z.object(deviceSettingsShape);
+const deviceSettingsStrict = deviceSettingsBase.strict();
+
+export const deviceSettingsSchema = deviceSettingsBase
+  .passthrough()
+  .superRefine((settings, ctx) => {
+    if (!settings || typeof settings !== 'object') {
+      return;
+    }
+
+    for (const key of Object.keys(settings as Record<string, unknown>)) {
+      const canonicalKey = canonicalDeviceSettingKeys.get(key.toLowerCase());
+
+      if (canonicalKey && canonicalKey !== key) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Unrecognized setting "${key}". Did you mean "${canonicalKey}"?`,
+        });
+      }
+    }
+  })
+  .pipe(deviceSettingsStrict);
+
+export const deviceSettingsPatchSchema = deviceSettingsStrict.partial();
+
+export const settingsRecord = deviceSettingsSchema;
+
+export const looseRecord = z.record(z.string(), z.unknown());
 
 export const emptyObjectSchema = z.object({}).strict();

--- a/src/backend/src/facade/commands/devices.schemas.test.ts
+++ b/src/backend/src/facade/commands/devices.schemas.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { schemas } from './devices.js';
+import { deviceSettingsSchema } from './commonSchemas.js';
+
+const SAMPLE_UUID = '11111111-1111-4111-8111-111111111111';
+
+describe('device command schemas', () => {
+  it('accepts recognized device settings during install', () => {
+    const result = schemas.installDeviceSchema.parse({
+      targetId: SAMPLE_UUID,
+      deviceId: '22222222-2222-4222-8222-222222222222',
+      settings: {
+        power: 0.8,
+        targetTemperatureRange: [21, 26],
+      },
+    });
+
+    expect(result.settings).toEqual({ power: 0.8, targetTemperatureRange: [21, 26] });
+  });
+
+  it('allows partial patches that define at least one setting', () => {
+    const result = schemas.updateDeviceSchema.parse({
+      instanceId: SAMPLE_UUID,
+      settings: {
+        targetHumidity: 0.62,
+      },
+    });
+
+    expect(result.settings).toEqual({ targetHumidity: 0.62 });
+  });
+
+  it('rejects unknown device setting keys', () => {
+    const result = deviceSettingsSchema.safeParse({
+      targetTemperature: 24,
+      TargetHumidity: 0.61,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      expect.objectContaining({
+        code: 'custom',
+        path: ['TargetHumidity'],
+        message: 'Unrecognized setting "TargetHumidity". Did you mean "targetHumidity"?',
+      }),
+    ]);
+  });
+
+  it('rejects non-numeric device settings', () => {
+    const result = deviceSettingsSchema.safeParse({
+      power: 'high' as unknown as number,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_type',
+        message: 'Value must be a number.',
+        path: ['power'],
+      }),
+    ]);
+  });
+
+  it('rejects patches without defined values', () => {
+    const emptyResult = schemas.updateDeviceSchema.safeParse({
+      instanceId: SAMPLE_UUID,
+      settings: {},
+    });
+
+    expect(emptyResult.success).toBe(false);
+    expect(emptyResult.error?.issues).toEqual([
+      expect.objectContaining({
+        message: 'Settings patch must include at least one property.',
+        path: ['settings'],
+      }),
+    ]);
+
+    const undefinedResult = schemas.updateDeviceSchema.safeParse({
+      instanceId: SAMPLE_UUID,
+      settings: {
+        power: undefined,
+      },
+    });
+
+    expect(undefinedResult.success).toBe(false);
+    expect(undefinedResult.error?.issues).toEqual([
+      expect.objectContaining({
+        message: 'Settings patch must include at least one property.',
+        path: ['settings'],
+      }),
+    ]);
+  });
+});

--- a/src/backend/src/facade/commands/devices.ts
+++ b/src/backend/src/facade/commands/devices.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import type { DeviceGroupToggleResult } from '@/engine/devices/deviceGroupService.js';
 import type { AdjustLightingCycleResult } from '@/engine/devices/lightingCycleService.js';
-import { entityIdentifier, settingsRecord, uuid } from './commonSchemas.js';
+import {
+  deviceSettingsPatchSchema,
+  deviceSettingsSchema,
+  entityIdentifier,
+  uuid,
+} from './commonSchemas.js';
 import {
   createServiceCommand,
   type CommandRegistration,
@@ -14,17 +19,20 @@ const installDeviceSchema = z
   .object({
     targetId: entityIdentifier,
     deviceId: uuid,
-    settings: settingsRecord.optional(),
+    settings: deviceSettingsSchema.optional(),
   })
   .strict();
 
 const updateDeviceSchema = z
   .object({
     instanceId: uuid,
-    settings: settingsRecord
-      .refine((value) => Object.keys(value).length > 0, {
-        message: 'Settings patch must include at least one property.',
-      })
+    settings: deviceSettingsPatchSchema
+      .refine(
+        (value) => (value ? Object.values(value).some((setting) => setting !== undefined) : false),
+        {
+          message: 'Settings patch must include at least one property.',
+        },
+      )
       .optional(),
   })
   .strict();

--- a/src/backend/src/facade/commands/workforce.ts
+++ b/src/backend/src/facade/commands/workforce.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { JobMarketRefreshSummary } from '@/engine/workforce/jobMarketService.js';
 import {
   emptyObjectSchema,
+  looseRecord,
   nonEmptyString,
   nonNegativeNumber,
   positiveNumber,
-  settingsRecord,
   uuid,
 } from './commonSchemas.js';
 import {
@@ -55,7 +55,7 @@ const assignStructureSchema = z
 const enqueueTaskSchema = z
   .object({
     taskKind: nonEmptyString,
-    payload: settingsRecord.optional(),
+    payload: looseRecord.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- enforce canonical device control keys and numeric/range validation in the shared command schema
- require device update patches to provide at least one concrete value and cover the stricter behaviour with new tests
- document the allowed façade device settings payload and changelog the validation change

## Testing
- pnpm --filter @weebbreed/backend test

------
https://chatgpt.com/codex/tasks/task_e_68dbfeed33dc8325ba045dadfdd0ae02