### PR TITLE
Fix monitoring CLI EventSource import

### DIFF
--- a/src/monitoring/src/index.ts
+++ b/src/monitoring/src/index.ts
@@ -1,8 +1,6 @@
 import contrib from 'blessed-contrib';
 import { Command } from 'commander';
-// eslint-disable-next-line import/default
-import EventSource from 'eventsource';
-import type { MessageEvent } from 'eventsource';
+import { EventSource, type MessageEvent } from 'eventsource';
 import blessed from 'neo-blessed';
 
 type FocusTarget = 'structures' | 'rooms' | 'zones';


### PR DESCRIPTION
### **User description**
## Summary
- update the monitoring CLI to use the named EventSource import provided by the eventsource package
- pull the MessageEvent type from the same named import to avoid the default import

## Testing
- pnpm run monitor

------
https://chatgpt.com/codex/tasks/task_e_68dce06cb5a483259c625bda83c54a06


___

### **PR Type**
Bug fix


___

### **Description**
- Switch from default to named EventSource import

- Consolidate MessageEvent type import from same module

- Remove ESLint disable comment for import/default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default EventSource import"] --> B["Named EventSource import"]
  C["Separate MessageEvent import"] --> B
  D["ESLint disable comment"] --> E["Clean import statement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Switch to named EventSource import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/monitoring/src/index.ts

<ul><li>Replace default EventSource import with named import<br> <li> Consolidate MessageEvent type import on same line<br> <li> Remove ESLint disable comment for import/default</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weebbreed-reboot/pull/382/files#diff-7a0a4a1bab1eba4f6bdb01039665659e1c1d7ef5aa6868bfbf17e7af0b065173">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

