### PR TITLE
Refactor monitor list selection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored the SSE console monitor list handling to share a reusable selection
+  helper, keeping the 80×30 viewport formatting intact while deduplicating the
+  structure and room pane logic (`tools/monitor/weedmonitor.py`).
 - Reworked the Python SSE monitor to use platform-specific terminal controllers,
   enabling Windows console input handling and a safe fallback when interactive
   controls are unavailable.


### PR DESCRIPTION
### **User description**
## Summary
- add a reusable `SelectableListState` helper for the CLI monitor to centralize list selection and pane rendering behaviour
- refactor the structure and room list states to delegate to the shared helper while keeping their snapshot parsing and empty-state messaging
- document the CLI monitor refactor in the changelog

## Testing
- pnpm run check *(fails: existing frontend lint violations unrelated to this change)*
- python manual viewport validation script

------
https://chatgpt.com/codex/tasks/task_e_68dcb9176ce483258bbe896fae80470c


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced reusable `SelectableListState` helper for CLI monitor

- Refactored structure and room list states to use shared selection logic

- Added generic protocol for displayable list items

- Consolidated pane rendering behavior while preserving functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old StructureListState"] --> C["SelectableListState<T>"]
  B["Old RoomListState"] --> C
  C --> D["Shared selection logic"]
  C --> E["Unified pane rendering"]
  F["DisplayLabelProvider Protocol"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document CLI monitor refactor changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry documenting the CLI monitor refactor<br> <li> Described the new reusable selection helper implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/374/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Add reusable SelectableListState helper class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Added generic <code>SelectableListState</code> class with shared selection <br>mechanics<br> <li> Introduced <code>DisplayLabelProvider</code> protocol for renderable list items<br> <li> Refactored <code>StructureListState</code> and <code>RoomListState</code> to inherit from base <br>class<br> <li> Consolidated pane building logic into shared <code>build_list_pane</code> method<br> <li> Removed duplicate selection and rendering code from both list states</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/374/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+87/-64</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

