### PR TITLE
Improve Windows terminal raw mode handling

### DIFF
--- a/tools/monitor/weedmonitor.py
+++ b/tools/monitor/weedmonitor.py
@@ -26,8 +26,12 @@ else:  # pragma: no cover - imported conditionally for typing friendliness
     tty = None  # type: ignore[assignment]
 
 if IS_WINDOWS:
+    import ctypes  # type: ignore
+    from ctypes import wintypes
     import msvcrt  # type: ignore
 else:  # pragma: no cover - imported conditionally for typing friendliness
+    ctypes = None  # type: ignore[assignment]
+    wintypes = None  # type: ignore[assignment]
     msvcrt = None  # type: ignore[assignment]
 
 
@@ -85,22 +89,33 @@ class WindowsTerminalController(TerminalController):
     ENABLE_LINE_INPUT = 0x0002
     ENABLE_EXTENDED_FLAGS = 0x0080
     ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 
     def __init__(self) -> None:
-        if msvcrt is None:
+        if msvcrt is None or ctypes is None or wintypes is None:
             raise OSError("msvcrt module is unavailable on this platform")
-        import ctypes
-        from ctypes import wintypes
 
         self._msvcrt = msvcrt
         self._kernel32 = ctypes.windll.kernel32
         self._stdin_handle = self._kernel32.GetStdHandle(-10)  # STD_INPUT_HANDLE
-        if self._stdin_handle in (0, ctypes.c_void_p(-1).value):
+        invalid_handle = ctypes.c_void_p(-1).value
+        if self._stdin_handle in (0, invalid_handle):
             raise OSError("Failed to obtain Windows STDIN handle")
         mode = wintypes.DWORD()
         if not self._kernel32.GetConsoleMode(self._stdin_handle, ctypes.byref(mode)):
             raise OSError("Failed to read Windows console mode")
         self._original_mode = mode.value
+        self._stdout_handle = self._kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        if self._stdout_handle in (0, invalid_handle):
+            self._stdout_handle = None
+            self._original_output_mode: Optional[int] = None
+        else:
+            output_mode = wintypes.DWORD()
+            if self._kernel32.GetConsoleMode(self._stdout_handle, ctypes.byref(output_mode)):
+                self._original_output_mode = output_mode.value
+            else:
+                self._original_output_mode = None
+        self._output_warning_emitted = False
         self._buffer: List[str] = []
 
     def enter_raw_mode(self) -> None:
@@ -110,11 +125,17 @@ class WindowsTerminalController(TerminalController):
         new_mode &= ~(self.ENABLE_LINE_INPUT | self.ENABLE_ECHO_INPUT)
         new_mode |= self.ENABLE_EXTENDED_FLAGS | self.ENABLE_VIRTUAL_TERMINAL_INPUT
         self._kernel32.SetConsoleMode(self._stdin_handle, new_mode)
+        self._enable_virtual_terminal_processing()
 
     def restore_mode(self) -> None:
-        if self._original_mode is None:
-            return
-        self._kernel32.SetConsoleMode(self._stdin_handle, self._original_mode)
+        if self._original_mode is not None:
+            self._kernel32.SetConsoleMode(self._stdin_handle, self._original_mode)
+        if (
+            self._stdout_handle is not None
+            and self._original_output_mode is not None
+            and sys.stdout.isatty()
+        ):
+            self._kernel32.SetConsoleMode(self._stdout_handle, self._original_output_mode)
 
     def _dequeue(self) -> Optional[str]:
         if self._buffer:
@@ -162,6 +183,26 @@ class WindowsTerminalController(TerminalController):
 
     def read_key(self, timeout: float) -> Optional[str]:
         return self.poll_key(timeout)
+
+    def _enable_virtual_terminal_processing(self) -> None:
+        if not sys.stdout.isatty() or ctypes is None or wintypes is None:
+            return
+        if self._stdout_handle is None:
+            return
+        current_mode = wintypes.DWORD()
+        if not self._kernel32.GetConsoleMode(
+            self._stdout_handle, ctypes.byref(current_mode)
+        ):
+            return
+        desired_mode = current_mode.value | self.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        if self._kernel32.SetConsoleMode(self._stdout_handle, desired_mode):
+            return
+        if not self._output_warning_emitted:
+            sys.stderr.write(
+                "Warning: unable to enable ANSI escape sequences on this Windows console; output will be plain.\n"
+            )
+            sys.stderr.flush()
+            self._output_warning_emitted = True
 
 
 class NonInteractiveTerminalController(TerminalController):


### PR DESCRIPTION
### **User description**
## Summary
- enable virtual terminal processing for Windows stdout and cache the original mode
- restore Windows stdin/stdout console modes and warn when ANSI enablement fails

## Testing
- pnpm run check *(fails: @eslint/js missing for @weebbreed/frontend lint)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc18d79ec8325895121a0322f8cd5


___

### **PR Type**
Enhancement


___

### **Description**
- Enable ANSI escape sequences on Windows terminals

- Add stdout console mode handling and restoration

- Implement graceful fallback with warning messages

- Improve Windows terminal compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows Terminal"] --> B["Enable ANSI Processing"]
  B --> C["Cache Original Modes"]
  C --> D["Restore on Exit"]
  D --> E["Warning on Failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Enhanced Windows terminal ANSI and console mode handling</code>&nbsp; </dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Add ctypes and wintypes imports for Windows console API access<br> <li> Implement stdout handle acquisition and original mode caching<br> <li> Add <code>_enable_virtual_terminal_processing()</code> method for ANSI support<br> <li> Enhance <code>restore_mode()</code> to restore both stdin and stdout console modes<br> <li> Add warning system when ANSI enablement fails</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/376/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+48/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

