### PR TITLE
chore: ignore monitor tooling in js workflows

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,7 +27,7 @@ module.exports = {
       },
     },
   },
-  ignorePatterns: ['dist', 'node_modules'],
+  ignorePatterns: ['dist', 'node_modules', 'tools/monitor/**'],
   rules: {
     'no-throw-literal': 'error',
   },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
-src/frontend-legacy/**
 docs/addendum/clickdummy/**
 tools/monitor/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Excluded the Python-based monitoring utilities under `tools/monitor` from JavaScript
+  linting and formatting workflows so repository checks ignore non-Node tooling.
 - Tightened façade device-setting schemas to accept only canonical numeric controls and
   two-value tuples, rejecting undefined patches and unknown keys. Updated command docs and
   regression tests capture the stricter validation.

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,4 +1,4 @@
-const EXCLUDED_PATTERNS = ['docs/addendum/clickdummy/'];
+const EXCLUDED_PATTERNS = ['docs/addendum/clickdummy/', 'tools/monitor/'];
 
 const filterTargets = (files) =>
   files.filter((file) => !EXCLUDED_PATTERNS.some((pattern) => file.includes(pattern)));


### PR DESCRIPTION
### **User description**
## Summary
- exclude `tools/monitor` from ESLint, lint-staged, and Prettier so Python utilities are not linted
- document the exclusion in the changelog

## Testing
- pnpm run check *(fails: existing @weebbreed/frontend lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dca765ffc48325a6296cee039ed654


___

### **PR Type**
Other


___

### **Description**
- Exclude `tools/monitor` directory from JavaScript linting workflows

- Add Python monitoring utilities to ignore patterns

- Update ESLint, Prettier, and lint-staged configurations

- Document exclusion changes in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tools/monitor directory"] --> B["ESLint ignore"]
  A --> C["Prettier ignore"]
  A --> D["lint-staged ignore"]
  B --> E["JavaScript linting excluded"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.eslintignore</strong><dd><code>Add monitor tools to ESLint ignore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.eslintignore

<ul><li>Add <code>tools/monitor/**</code> to ESLint ignore patterns<br> <li> Fix missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/362/files#diff-a0fdacd2ade87c5238dde44378f574f7e123e669acdf8b740878b14b33b20275">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.eslintrc.cjs</strong><dd><code>Update ESLint ignore patterns configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.eslintrc.cjs

- Add `tools/monitor/**` to ignorePatterns array


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/362/files#diff-e1ce717e1179a0db14e90ec5374768a206651ca807db58352991eb7895ed7c9c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.prettierignore</strong><dd><code>Create Prettier ignore configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.prettierignore

<ul><li>Create new Prettier ignore file<br> <li> Add <code>docs/addendum/clickdummy/**</code> and <code>tools/monitor/**</code> patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/362/files#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lint-staged.config.cjs</strong><dd><code>Update lint-staged exclusion patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lint-staged.config.cjs

- Add `tools/monitor/` to EXCLUDED_PATTERNS array


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/362/files#diff-be4c195af28367d11bf560eb5bee62cd0927342a1406f1666d6eab3fbb5d5872">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document monitoring tools exclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document exclusion of Python monitoring utilities from JavaScript <br>workflows<br> <li> Add entry explaining the rationale for ignoring non-Node tooling</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/362/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

