### PR TITLE
feat: add cross-platform terminal handling for monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reworked the Python SSE monitor to use platform-specific terminal controllers,
+  enabling Windows console input handling and a safe fallback when interactive
+  controls are unavailable.
 - Excluded the Python-based monitoring utilities under `tools/monitor` from JavaScript
   linting and formatting workflows so repository checks ignore non-Node tooling.
 - Tightened façade device-setting schemas to accept only canonical numeric controls and


### PR DESCRIPTION
### **User description**
## Summary
- add platform-specific terminal controllers to the SSE monitor so Windows consoles use msvcrt and POSIX keeps termios/tty
- introduce a fallback controller that warns when interactive controls are unavailable while keeping the monitor usable
- document the change in the changelog

## Testing
- pnpm run check *(fails: existing frontend lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb138d9008325bffd177fe82b4103


___

### **PR Type**
Enhancement


___

### **Description**
- Add cross-platform terminal handling for monitor

- Implement Windows console support with msvcrt

- Create fallback controller for non-interactive environments

- Update changelog with terminal controller changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Platform Detection"] --> B["POSIX Controller"]
  A --> C["Windows Controller"]
  A --> D["Fallback Controller"]
  B --> E["Monitor Interface"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document terminal controller changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document reworked Python SSE monitor with platform-specific terminal <br>controllers<br> <li> Note Windows console input handling and safe fallback support</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/369/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Implement cross-platform terminal controllers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Add abstract <code>TerminalController</code> base class<br> <li> Implement <code>PosixTerminalController</code> for Unix-like systems<br> <li> Implement <code>WindowsTerminalController</code> with msvcrt support<br> <li> Add <code>NonInteractiveTerminalController</code> fallback with warnings<br> <li> Replace direct termios/tty usage with controller abstraction<br> <li> Update keypress handling to use controller interface</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/369/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+205/-25</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

