### PR TITLE
Validate socket gateway intents before execution

### DIFF
--- a/docs/system/socket_protocol.md
+++ b/docs/system/socket_protocol.md
@@ -391,7 +391,11 @@ object:
 - `action` selects a command within that domain. Actions are validated against
   the domain catalog that `SimulationFacade` builds during startup.
 - `payload` is validated with the command’s Zod schema before any engine service
-  executes. Missing payloads default to `{}` when a schema allows it.
+  executes. The socket gateway strips helper metadata, runs the command
+  preprocess hook (when present), and responds with the same normalized
+  `ERR_VALIDATION` payload the façade would emit. Validation failures do **not**
+  invoke command handlers or mutate simulation state. Missing payloads default
+  to `{}` when a schema allows it.
 - Responses are emitted on `<domain>.intent.result` and include the merged
   `CommandResult` (`{ ok, data?, warnings?, errors? }`). Unknown domains/actions
   yield `ERR_VALIDATION` with the offending field path (`['facade.intent',

--- a/src/backend/src/facade/index.ts
+++ b/src/backend/src/facade/index.ts
@@ -840,6 +840,13 @@ export class SimulationFacade {
     return this.intentCatalog.has(domain);
   }
 
+  getIntentRegistration(
+    domain: string,
+    action: string,
+  ): CommandRegistration<unknown, unknown> | undefined {
+    return this.domainRegistrations.get(domain)?.[action];
+  }
+
   getIntentHandler(domain: string, action: string): DomainCommandInvoker | undefined {
     return this.domainHandlers.get(domain)?.[action];
   }


### PR DESCRIPTION
### **User description**
## Summary
- validate facade intents in the socket gateway using the facade-registered schemas before invoking command handlers
- expose intent registration metadata on the simulation facade so transports can reuse command schemas
- extend socket gateway integration tests with schema-aware stubs and document stricter validation semantics in the socket protocol guide

## Testing
- pnpm --filter @weebbreed/backend test -- socketGateway

------
https://chatgpt.com/codex/tasks/task_e_68dc0e8e028c832585a61d799e23cea4


___

### **PR Type**
Enhancement


___

### **Description**
- Add schema validation for socket gateway facade intents

- Expose intent registration metadata on simulation facade

- Extend integration tests with schema-aware validation stubs

- Update socket protocol documentation for stricter validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Socket Gateway"] --> B["Intent Registration"]
  B --> C["Schema Validation"]
  C --> D["Command Handler"]
  E["Simulation Facade"] --> B
  C --> F["Validation Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Expose intent registration metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/facade/index.ts

<ul><li>Add <code>getIntentRegistration</code> method to expose command registration <br>metadata<br> <li> Enable socket gateway access to validation schemas</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/359/files#diff-af16b94f90c68e774020b86f3f1f6bb2d924eb966d3b8912b95a3892a225bdce">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>socketGateway.ts</strong><dd><code>Implement schema validation in gateway</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/socketGateway.ts

<ul><li>Validate facade intents using registered Zod schemas before execution<br> <li> Add preprocessing and validation error handling<br> <li> Prevent handler invocation on validation failures</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/359/files#diff-e7c4459685aa6255cb512b1d7cd6d296dc4322282f75230933afde37e786e639">+37/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>socketGateway.test.ts</strong><dd><code>Add schema validation integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/server/socketGateway.test.ts

<ul><li>Add schema-aware stub facade with intent registration support<br> <li> Implement test for invalid payload rejection before handler invocation<br> <li> Initialize intent registrations for all domains and actions</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/359/files#diff-055670629119482efd84b5ef3d052f5abcde87c9ffe3cbc07017ed9104e2a669">+110/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>socket_protocol.md</strong><dd><code>Update socket protocol validation docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/system/socket_protocol.md

<ul><li>Document stricter validation semantics for facade intents<br> <li> Clarify preprocessing and error handling behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/359/files#diff-0af8ef4d9194d8affcf445132c4456fd7133e7ceb012b1a1e2bc6b5ef1d12d8c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

