### PR TITLE
Add zone pane to CLI monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reworked the Python SSE monitor to use platform-specific terminal controllers,
   enabling Windows console input handling and a safe fallback when interactive
   controls are unavailable.
+- Expanded the SSE console monitor with a zone pane, hierarchical focus
+  navigation, and viewport-safe rendering when drilling into rooms so zone
+  metrics stay within the 80×30 frame (`tools/monitor/weedmonitor.py`).
 - Bounded the SSE console monitor viewport to a framed 80×30 layout, adding
   clipping, ellipsis truncation, and list row limiting so KPIs and selections
   render consistently across terminals.


### PR DESCRIPTION
### **User description**
## Summary
- parse zone entries from simulation snapshots and store per-room zone list state in the monitor
- extend the monitor focus management to include a zone pane rendered alongside structures and rooms
- keep the console renderer within its 80×30 viewport while showing the additional pane

## Testing
- pnpm run check *(fails: @weebbreed/frontend@0.1.0 lint: `eslint .`)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbc4042f4832597f23e716fcdb394


___

### **PR Type**
Enhancement


___

### **Description**
- Add zone pane to CLI monitor with hierarchical navigation

- Parse zone data from simulation snapshots with environmental metrics

- Implement zone-to-room relationship tracking and selection state

- Extend focus management for three-pane navigation (structures/rooms/zones)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Simulation Snapshot"] --> B["Zone Parser"]
  B --> C["ZoneListState"]
  C --> D["Zone Pane"]
  E["Focus Manager"] --> F["Structures Pane"]
  E --> G["Rooms Pane"] 
  E --> D
  G --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with zone pane feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document addition of zone pane to SSE console monitor<br> <li> Note hierarchical focus navigation and viewport-safe rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/375/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Implement zone pane with hierarchical navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Add <code>ZoneRow</code> dataclass for zone representation with environmental <br>metrics<br> <li> Implement <code>ZoneListState</code> with room-based zone filtering and selection <br>persistence<br> <li> Add zone parsing function <code>_parse_zone</code> for snapshot data extraction<br> <li> Extend <code>MonitorState</code> with zone pane and three-level hierarchical focus <br>navigation<br> <li> Update keypress handling for parent navigation and focus validation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/375/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+239/-15</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

