### PR TITLE
Add coverage for world state selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added state selector unit tests that build multi-structure fixtures and validate
+  structure, room, and zone lookup metadata including miss cases for empty
+  collections and similar-looking ids.
 - Added zone service unit tests validating create/clone/duplicate flows with
   blueprint compatibility fixtures, geometry validation, and cost accounting
   purchase recording.

--- a/src/backend/src/engine/world/stateSelectors.test.ts
+++ b/src/backend/src/engine/world/stateSelectors.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  FinanceState,
+  GameMetadata,
+  GameState,
+  GlobalInventoryState,
+  PersonnelRoster,
+  RoomState,
+  SimulationClockState,
+  StructureState,
+  TaskSystemState,
+  ZoneState,
+} from '@/state/types.js';
+import { findRoom, findStructure, findZone } from './stateSelectors.js';
+
+const createMetadata = (): GameMetadata => ({
+  gameId: 'game-test',
+  createdAt: new Date(0).toISOString(),
+  seed: 'seed-test',
+  difficulty: 'normal',
+  simulationVersion: '1.0.0-test',
+  tickLengthMinutes: 60,
+  economics: {
+    initialCapital: 100_000,
+    itemPriceMultiplier: 1,
+    harvestPriceMultiplier: 1,
+    rentPerSqmStructurePerTick: 0,
+    rentPerSqmRoomPerTick: 0,
+  },
+});
+
+const createClock = (): SimulationClockState => ({
+  tick: 0,
+  isPaused: false,
+  startedAt: new Date(0).toISOString(),
+  lastUpdatedAt: new Date(0).toISOString(),
+  targetTickRate: 1,
+});
+
+const createInventory = (): GlobalInventoryState => ({
+  resources: {
+    waterLiters: 0,
+    nutrientsGrams: 0,
+    co2Kg: 0,
+    substrateKg: 0,
+    packagingUnits: 0,
+    sparePartsValue: 0,
+  },
+  seeds: [],
+  devices: [],
+  harvest: [],
+  consumables: {},
+});
+
+const createFinances = (): FinanceState => ({
+  cashOnHand: 10_000,
+  reservedCash: 0,
+  outstandingLoans: [],
+  ledger: [],
+  summary: {
+    totalRevenue: 0,
+    totalExpenses: 0,
+    totalPayroll: 0,
+    totalMaintenance: 0,
+    netIncome: 0,
+    lastTickRevenue: 0,
+    lastTickExpenses: 0,
+  },
+  utilityPrices: {
+    version: 'test',
+    pricePerKwh: 0.2,
+    pricePerLiterWater: 0.01,
+    pricePerGramNutrients: 0.05,
+  },
+});
+
+const createPersonnel = (): PersonnelRoster => ({
+  employees: [],
+  applicants: [],
+  trainingPrograms: [],
+  overallMorale: 1,
+});
+
+const createTasks = (): TaskSystemState => ({
+  backlog: [],
+  active: [],
+  completed: [],
+  cancelled: [],
+});
+
+const createZone = (overrides: Partial<ZoneState> = {}): ZoneState => ({
+  id: 'zone-default',
+  roomId: 'room-default',
+  name: 'Default Zone',
+  cultivationMethodId: 'method-default',
+  strainId: 'strain-default',
+  area: 10,
+  ceilingHeight: 3,
+  volume: 30,
+  environment: {
+    temperature: 22,
+    relativeHumidity: 0.55,
+    co2: 900,
+    ppfd: 400,
+    vpd: 1.1,
+  },
+  resources: {
+    waterLiters: 0,
+    nutrientSolutionLiters: 0,
+    nutrientStrength: 1,
+    substrateHealth: 1,
+    reservoirLevel: 0,
+    lastTranspirationLiters: 0,
+  },
+  plants: [],
+  devices: [],
+  metrics: {
+    averageTemperature: 22,
+    averageHumidity: 0.55,
+    averageCo2: 900,
+    averagePpfd: 400,
+    stressLevel: 0,
+    lastUpdatedTick: 0,
+  },
+  control: { setpoints: {} },
+  health: { plantHealth: {}, pendingTreatments: [], appliedTreatments: [] },
+  activeTaskIds: [],
+  ...overrides,
+});
+
+const createRoom = (overrides: Partial<RoomState> = {}): RoomState => ({
+  id: 'room-default',
+  structureId: 'structure-default',
+  name: 'Default Room',
+  purposeId: 'purpose-default',
+  area: 100,
+  height: 3,
+  volume: 300,
+  zones: [],
+  cleanliness: 1,
+  maintenanceLevel: 1,
+  ...overrides,
+});
+
+const createStructure = (overrides: Partial<StructureState> = {}): StructureState => ({
+  id: 'structure-default',
+  blueprintId: 'blueprint-default',
+  name: 'Default Structure',
+  status: 'active',
+  footprint: { length: 10, width: 10, height: 3, area: 100, volume: 300 },
+  rooms: [],
+  rentPerTick: 0,
+  upfrontCostPaid: 0,
+  ...overrides,
+});
+
+const createGameState = (structures: StructureState[]): GameState => ({
+  metadata: createMetadata(),
+  clock: createClock(),
+  structures,
+  inventory: createInventory(),
+  finances: createFinances(),
+  personnel: createPersonnel(),
+  tasks: createTasks(),
+});
+
+const createMultiStructureState = (): GameState => {
+  const zoneA1 = createZone({ id: 'zone-a-1', roomId: 'room-a-1', name: 'Zone A1' });
+  const zoneA10 = createZone({ id: 'zone-a-10', roomId: 'room-a-1', name: 'Zone A10' });
+  const zoneB1 = createZone({ id: 'zone-b-1', roomId: 'room-b-1', name: 'Zone B1' });
+  const zoneB10 = createZone({ id: 'zone-b-10', roomId: 'room-b-10', name: 'Zone B10' });
+  const zoneC1 = createZone({ id: 'zone-c-1', roomId: 'room-c-1', name: 'Zone C1' });
+
+  const structureOne = createStructure({
+    id: 'structure-1',
+    name: 'North Facility',
+    rooms: [
+      createRoom({
+        id: 'room-a-1',
+        structureId: 'structure-1',
+        name: 'Propagation Wing',
+        zones: [zoneA1, zoneA10],
+      }),
+      createRoom({
+        id: 'room-a-10',
+        structureId: 'structure-1',
+        name: 'Spare Room',
+        zones: [],
+      }),
+    ],
+  });
+
+  const structureTwo = createStructure({
+    id: 'structure-10',
+    name: 'South Facility',
+    rooms: [
+      createRoom({
+        id: 'room-b-1',
+        structureId: 'structure-10',
+        name: 'Flower Room',
+        zones: [zoneB1],
+      }),
+      createRoom({
+        id: 'room-b-10',
+        structureId: 'structure-10',
+        name: 'Flower Annex',
+        zones: [zoneB10],
+      }),
+    ],
+  });
+
+  const structureThree = createStructure({
+    id: 'structure-extra',
+    name: 'Research Facility',
+    rooms: [
+      createRoom({
+        id: 'room-c-1',
+        structureId: 'structure-extra',
+        name: 'Lab Room',
+        zones: [zoneC1],
+      }),
+    ],
+  });
+
+  return createGameState([structureOne, structureTwo, structureThree]);
+};
+
+describe('findStructure', () => {
+  it('returns the structure and index when an exact id match exists among similar ids', () => {
+    const state = createMultiStructureState();
+
+    const result = findStructure(state, 'structure-1');
+
+    expect(result).toBeDefined();
+    expect(result?.structure.id).toBe('structure-1');
+    expect(result?.index).toBe(0);
+  });
+
+  it('returns undefined when no structure matches the requested id', () => {
+    const state = createMultiStructureState();
+
+    expect(findStructure(state, 'structure-missing')).toBeUndefined();
+  });
+
+  it('returns undefined when the state has no structures', () => {
+    const emptyState = createGameState([]);
+
+    expect(findStructure(emptyState, 'structure-1')).toBeUndefined();
+  });
+});
+
+describe('findRoom', () => {
+  it('returns the room with structure metadata and indices', () => {
+    const state = createMultiStructureState();
+
+    const result = findRoom(state, 'room-b-1');
+
+    expect(result).toBeDefined();
+    expect(result?.structure.id).toBe('structure-10');
+    expect(result?.room.id).toBe('room-b-1');
+    expect(result?.index).toBe(1);
+    expect(result?.roomIndex).toBe(0);
+  });
+
+  it('prefers an exact id match over similar ids', () => {
+    const state = createMultiStructureState();
+
+    const result = findRoom(state, 'room-a-1');
+
+    expect(result).toBeDefined();
+    expect(result?.room.id).toBe('room-a-1');
+    expect(result?.room.id).not.toBe('room-a-10');
+  });
+
+  it('returns undefined when no room matches', () => {
+    const state = createMultiStructureState();
+
+    expect(findRoom(state, 'room-missing')).toBeUndefined();
+  });
+
+  it('returns undefined when structures have no rooms', () => {
+    const state = createGameState([createStructure({ id: 'structure-empty', rooms: [] })]);
+
+    expect(findRoom(state, 'room-b-1')).toBeUndefined();
+  });
+});
+
+describe('findZone', () => {
+  it('returns the zone with full hierarchy metadata and indices', () => {
+    const state = createMultiStructureState();
+
+    const result = findZone(state, 'zone-b-10');
+
+    expect(result).toBeDefined();
+    expect(result?.structure.id).toBe('structure-10');
+    expect(result?.room.id).toBe('room-b-10');
+    expect(result?.zone.id).toBe('zone-b-10');
+    expect(result?.index).toBe(1);
+    expect(result?.roomIndex).toBe(1);
+    expect(result?.zoneIndex).toBe(0);
+  });
+
+  it('does not match zones with similar ids in other rooms or structures', () => {
+    const state = createMultiStructureState();
+
+    const result = findZone(state, 'zone-a-1');
+
+    expect(result).toBeDefined();
+    expect(result?.zone.id).toBe('zone-a-1');
+    expect(result?.zone.id).not.toBe('zone-a-10');
+    expect(result?.structure.id).toBe('structure-1');
+    expect(result?.room.id).toBe('room-a-1');
+  });
+
+  it('returns undefined when the zone id is unknown', () => {
+    const state = createMultiStructureState();
+
+    expect(findZone(state, 'zone-missing')).toBeUndefined();
+  });
+
+  it('returns undefined when rooms contain no zones', () => {
+    const state = createGameState([
+      createStructure({
+        id: 'structure-empty',
+        rooms: [createRoom({ id: 'room-empty', structureId: 'structure-empty', zones: [] })],
+      }),
+    ]);
+
+    expect(findZone(state, 'zone-any')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- add a dedicated test suite for the world state selectors that builds multi-structure fixtures
- verify structure, room, and zone lookups include expected metadata and return undefined for misses
- document the new test coverage in the changelog

## Testing
- pnpm --filter @weebbreed/backend test -- src/engine/world/stateSelectors.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcb08329548325b61cf0ddfb0da83a


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive test suite for world state selectors

- Validate structure, room, and zone lookups with metadata

- Test edge cases including missing IDs and empty collections

- Document test coverage in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["Structure Finder Tests"]
  A --> C["Room Finder Tests"]
  A --> D["Zone Finder Tests"]
  B --> E["ID Matching & Metadata"]
  C --> E
  D --> E
  E --> F["Edge Case Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stateSelectors.test.ts</strong><dd><code>Add comprehensive state selector test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/src/engine/world/stateSelectors.test.ts

<ul><li>Create comprehensive test suite with 331 lines of test code<br> <li> Build multi-structure fixtures with nested rooms and zones<br> <li> Test <code>findStructure</code>, <code>findRoom</code>, and <code>findZone</code> selector functions<br> <li> Validate exact ID matching, metadata inclusion, and undefined returns <br>for misses</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/368/files#diff-81c52534e0a796fd600baff4e840abb80855759e96dc384f298c1a415629cf24">+331/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document state selector test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document new state selector unit tests in changelog<br> <li> Describe multi-structure fixture validation and edge case coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/368/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

