### PR TITLE
Fix weedwire module docstring order

### DIFF
--- a/tools/resin/weedwire.py
+++ b/tools/resin/weedwire.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""weedwire"""
-"""RESIN - Real-time Event Stream INspector"""
-"""Interactive CLI monitor for the WeedBreed simulation via Server-Sent Events."""
+"""Interactive CLI monitor for the WeedBreed simulation via Server-Sent Events.
+
+Also known as RESIN (Real-time Event Stream INspector) and "weedwire".
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
### **User description**
## Summary
- consolidate the introductory strings in `tools/resin/weedwire.py` into a single module docstring so `from __future__ import annotations` immediately follows it

## Testing
- `python tools/resin/weedwire.py` *(fails: ModuleNotFoundError: No module named 'colorama')*
- `pnpm run check` *(fails: @weebbreed/frontend lint exits with status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd294260883259ae5f2d61a499e1b


___

### **PR Type**
Other


___

### **Description**
- Consolidate multiple module docstrings into single comprehensive docstring

- Fix import order by placing `from __future__ import annotations` after docstring


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple docstrings"] --> B["Single consolidated docstring"]
  B --> C["Proper import order"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weedwire.py</strong><dd><code>Consolidate docstrings and fix import order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/resin/weedwire.py

<ul><li>Merged three separate docstrings into one comprehensive module <br>docstring<br> <li> Added descriptive text explaining the tool's purpose and aliases<br> <li> Fixed Python import order by ensuring <code>from __future__ import </code><br><code>annotations</code> follows the docstring</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/379/files#diff-063171248059bb41f9032cb87554ab65326b65c969d432346055b06cd42c734e">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

