### PR TITLE
chore(monitor): rely on colorama for ansi setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `colorama` to the Python monitor tooling and initialized ANSI handling
+  on startup to keep Windows consoles warning-free while retaining rich output.
 - Added state selector unit tests that build multi-structure fixtures and validate
   structure, room, and zone lookup metadata including miss cases for empty
   collections and similar-looking ids.

--- a/tools/monitor/requirements.txt
+++ b/tools/monitor/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+colorama>=0.4.6


### PR DESCRIPTION
### **User description**
## Summary
- add colorama to the monitor tool's Python requirements and initialize it before rendering
- streamline the Windows terminal controller to only manage stdin raw mode and rely on colorama for ANSI support
- document the monitor update in the changelog

## Testing
- python -m compileall tools/monitor/weedmonitor.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc438006c83259c74fcf034b42432


___

### **PR Type**
Enhancement


___

### **Description**
- Add colorama dependency for cross-platform ANSI support

- Simplify Windows terminal controller by removing ANSI handling

- Initialize colorama on startup for consistent output

- Update changelog with monitor tool improvements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["requirements.txt"] -- "add colorama" --> B["weedmonitor.py"]
  B -- "initialize colorama" --> C["Windows Terminal"]
  C -- "remove ANSI handling" --> D["Simplified Controller"]
  E["CHANGELOG.md"] -- "document changes" --> F["Release Notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document colorama integration in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add entry documenting colorama addition to monitor tooling<br> <li> Note ANSI handling initialization for Windows console compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/377/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Add Python dependencies for monitor tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/monitor/requirements.txt

<ul><li>Create new requirements file for monitor tool<br> <li> Add requests>=2.31.0 and colorama>=0.4.6 dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/377/files#diff-bdca12a63af5cdf23e0c1a5438b21fa2a3a99903423a42236d3e703772ca2704">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedmonitor.py</strong><dd><code>Integrate colorama and simplify Windows terminal handling</code></dd></summary>
<hr>

tools/monitor/weedmonitor.py

<ul><li>Import colorama module and initialize it in main()<br> <li> Remove Windows ANSI terminal processing code from <br>WindowsTerminalController<br> <li> Simplify controller to only handle stdin raw mode<br> <li> Remove stdout handle management and warning messages</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/377/files#diff-3a322963896a269c2e86947d6aa1626263744898c4992765b769b4c8e2d05d84">+3/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

