### PR TITLE
Constrain SSE monitor output to a fixed viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reworked the Python SSE monitor to use platform-specific terminal controllers,
   enabling Windows console input handling and a safe fallback when interactive
   controls are unavailable.
+- Bounded the SSE console monitor viewport to a framed 80×30 layout, adding
+  clipping, ellipsis truncation, and list row limiting so KPIs and selections
+  render consistently across terminals.
 - Excluded the Python-based monitoring utilities under `tools/monitor` from JavaScript
   linting and formatting workflows so repository checks ignore non-Node tooling.
 - Tightened façade device-setting schemas to accept only canonical numeric controls and


### PR DESCRIPTION
### **User description**
## Summary
- add a ListPane data structure for the SSE console monitor and rebuild the renderer to draw a fixed 80×30 border-framed buffer with truncation and row limiting
- update the monitor state to feed structured panes into the renderer and keep room messaging when no structure is focused
- document the new bounded viewport behaviour in the changelog

## Testing
- pnpm run check *(fails: @weebbreed/frontend@0.1.0 lint: `eslint .`)*
- python -m compileall tools/monitor/weedmonitor.py
- python - <<'PY' … *(validated rendered output stays within 80×30)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb707fd7883259a422abc7a660535


___

### **PR Type**
Enhancement


___

### **Description**
- Constrain SSE monitor viewport to fixed 80×30 bordered layout

- Add text truncation with ellipsis and row limiting

- Refactor renderer to use structured ListPane data model

- Update changelog documenting viewport improvements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Renderer"] --> B["New ConsoleRenderer"]
  B --> C["Fixed 80×30 Viewport"]
  C --> D["Bordered Layout"]
  C --> E["Text Truncation"]
  C --> F["Row Limiting"]
  G["StructureState"] --> H["ListPane Model"]
  I["RoomState"] --> H
  H --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document viewport constraint improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add entry documenting bounded SSE console monitor viewport<br> <li> Describe 80×30 layout with clipping and truncation features</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/373/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Implement fixed viewport console renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Add <code>ListPane</code> dataclass for structured pane representation<br> <li> Refactor <code>ConsoleRenderer</code> with fixed 80×30 viewport dimensions<br> <li> Implement text truncation with ellipsis and row limiting logic<br> <li> Update <code>StructureState</code> and <code>RoomState</code> to use <code>build_pane()</code> method<br> <li> Replace direct line rendering with structured content composition</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/373/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+175/-43</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

